### PR TITLE
Add Infrahub skills: objects, checks, generators, transforms, menus

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "infrahub",
-  "version": "1.0.0",
-  "description": "A Claude Code plugin to support developing on top of Infrahub.",
+  "version": "2.0.0",
+  "description": "A Claude Code plugin to support developing on top of Infrahub. Includes skills for schemas, objects, checks, generators, transforms, and menus.",
   "author": {
     "name": "Solution Engineering and Architecture",
     "email": "customer-success@opsmill.com"
@@ -9,7 +9,14 @@
   "keywords": [
     "opsmill",
     "infrahub",
-    "schema"
+    "schema",
+    "objects",
+    "checks",
+    "generators",
+    "transforms",
+    "menus",
+    "infrastructure",
+    "data-center"
   ],
   "repository": "https://github.com/opsmill/infrahub-skills"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides context for Claude when working with this Infrahub plugin pro
 
 ## Project Overview
 
-This is a Claude Code plugin for [Infrahub](https://github.com/opsmill/infrahub), the infrastructure data management platform by OpsMill. The plugin provides skills to help users design, create, validate, and modify Infrahub schemas.
+This is a Claude Code plugin for [Infrahub](https://github.com/opsmill/infrahub), the infrastructure data management platform by OpsMill. The plugin provides skills covering the full Infrahub development lifecycle: schema design, data population, validation checks, generators, transforms, and menu customization.
 
 ## Directory Structure
 
@@ -17,11 +17,16 @@ This is a Claude Code plugin for [Infrahub](https://github.com/opsmill/infrahub)
 ├── hooks-handlers/
 │   └── session-start.sh         # Detects Infrahub projects and activates skills
 ├── skills/
-│   └── schema-creator/
-│       ├── SKILL.md             # Main skill definition
-│       ├── reference.md         # Schema property reference
-│       ├── validation.md        # Validation and migration guide
-│       └── examples.md          # Example schema templates
+│   ├── common/                  # Shared references and rules
+│   │   ├── graphql-queries.md   # GraphQL query writing reference
+│   │   ├── infrahub-yml-reference.md  # .infrahub.yml config reference
+│   │   └── rules/              # Shared rules (git integration, caching)
+│   ├── schema-creator/          # Schema design skill
+│   ├── object-creator/          # Data population skill
+│   ├── check-creator/           # Validation check skill
+│   ├── generator-creator/       # Generator automation skill
+│   ├── transform-creator/       # Data transform skill
+│   └── menu-creator/            # Navigation menu skill
 ├── CLAUDE.md                    # This file - project context
 ├── README.md                    # User documentation
 └── LICENSE                      # MIT License
@@ -29,15 +34,26 @@ This is a Claude Code plugin for [Infrahub](https://github.com/opsmill/infrahub)
 
 ## Skills
 
-### Schema Creator (`infrahub-schema-creator`)
+| Skill | Directory | Description |
+|-------|-----------|-------------|
+| `infrahub-schema-creator` | `skills/schema-creator/` | Schema nodes, generics, attributes, relationships |
+| `infrahub-object-creator` | `skills/object-creator/` | YAML data files for infrastructure objects |
+| `infrahub-check-creator` | `skills/check-creator/` | Python validation checks for proposed changes |
+| `infrahub-generator-creator` | `skills/generator-creator/` | Design-driven automation (create objects from designs) |
+| `infrahub-transform-creator` | `skills/transform-creator/` | Data transforms (Python/Jinja2 to JSON/text/CSV) |
+| `infrahub-menu-creator` | `skills/menu-creator/` | Custom navigation menus for the web UI |
 
-Located in `skills/schema-creator/`. Helps users create and manage Infrahub schemas.
+Each skill directory contains:
+- `SKILL.md` - Entry point with overview, capabilities, rule categories
+- `examples.md` - Ready-to-use patterns (most skills)
+- `reference.md` - Property/format reference (schema-creator, object-creator)
+- `rules/` - Individual rules organized by category prefix with `_sections.md` index
 
-**Files:**
-- `SKILL.md` - Entry point with overview, capabilities, and quick start
-- `reference.md` - Complete reference for nodes, attributes, relationships, generics
-- `validation.md` - Commands for validating/loading schemas, migration strategies
-- `examples.md` - Ready-to-use schema templates (IPAM, VLANs, datacenter, etc.)
+## Shared Resources (`skills/common/`)
+
+- `graphql-queries.md` - GraphQL query syntax for checks, generators, transforms
+- `infrahub-yml-reference.md` - .infrahub.yml project configuration
+- `rules/` - Cross-cutting rules (git integration, display label caching)
 
 ## Development Guidelines
 
@@ -47,26 +63,32 @@ Located in `skills/schema-creator/`. Helps users create and manage Infrahub sche
 2. Add a `SKILL.md` file with required YAML frontmatter:
    ```yaml
    ---
-   name: my-skill-name
+   name: infrahub-my-skill
    description: Brief description of what this skill does
+   license: MIT
+   metadata:
+     author: infrahub
+     version: 1.0.0
    ---
    ```
-3. Include sections: Description, Capabilities, When to Use
-4. Add supporting `.md` files for detailed reference content
-5. Keep `SKILL.md` under 500 lines; use linked files for extended content
+3. Include sections: Overview, When to Use, Rule Categories, Supporting References
+4. Add a `rules/` directory with `_sections.md` and `_template.md`
+5. Add supporting `.md` files for detailed reference content
+6. Keep `SKILL.md` under 500 lines; use linked files for extended content
+7. Reference `../common/` for shared resources
 
-### Modifying Schema Creator
+### Adding New Rules
 
-- Keep best practices in `reference.md`
-- Add new examples to `examples.md`
-- Update validation commands in `validation.md`
-- Ensure `SKILL.md` links to all supporting files
+- Skill-specific rules go in `skills/<skill>/rules/` with the category prefix from `_sections.md`
+- Cross-cutting rules (apply to multiple skills) go in `skills/common/rules/`
+- Follow the template format in `rules/_template.md`
 
 ## Conventions
 
 - Use semantic versioning for plugin versions
-- Skills require YAML frontmatter with `name` and `description`
-- Skill names: lowercase with hyphens (e.g., `infrahub-schema-creator`)
+- Skills require YAML frontmatter with `name`, `description`, `license`, and `metadata`
+- Skill names: `infrahub-` prefix with lowercase hyphens (e.g., `infrahub-schema-creator`)
+- Directory names: drop the `infrahub-` prefix (e.g., `schema-creator/`)
 - Keep documentation current with Infrahub schema format changes
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -64,26 +64,109 @@ Create, validate, and modify Infrahub schemas for infrastructure data management
 
 **Capabilities:**
 - Create new schemas from natural language requirements
-- Design nodes with attributes and relationships
-- Create generics for shared properties and inheritance
-- Validate schemas against Infrahub conventions
-- Plan schema migrations and updates
-- Generate human-friendly IDs and uniqueness constraints
+- Design nodes with attributes, relationships, and generics
+- Set up hierarchical location trees and component/parent patterns
+- Configure display properties (human_friendly_id, display_label)
+- Validate schemas and plan migrations
 
-**Example prompts:**
-- "Create an Infrahub schema for network devices with hostname and IP address"
-- "Design a schema with Sites that contain Racks and Devices"
-- "Create an Interface generic with Physical and Logical implementations"
-- "How do I extend an existing schema to add new attributes?"
-- "What are the best practices for Infrahub schema design?"
+**Documentation:** `skills/schema-creator/` -- SKILL.md, reference.md, examples.md, validation.md, rules/
 
-**Documentation files:**
-| File | Description |
-|------|-------------|
-| `SKILL.md` | Main skill definition and quick start |
-| `reference.md` | Complete schema property reference |
-| `validation.md` | Validation commands and migration guide |
-| `examples.md` | Ready-to-use schema templates |
+---
+
+### Object Creator
+
+**Name:** `infrahub-object-creator`
+
+Create and manage Infrahub object data files for populating infrastructure data.
+
+**Capabilities:**
+- Create YAML data files for devices, locations, organizations, modules
+- Set up hierarchical data (location trees, tenant groups)
+- Reference related objects across files
+- Manage component children (interfaces, modules, bays)
+- Organize files for correct dependency load order
+
+**Documentation:** `skills/object-creator/` -- SKILL.md, reference.md, examples.md, rules/
+
+---
+
+### Check Creator
+
+**Name:** `infrahub-check-creator`
+
+Create validation checks that run in proposed change pipelines.
+
+**Capabilities:**
+- Write Python validation logic (InfrahubCheck class)
+- Create GraphQL queries for data fetching
+- Build global and targeted checks
+- Register checks in .infrahub.yml
+- Debug check failures
+
+**Documentation:** `skills/check-creator/` -- SKILL.md, examples.md, rules/
+
+---
+
+### Generator Creator
+
+**Name:** `infrahub-generator-creator`
+
+Create design-driven generators that automatically create infrastructure objects.
+
+**Capabilities:**
+- Build generators that create objects from design definitions
+- Implement idempotent create-or-update workflows (allow_upsert)
+- Set up target groups and GraphQL queries
+- Configure automatic cleanup of stale objects
+- Register generators in .infrahub.yml
+
+**Documentation:** `skills/generator-creator/` -- SKILL.md, examples.md, rules/
+
+---
+
+### Transform Creator
+
+**Name:** `infrahub-transform-creator`
+
+Create data transforms that convert Infrahub data into different formats.
+
+**Capabilities:**
+- Build Python transforms (InfrahubTransform class)
+- Create Jinja2 template-based transforms
+- Generate device configs, CSV reports, inventory exports
+- Connect transforms to artifacts for automated output
+- Hybrid Python + Jinja2 patterns
+
+**Documentation:** `skills/transform-creator/` -- SKILL.md, examples.md, rules/
+
+---
+
+### Menu Creator
+
+**Name:** `infrahub-menu-creator`
+
+Create custom navigation menus for the Infrahub web interface.
+
+**Capabilities:**
+- Design navigation menus with nested hierarchies
+- Organize node types into logical groups
+- Configure icons (MDI icon set) and labels
+- Link menu items to schema node list views
+
+**Documentation:** `skills/menu-creator/` -- SKILL.md, rules/
+
+---
+
+### Common References
+
+Shared documentation and rules referenced by all skills.
+
+**Contents:**
+- `graphql-queries.md` -- GraphQL query writing reference
+- `infrahub-yml-reference.md` -- .infrahub.yml project configuration
+- `rules/` -- Shared rules (git integration, caching gotchas)
+
+**Location:** `skills/common/`
 
 ## Automatic Detection
 
@@ -91,7 +174,7 @@ The plugin automatically detects Infrahub projects on session start by looking f
 - `.infrahub.yml` or `infrahub.toml` configuration files
 - Schema files with `version: "1.0"` and `nodes:` or `generics:` keys
 
-When an Infrahub project is detected, Claude is automatically instructed to use the schema-creator skill for relevant tasks.
+When detected, Claude is instructed to use the appropriate skills for relevant tasks.
 
 ## Project Structure
 
@@ -104,11 +187,16 @@ When an Infrahub project is detected, Claude is automatically instructed to use 
 ├── hooks-handlers/
 │   └── session-start.sh         # Infrahub project detection script
 ├── skills/
-│   └── schema-creator/
-│       ├── SKILL.md             # Skill definition
-│       ├── reference.md         # Schema reference
-│       ├── validation.md        # Validation guide
-│       └── examples.md          # Example schemas
+│   ├── common/                  # Shared references and rules
+│   │   ├── graphql-queries.md
+│   │   ├── infrahub-yml-reference.md
+│   │   └── rules/
+│   ├── schema-creator/          # Schema design skill
+│   ├── object-creator/          # Data population skill
+│   ├── check-creator/           # Validation check skill
+│   ├── generator-creator/       # Generator automation skill
+│   ├── transform-creator/       # Data transform skill
+│   └── menu-creator/            # Navigation menu skill
 ├── CLAUDE.md                    # Project context
 ├── README.md                    # This file
 └── LICENSE                      # MIT License

--- a/hooks-handlers/session-start.sh
+++ b/hooks-handlers/session-start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Detect if this is an Infrahub project and activate schema skills
+# Detect if this is an Infrahub project and activate all Infrahub skills
 
 INFRAHUB_DETECTED=false
 
@@ -28,7 +28,7 @@ if [[ "$INFRAHUB_DETECTED" == "true" ]]; then
 {
   "hookSpecificOutput": {
     "hookEventName": "SessionStart",
-    "additionalContext": "This is an Infrahub project. When the user asks about schema design, data modeling, or infrastructure data management tasks, use the `infrahub-schema-creator` skill from the infrahub plugin.\n\nThe skill documentation is located at: ${CLAUDE_PLUGIN_ROOT}/skills/schema-creator/\n\nKey files to reference:\n- SKILL.md - Overview and quick start\n- reference.md - Complete schema property reference (nodes, attributes, relationships, generics)\n- validation.md - Schema validation commands and migration guide\n- examples.md - Ready-to-use schema templates\n\nWhen working with Infrahub schemas:\n1. Read the relevant skill documentation files before making schema changes\n2. Follow Infrahub naming conventions (PascalCase for nodes/generics, snake_case for attributes)\n3. Always include human_friendly_id for nodes\n4. Set identifier on bidirectional relationships\n5. Use generics for shared attributes across multiple node types\n6. Validate schemas with `infrahubctl schema check` before loading"
+    "additionalContext": "This is an Infrahub project. When the user asks about schema design, data modeling, or infrastructure data management tasks, use the `infrahub-schema-creator` skill from the infrahub plugin.\n\nThe skill documentation is located at: ${CLAUDE_PLUGIN_ROOT}/skills/schema-creator/\n\nKey files to reference:\n- SKILL.md - Overview and quick start\n- reference.md - Complete schema property reference (nodes, attributes, relationships, generics)\n- validation.md - Schema validation commands and migration guide\n- examples.md - Ready-to-use schema templates\n\nWhen working with Infrahub schemas:\n1. Read the relevant skill documentation files before making schema changes\n2. Follow Infrahub naming conventions (PascalCase for nodes/generics, snake_case for attributes)\n3. Always include human_friendly_id for nodes\n4. Set identifier on bidirectional relationships\n5. Use generics for shared attributes across multiple node types\n6. Validate schemas with `infrahubctl schema check` before loading\n\nAdditional skills available:\n- `infrahub-object-creator` - Create data objects (devices, locations, etc.) at ${CLAUDE_PLUGIN_ROOT}/skills/object-creator/\n- `infrahub-check-creator` - Create validation checks at ${CLAUDE_PLUGIN_ROOT}/skills/check-creator/\n- `infrahub-generator-creator` - Create design-driven generators at ${CLAUDE_PLUGIN_ROOT}/skills/generator-creator/\n- `infrahub-transform-creator` - Create data transforms at ${CLAUDE_PLUGIN_ROOT}/skills/transform-creator/\n- `infrahub-menu-creator` - Create navigation menus at ${CLAUDE_PLUGIN_ROOT}/skills/menu-creator/\n- Shared references and rules at ${CLAUDE_PLUGIN_ROOT}/skills/common/"
   }
 }
 EOF

--- a/skills/check-creator/SKILL.md
+++ b/skills/check-creator/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: infrahub-check-creator
+description: Create and manage Infrahub check definitions. Use when writing validation logic, creating Python checks that run in proposed change pipelines, or building data quality guards for Infrahub.
+license: MIT
+metadata:
+  author: infrahub
+  version: 1.0.0
+---
+
+## Overview
+
+Expert guidance for creating Infrahub checks. Checks are user-defined validation logic (Python + GraphQL) that run as part of a proposed change pipeline. If a check logs any errors, the proposed change cannot be merged.
+
+## When to Use
+
+- Writing validation logic for proposed changes
+- Creating data quality guards (e.g., rack collision detection)
+- Building global checks that validate all objects of a type
+- Building targeted checks that validate specific grouped objects
+- Debugging check failures or understanding the check lifecycle
+
+## Rule Categories
+
+| Priority | Category | Prefix | Description |
+|----------|----------|--------|-------------|
+| CRITICAL | Architecture | `architecture-` | Three components, global vs targeted, execution flow |
+| CRITICAL | Python Class | `python-` | InfrahubCheck base class, validate(), log_error/log_info |
+| HIGH | API Reference | `api-` | Class attributes, instance properties, methods, lifecycle |
+| HIGH | Registration | `registration-` | .infrahub.yml config, query name matching, parameters |
+| MEDIUM | Patterns | `patterns-` | Error collection, shared utilities, scoped validation |
+| LOW | Testing | `testing-` | infrahubctl check commands, branch testing |
+
+## Check Basics
+
+Every check has three components:
+
+1. **GraphQL query** (`.gql` file) -- fetches the data to validate
+2. **Python class** -- inherits from `InfrahubCheck`, implements `validate()`
+3. **Configuration** -- declared in `.infrahub.yml` under `check_definitions`
+
+```python
+from infrahub_sdk.checks import InfrahubCheck
+
+class MyCheck(InfrahubCheck):
+    query = "my_query"                    # Must match query name in .infrahub.yml
+
+    def validate(self, data: dict) -> None:
+        # Validation logic here
+        if something_is_wrong:
+            self.log_error(message="Problem description")
+```
+
+## Supporting References
+
+- **[examples.md](./examples.md)** -- Complete check patterns (global, targeted, minimal)
+- **[../common/graphql-queries.md](../common/graphql-queries.md)** -- GraphQL query writing reference
+- **[../common/infrahub-yml-reference.md](../common/infrahub-yml-reference.md)** -- .infrahub.yml project configuration
+- **[../common/rules/](../common/rules/)** -- Shared rules (git integration, caching gotchas) that apply across all skills
+- **[../schema-creator/SKILL.md](../schema-creator/SKILL.md)** -- Schema definitions checks validate against
+- **[rules/](./rules/)** -- Individual rules organized by category prefix

--- a/skills/check-creator/examples.md
+++ b/skills/check-creator/examples.md
@@ -1,0 +1,364 @@
+# Infrahub Check Examples
+
+Real-world examples extracted from production Infrahub repositories.
+
+---
+
+## 1. Global Check: Rack Unit Collision Detection
+
+A global check that validates all devices across all racks don't have conflicting positions.
+
+### Query: `queries/rack_devices.gql`
+
+```graphql
+query RackDevices {
+  DcimGenericDevice {
+    edges {
+      node {
+        id
+        __typename
+        display_label
+        name {
+          value
+        }
+        rack_u_position {
+          value
+        }
+        rack_face {
+          value
+        }
+        rack {
+          node {
+            id
+            display_label
+            name {
+              value
+            }
+          }
+        }
+        device_type {
+          node {
+            id
+            model {
+              value
+            }
+            u_height {
+              value
+            }
+            is_full_depth {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Check: `checks/rack_unit_collision.py`
+
+```python
+from collections import defaultdict
+from infrahub_sdk.checks import InfrahubCheck
+
+
+class RackUnitCollisionCheck(InfrahubCheck):
+    query = "rack_devices"
+
+    def validate(self, data: dict) -> None:
+        edges = data.get("DcimGenericDevice", {}).get("edges", [])
+
+        # Group devices by rack
+        devices_by_rack: dict[str, list[dict]] = defaultdict(list)
+        for edge in edges:
+            device = edge.get("node", {})
+            rack_u_position = device.get("rack_u_position", {}).get("value")
+            if rack_u_position is None:
+                continue
+
+            rack_node = device.get("rack", {}).get("node")
+            if not rack_node:
+                continue
+
+            rack_id = rack_node.get("id")
+            device_type = device.get("device_type", {}).get("node", {})
+
+            device_info = {
+                "id": device.get("id"),
+                "name": device.get("display_label") or device.get("name", {}).get("value", "Unknown"),
+                "type": device.get("__typename", "Unknown"),
+                "rack_name": rack_node.get("display_label", "Unknown"),
+                "rack_u_position": rack_u_position,
+                "u_height": device_type.get("u_height", {}).get("value", 1) or 1,
+                "rack_face": device.get("rack_face", {}).get("value", "front"),
+                "is_full_depth": device_type.get("is_full_depth", {}).get("value", True),
+            }
+            devices_by_rack[rack_id].append(device_info)
+
+        # Check collisions within each rack
+        for rack_id, devices in devices_by_rack.items():
+            for i, dev_a in enumerate(devices):
+                rus_a = set(range(dev_a["rack_u_position"], dev_a["rack_u_position"] + dev_a["u_height"]))
+                for dev_b in devices[i + 1:]:
+                    rus_b = set(range(dev_b["rack_u_position"], dev_b["rack_u_position"] + dev_b["u_height"]))
+                    overlap = rus_a & rus_b
+                    if overlap and (dev_a["is_full_depth"] or dev_b["is_full_depth"] or dev_a["rack_face"] == dev_b["rack_face"]):
+                        self.log_error(
+                            message=f"RU collision in rack '{dev_a['rack_name']}': '{dev_a['name']}' conflicts with '{dev_b['name']}'",
+                            object_id=dev_a["id"],
+                            object_type=dev_a["type"],
+                        )
+```
+
+### Config: `.infrahub.yml`
+
+```yaml
+queries:
+  - name: rack_devices
+    file_path: queries/rack_devices.gql
+
+check_definitions:
+  - name: check_rack_unit_collision
+    class_name: RackUnitCollisionCheck
+    file_path: checks/rack_unit_collision.py
+    # No targets = global check (runs on every proposed change)
+```
+
+---
+
+## 2. Targeted Check: Leaf Device Validation
+
+A targeted check that validates leaf switches have proper interface configuration.
+
+### Query: `queries/config/leaf.gql`
+
+```graphql
+query leaf_config($device: String!) {
+  DcimDevice(name__value: $device) {
+    edges {
+      node {
+        id
+        name { value }
+        role { value }
+        interfaces {
+          edges {
+            node {
+              name { value }
+              role { value }
+              ... on InterfacePhysical {
+                ip_addresses {
+                  edges {
+                    node {
+                      address { value }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        device_services {
+          edges {
+            node {
+              __typename
+              name { value }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Check: `checks/leaf.py`
+
+```python
+from typing import Any
+from infrahub_sdk.checks import InfrahubCheck
+from .common import get_data, validate_interfaces
+
+
+class CheckLeaf(InfrahubCheck):
+    query = "leaf_config"
+
+    def validate(self, data: Any) -> None:
+        errors: list[str] = []
+        warnings: list[str] = []
+        data = get_data(data)
+
+        # Validate interfaces - critical
+        errors.extend(validate_interfaces(data))
+
+        # Check for services - warn if missing but don't fail
+        device_services = data.get("device_services") or []
+        if not device_services:
+            warnings.append("No services configured on this device")
+        else:
+            redundant_bgp = [
+                s.get("name") for s in device_services
+                if s.get("typename") == "ServiceBGP"
+            ]
+            if redundant_bgp and len(redundant_bgp) < 2:
+                warnings.append("BGP redundancy not configured")
+
+        for warning in warnings:
+            self.log_info(message=f"WARNING: {warning}")
+
+        for error in errors:
+            self.log_error(message=error)
+```
+
+### Shared Utilities: `checks/common.py`
+
+```python
+from typing import Any
+
+
+def clean_data(data: Any) -> Any:
+    """Recursively normalize Infrahub API data by extracting values."""
+    if isinstance(data, dict):
+        result = {}
+        for key, value in data.items():
+            if isinstance(value, dict):
+                keys = set(value.keys())
+                if keys == {"value"}:
+                    result[key] = value["value"]
+                elif keys == {"edges"} and not value["edges"]:
+                    result[key] = []
+                elif "node" in value:
+                    result[key] = clean_data(value["node"])
+                elif "edges" in value:
+                    result[key] = clean_data(value["edges"])
+                else:
+                    result[key] = clean_data(value)
+            elif "__" in key:
+                result[key.replace("__", "")] = value
+            else:
+                result[key] = clean_data(value)
+        return result
+    if isinstance(data, list):
+        return [clean_data(item.get("node", item)) for item in data]
+    return data
+
+
+def get_data(data: Any) -> Any:
+    """Extract the first object from cleaned data."""
+    cleaned = clean_data(data)
+    if isinstance(cleaned, dict) and cleaned:
+        first_key = next(iter(cleaned))
+        first_value = cleaned[first_key]
+        if isinstance(first_value, list) and first_value:
+            return first_value[0]
+        return first_value if first_value is not None else {}
+    raise ValueError("clean_data() did not return a non-empty dictionary")
+
+
+def validate_interfaces(data: dict[str, Any]) -> list[str]:
+    """Validate device interfaces and loopback IPs."""
+    errors: list[str] = []
+    if len(data.get("interfaces", [])) == 0:
+        errors.append("Device has no interfaces configured")
+
+    for intf in data.get("interfaces", []):
+        if intf.get("role") == "loopback" and not intf.get("ip_addresses"):
+            errors.append(f"Loopback interface {intf.get('name', 'unknown')} is missing IP address")
+
+    return errors
+```
+
+### Config: `.infrahub.yml`
+
+```yaml
+queries:
+  - name: leaf_config
+    file_path: queries/config/leaf.gql
+
+check_definitions:
+  - name: validate_leaf
+    class_name: CheckLeaf
+    file_path: checks/leaf.py
+    targets: leafs                       # Only runs against devices in the "leafs" group
+    parameters:
+      device: name__value                # $device = target's name attribute
+```
+
+---
+
+## 3. Minimal Check Template
+
+The simplest possible check structure:
+
+### Query: `queries/tags.gql`
+
+```graphql
+query Tags {
+  BuiltinTag {
+    edges {
+      node {
+        id
+        name { value }
+      }
+    }
+  }
+}
+```
+
+### Check: `checks/tag_naming.py`
+
+```python
+import re
+from infrahub_sdk.checks import InfrahubCheck
+
+VALID_TAG = re.compile(r"^[a-z][a-z0-9-]+$")
+
+
+class TagNamingCheck(InfrahubCheck):
+    query = "tags"
+
+    def validate(self, data: dict) -> None:
+        for edge in data["BuiltinTag"]["edges"]:
+            tag_name = edge["node"]["name"]["value"]
+            if not VALID_TAG.match(tag_name):
+                self.log_error(
+                    message=f"Invalid tag name '{tag_name}': must be lowercase alphanumeric with hyphens",
+                    object_id=edge["node"]["id"],
+                    object_type="BuiltinTag",
+                )
+```
+
+### Config: `.infrahub.yml`
+
+```yaml
+queries:
+  - name: tags
+    file_path: queries/tags.gql
+
+check_definitions:
+  - name: check_tag_naming
+    class_name: TagNamingCheck
+    file_path: checks/tag_naming.py
+```
+
+---
+
+## Complete File Structure
+
+```
+project/
+  .infrahub.yml
+  checks/
+    __init__.py
+    common.py                    # Shared utilities (clean_data, get_data, etc.)
+    rack_unit_collision.py       # Global check
+    leaf.py                      # Targeted check
+    spine.py                     # Targeted check
+  queries/
+    rack_devices.gql             # Global query (no variables)
+    config/
+      leaf.gql                   # Targeted query ($device variable)
+      spine.gql
+    validation/
+      loadbalancer_validation.gql
+```

--- a/skills/check-creator/rules/_sections.md
+++ b/skills/check-creator/rules/_sections.md
@@ -1,0 +1,13 @@
+# Infrahub Check Creator - Rule Sections
+
+1. **Architecture (architecture-)** -- CRITICAL. Three-component structure (query + Python + config), global vs targeted checks, when each runs. Foundational understanding required before writing checks.
+
+2. **Python Class (python-)** -- CRITICAL. InfrahubCheck base class, validate() method signature, log_error() causes failure, log_info() is safe, no log_warning(). Getting logging wrong causes silent pass or unexpected fail.
+
+3. **API Reference (api-)** -- HIGH. Class attributes (query, timeout), instance properties (client, branch_name, params), execution lifecycle (collect_data → validate → count errors).
+
+4. **Registration (registration-)** -- HIGH. .infrahub.yml check_definitions config, query name matching, targets for targeted checks, parameters mapping.
+
+5. **Patterns (patterns-)** -- MEDIUM. Error collection before logging, shared utility functions (common.py), scoped validation for performance on large datasets.
+
+6. **Testing (testing-)** -- LOW. infrahubctl check commands, listing checks, running against specific branches.

--- a/skills/check-creator/rules/_template.md
+++ b/skills/check-creator/rules/_template.md
@@ -1,0 +1,25 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+**Impact: MEDIUM**
+
+Brief explanation of the rule and why it matters for Infrahub check creation.
+
+**Incorrect:**
+
+```python
+# Bad example
+```
+
+**Correct:**
+
+```python
+# Good example
+```
+
+Reference: [Infrahub Check Docs](https://docs.infrahub.app)

--- a/skills/check-creator/rules/api-reference.md
+++ b/skills/check-creator/rules/api-reference.md
@@ -1,0 +1,45 @@
+---
+title: InfrahubCheck API Reference
+impact: HIGH
+tags: api, class-attributes, properties, methods, lifecycle
+---
+
+## InfrahubCheck API Reference
+
+**Impact: HIGH**
+
+### Class Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` | **Required.** Name of the GraphQL query |
+| `timeout` | `int` | Timeout in seconds (default: 60) |
+
+### Instance Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.client` | `InfrahubClient` | SDK client for API calls |
+| `self.branch_name` | `str` | Current branch name |
+| `self.root_directory` | `str` | Repository root path |
+| `self.params` | `dict` | Query parameters |
+| `self.passed` | `bool` | Whether check passed (set after `run()`) |
+| `self.logs` | `list[dict]` | All log entries |
+| `self.errors` | property | Filtered ERROR-level logs |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `validate(data: dict) -> None` | **You must implement this.** Can be sync or async. |
+| `log_error(message, object_id=None, object_type=None)` | Log a validation error (causes check to FAIL) |
+| `log_info(message, object_id=None, object_type=None)` | Log an informational message (does NOT cause failure) |
+
+### Execution Lifecycle
+
+1. `collect_data()` -- executes the GraphQL query
+2. Unpacks the `"data"` key from the response
+3. Calls your `validate(data)` method
+4. Counts ERROR-level logs -- if zero errors, check passes
+
+Reference: [Infrahub SDK Docs](https://docs.infrahub.app)

--- a/skills/check-creator/rules/architecture-types.md
+++ b/skills/check-creator/rules/architecture-types.md
@@ -1,0 +1,79 @@
+---
+title: Check Architecture and Types
+impact: CRITICAL
+tags: architecture, global, targeted, components
+---
+
+## Check Architecture and Types
+
+**Impact: CRITICAL**
+
+Every check consists of three components that must be wired together correctly.
+
+### Three Components
+
+1. **GraphQL query** (`.gql` file) -- fetches the data to validate
+2. **Python class** -- inherits from `InfrahubCheck`, implements `validate()`
+3. **Configuration** -- declared in `.infrahub.yml` under `check_definitions`
+
+### Two Types of Checks
+
+| Type | `targets` field | Runs when | Use case |
+|------|----------------|-----------|----------|
+| **Global** | Omitted | Every proposed change | Validate all objects of a type |
+| **Targeted** | Group name | Target objects change | Validate specific objects in a group |
+
+### Global Check Query (no variables)
+
+```graphql
+query RackDevices {
+  DcimGenericDevice {
+    edges {
+      node {
+        id
+        __typename
+        display_label
+        name { value }
+        rack { node { id name { value } } }
+      }
+    }
+  }
+}
+```
+
+### Targeted Check Query (with variable)
+
+```graphql
+query leaf_config($device: String!) {
+  DcimDevice(name__value: $device) {
+    edges {
+      node {
+        id
+        name { value }
+        interfaces {
+          edges {
+            node { name { value } role { value } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### File Organization
+
+```
+checks/
+  __init__.py                   # Optional: package for shared imports
+  common.py                     # Optional: shared utility functions
+  rack_unit_collision.py        # Check modules
+  leaf.py
+
+queries/
+  rack_devices.gql              # Global queries
+  validation/
+    leaf_validation.gql         # Targeted queries
+```
+
+Reference: [examples.md](../examples.md) for complete check examples.

--- a/skills/check-creator/rules/patterns-common.md
+++ b/skills/check-creator/rules/patterns-common.md
@@ -1,0 +1,78 @@
+---
+title: Common Check Patterns
+impact: MEDIUM
+tags: patterns, error-collection, shared-utilities, scoped-validation
+---
+
+## Common Check Patterns
+
+**Impact: MEDIUM**
+
+### Collecting Errors Before Logging
+
+```python
+def validate(self, data: dict) -> None:
+    errors = []
+    warnings = []
+
+    for item in data["MyNode"]["edges"]:
+        if bad_condition:
+            errors.append(f"Problem with {item['node']['name']['value']}")
+        if mild_concern:
+            warnings.append(f"Note about {item['node']['name']['value']}")
+
+    for warning in warnings:
+        self.log_info(message=f"WARNING: {warning}")
+
+    for error in errors:
+        self.log_error(message=error)
+```
+
+### Shared Utility Functions
+
+```python
+# checks/common.py
+def clean_data(data):
+    """Recursively normalize Infrahub API data."""
+    # ... unwrap value/node/edges nesting ...
+
+def get_data(data):
+    """Extract the first object from cleaned data."""
+    cleaned = clean_data(data)
+    first_key = next(iter(cleaned))
+    first_value = cleaned[first_key]
+    return first_value[0] if isinstance(first_value, list) else first_value
+```
+
+```python
+# checks/my_check.py
+from .common import get_data
+
+class MyCheck(InfrahubCheck):
+    query = "my_query"
+
+    def validate(self, data: dict) -> None:
+        device = get_data(data)
+        # ... validate using cleaned data ...
+```
+
+### Scoped Validation (Performance)
+
+For global checks on large datasets, group by parent for efficient comparison:
+
+```python
+def validate(self, data: dict) -> None:
+    edges = data.get("DcimGenericDevice", {}).get("edges", [])
+
+    devices_by_rack = defaultdict(list)
+    for edge in edges:
+        device = edge["node"]
+        rack_id = device.get("rack", {}).get("node", {}).get("id")
+        if rack_id:
+            devices_by_rack[rack_id].append(device)
+
+    for rack_id, devices in devices_by_rack.items():
+        self._check_rack(devices)
+```
+
+Reference: [examples.md](../examples.md) for complete check examples.

--- a/skills/check-creator/rules/python-validate.md
+++ b/skills/check-creator/rules/python-validate.md
@@ -1,0 +1,54 @@
+---
+title: Python Check Class and Validation
+impact: CRITICAL
+tags: python, validate, log_error, log_info, InfrahubCheck
+---
+
+## Python Check Class and Validation
+
+**Impact: CRITICAL**
+
+The `validate()` method is where all check logic lives. Understanding logging behavior is essential -- `log_error()` causes failure, `log_info()` is safe.
+
+### Basic Structure
+
+```python
+from infrahub_sdk.checks import InfrahubCheck
+
+
+class MyCheck(InfrahubCheck):
+    query = "my_query"                    # Must match query name in .infrahub.yml
+
+    def validate(self, data: dict) -> None:
+        edges = data.get("MyNodeKind", {}).get("edges", [])
+
+        for edge in edges:
+            node = edge["node"]
+
+            if something_is_wrong:
+                self.log_error(
+                    message="Description of the problem",
+                    object_id=node["id"],          # Optional but recommended
+                    object_type=node["__typename"], # Optional but recommended
+                )
+
+            self.log_info(message="Everything looks good")
+```
+
+### Logging Rules
+
+| Method | Effect | Use For |
+|--------|--------|---------|
+| `self.log_error(message, object_id=None, object_type=None)` | **Causes check to FAIL** | Validation failures |
+| `self.log_info(message, object_id=None, object_type=None)` | No effect on pass/fail | Informational messages |
+
+**There is no `log_warning()` method.** Use `log_info()` with a "WARNING:" prefix for non-failing warnings.
+
+### Key Rules
+
+- `validate()` can be sync or async -- the SDK handles both
+- Always include `id` and `__typename` in your GraphQL query for error logging
+- Any `log_error()` call means the proposed change cannot merge
+- The `data` parameter is the unpacked GraphQL response (the `"data"` key is already extracted)
+
+Reference: [Infrahub Check Docs](https://docs.infrahub.app)

--- a/skills/check-creator/rules/registration-config.md
+++ b/skills/check-creator/rules/registration-config.md
@@ -1,0 +1,50 @@
+---
+title: Check Registration in .infrahub.yml
+impact: HIGH
+tags: registration, config, infrahub-yml, targets, parameters
+---
+
+## Check Registration in .infrahub.yml
+
+**Impact: HIGH**
+
+Checks must be registered in `.infrahub.yml` with matching query names. Mismatched names cause silent failures.
+
+### Global Check Config
+
+```yaml
+queries:
+  - name: rack_devices                    # Query name
+    file_path: queries/rack_devices.gql
+
+check_definitions:
+  - name: rack_unit_collision
+    class_name: RackUnitCollision
+    file_path: checks/rack_unit_collision.py
+    # No targets = global check (runs on every proposed change)
+```
+
+### Targeted Check Config
+
+```yaml
+queries:
+  - name: leaf_config
+    file_path: queries/validation/leaf.gql
+
+check_definitions:
+  - name: leaf_validation
+    class_name: LeafValidation
+    file_path: checks/leaf.py
+    targets: leaf_devices                  # CoreCheckGroup name
+    parameters:
+      device: name__value                  # Maps $device to target's name
+```
+
+### Critical Rules
+
+- **`query` class attribute must match** the query `name` in `.infrahub.yml` exactly
+- **Global checks** omit `targets` -- they run on every proposed change
+- **Targeted checks** need both `targets` and `parameters`
+- **`parameters`** maps GraphQL variable names to target object attributes
+
+Reference: [../common/infrahub-yml-reference.md](../../common/infrahub-yml-reference.md)

--- a/skills/check-creator/rules/testing-commands.md
+++ b/skills/check-creator/rules/testing-commands.md
@@ -1,0 +1,31 @@
+---
+title: Testing Checks
+impact: LOW
+tags: testing, infrahubctl, commands
+---
+
+## Testing Checks
+
+**Impact: LOW (reference)**
+
+### Commands
+
+```bash
+# List available checks
+infrahubctl check --list
+
+# Run a specific check
+infrahubctl check my_check_name
+
+# Run against a specific branch
+infrahubctl check my_check_name --branch=feature-branch
+```
+
+### Debugging Tips
+
+- Check logs for `ERROR` entries to see what failed
+- Use `log_info()` liberally during development to trace data flow
+- Test against a branch first before running on main
+- Global checks run on every proposed change -- keep them efficient
+
+Reference: [Infrahub CLI Docs](https://docs.infrahub.app)

--- a/skills/common/graphql-queries.md
+++ b/skills/common/graphql-queries.md
@@ -1,0 +1,309 @@
+# GraphQL Queries for Infrahub
+
+GraphQL queries are the data layer for checks, transforms, and generators. They fetch data from Infrahub's API and pass it to your Python code.
+
+## File Format
+
+Queries are stored as `.gql` files and registered in `.infrahub.yml`:
+
+```yaml
+queries:
+  - name: my_query
+    file_path: queries/my_query.gql
+```
+
+## Query Structure
+
+### Global Query (No Variables)
+
+Used by global checks that validate all objects of a type:
+
+```graphql
+query RackDevices {
+  DcimGenericDevice {
+    edges {
+      node {
+        id
+        __typename
+        display_label
+        name {
+          value
+        }
+        rack {
+          node {
+            id
+            name {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Targeted Query (With Variables)
+
+Used by targeted checks, transforms, and generators. The variable name must match the `parameters` key in `.infrahub.yml`:
+
+```graphql
+query spine_config($device: String!) {
+  DcimDevice(name__value: $device) {
+    edges {
+      node {
+        id
+        name { value }
+        role { value }
+        device_type {
+          node {
+            name { value }
+            manufacturer { node { name { value } } }
+          }
+        }
+        interfaces {
+          edges {
+            node {
+              name { value }
+              status { value }
+              role { value }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**How it connects:**
+```yaml
+# .infrahub.yml
+check_definitions:
+  - name: validate_spine
+    file_path: checks/spine.py
+    targets: spines              # Group of target objects
+    parameters:
+      device: name__value        # $device = target object's name
+```
+
+When Infrahub runs this check for a device named `spine-01`, it executes the query with `$device = "spine-01"`.
+
+## Infrahub GraphQL Conventions
+
+### Data Access Pattern
+
+All queries follow the `edges/node` pattern (Relay-style pagination):
+
+```graphql
+MyNodeKind {
+  edges {
+    node {
+      # fields here
+    }
+  }
+}
+```
+
+### Attribute Fields
+
+Attributes are nested under a `value` key:
+
+```graphql
+name { value }           # Text attribute
+status { value }         # Dropdown attribute
+rack_u_position { value } # Number attribute
+is_full_depth { value }  # Boolean attribute
+```
+
+### Relationship Fields (cardinality: one)
+
+Single relationships use `node` nesting:
+
+```graphql
+rack {
+  node {
+    id
+    name { value }
+  }
+}
+
+device_type {
+  node {
+    model { value }
+    manufacturer {
+      node {
+        name { value }
+      }
+    }
+  }
+}
+```
+
+### Relationship Fields (cardinality: many)
+
+Many relationships use `edges/node`:
+
+```graphql
+interfaces {
+  edges {
+    node {
+      name { value }
+      status { value }
+    }
+  }
+}
+
+tags {
+  edges {
+    node {
+      name { value }
+    }
+  }
+}
+```
+
+### Inline Fragments (Generics/Polymorphism)
+
+When querying a Generic type that has multiple concrete implementations, use `... on` fragments:
+
+```graphql
+location {
+  node {
+    ... on LocationGeneric {
+      name { value }
+    }
+  }
+}
+
+device_services {
+  edges {
+    node {
+      __typename                    # Tells you which concrete type
+      name { value }
+      status { value }
+
+      ... on ServiceBGP {
+        local_as { node { asn { value } } }
+        remote_as { node { asn { value } } }
+      }
+
+      ... on ServiceOSPF {
+        process_id { value }
+        version { value }
+      }
+    }
+  }
+}
+```
+
+### Filtering
+
+Filter using `__` notation on query arguments:
+
+```graphql
+# Filter by exact value
+DcimDevice(name__value: "spine-01") { ... }
+
+# With variable
+query my_query($device: String!) {
+  DcimDevice(name__value: $device) { ... }
+}
+```
+
+### Common Fields to Include
+
+Always include these for object identification:
+
+```graphql
+node {
+  id               # Infrahub internal ID (for object_id in check logs)
+  __typename       # Concrete node type (for object_type in check logs)
+  display_label    # Human-readable label
+  name { value }   # Primary identifier
+}
+```
+
+## Response Data Structure
+
+The GraphQL response arrives in your Python code as nested dictionaries:
+
+```python
+# For a query like: DcimDevice { edges { node { name { value } } } }
+data = {
+    "DcimDevice": {
+        "edges": [
+            {
+                "node": {
+                    "id": "abc-123",
+                    "__typename": "DcimDevice",
+                    "name": {"value": "spine-01"},
+                    "status": {"value": "active"},
+                    "rack": {
+                        "node": {
+                            "id": "def-456",
+                            "name": {"value": "Rack-A"}
+                        }
+                    },
+                    "interfaces": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "name": {"value": "eth0"},
+                                    "status": {"value": "active"}
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+}
+```
+
+### Extracting Data
+
+Common patterns for navigating the response:
+
+```python
+# Get list of devices
+edges = data["DcimDevice"]["edges"]
+for edge in edges:
+    device = edge["node"]
+    name = device["name"]["value"]
+
+# Get a relationship (cardinality: one)
+rack_name = device["rack"]["node"]["name"]["value"]
+
+# Get a relationship (cardinality: many)
+for intf_edge in device["interfaces"]["edges"]:
+    intf = intf_edge["node"]
+    intf_name = intf["name"]["value"]
+```
+
+## File Organization
+
+```
+queries/
+  rack_devices.gql              # Global queries
+  config/
+    spine.gql                   # Device config queries
+    leaf.gql
+    edge.gql
+  topology/
+    dc.gql                      # Topology queries
+    pop.gql
+  validation/
+    loadbalancer_validation.gql # Validation-specific queries
+  segment/
+    segment.gql                 # Service queries
+```
+
+## Best Practices
+
+1. **Query only what you need** -- don't fetch entire objects if you only need a few fields
+2. **Include `id` and `__typename`** -- needed for `log_error()` calls in checks and object tracking in generators
+3. **Use inline fragments** for Generic/polymorphic types
+4. **Match variable names** to the `parameters` keys in `.infrahub.yml`
+5. **Organize by purpose** -- group queries into subdirectories (config/, topology/, validation/)

--- a/skills/common/infrahub-yml-reference.md
+++ b/skills/common/infrahub-yml-reference.md
@@ -1,0 +1,219 @@
+# .infrahub.yml Configuration Reference
+
+The `.infrahub.yml` file is the central manifest that connects your Git repository to Infrahub. It declares all schemas, data, queries, checks, transforms, generators, menus, and artifacts.
+
+## Complete Structure
+
+```yaml
+---
+# Schema files (loaded first - establishes data models)
+schemas:
+  - schemas                              # Directory path (loads all .yml files recursively)
+
+# Menu files
+menus:
+  - menus/menu-full.yml                  # Array of file paths
+
+# Object data files
+objects:
+  - objects                              # Directory path (loads all .yml files recursively)
+
+# GraphQL queries (used by checks, transforms, generators)
+queries:
+  - name: my_query                       # Unique query identifier
+    file_path: "queries/my_query.gql"    # Path to .gql file
+
+# Check definitions (validation logic)
+check_definitions:
+  - name: my_check                       # Unique identifier
+    file_path: "checks/my_check.py"      # Path to Python file
+    class_name: MyCheck                  # Optional: Python class name
+    targets: my_group                    # Optional: group name (omit for global)
+    parameters:                          # Optional: maps query variables to target attributes
+      device: "name__value"
+
+# Python transforms (code-based data transformation)
+python_transforms:
+  - name: my_transform                   # Unique identifier
+    file_path: "transforms/my_transform.py"
+    class_name: MyTransform              # Optional: class name
+    convert_query_response: true         # Optional: convert to SDK objects
+
+# Jinja2 transforms (template-based text rendering)
+jinja2_transforms:
+  - name: my_jinja_transform             # Unique identifier
+    query: "my_query"                    # GraphQL query name
+    template_path: "templates/config.j2" # Path to Jinja2 template
+    description: "Optional description"  # Optional
+
+# Artifact definitions (connects transforms to output files)
+artifact_definitions:
+  - name: my_artifact                    # Unique identifier
+    artifact_name: "Human Readable Name" # Optional: display name
+    parameters:                          # Maps target attributes to query variables
+      device: "name__value"
+    content_type: "text/plain"           # MIME type of output
+    targets: "my_group"                  # Target group name
+    transformation: "my_transform"       # Transform name to use
+
+# Generator definitions (design-driven automation)
+generator_definitions:
+  - name: my_generator                   # Unique identifier
+    file_path: "generators/my_gen.py"    # Path to Python file
+    query: my_query                      # GraphQL query name
+    targets: my_group                    # Target group name
+    class_name: MyGenerator              # Optional: class name
+    parameters:                          # Optional: maps target attributes to query variables
+      name: "name__value"
+    convert_query_response: true         # Optional: convert to SDK objects
+    execute_in_proposed_change: true     # Optional (default: true)
+    execute_after_merge: true            # Optional (default: true)
+```
+
+## Loading Order
+
+Resources are loaded in this order:
+
+1. **Schemas** -- establish data models
+2. **GraphQL queries** -- registered for use by other components
+3. **Objects** -- initial data population
+4. **Python files** -- checks, transforms, generators
+5. **Jinja2 transforms** -- template-based transforms
+6. **Artifact definitions** -- connect transforms to outputs
+
+## Section Details
+
+### `schemas`
+
+Array of directory paths or file paths. Loads all `.yml`, `.yaml`, and `.json` files recursively.
+
+### `menus`
+
+Array of file paths pointing to menu YAML files. See the menu creator skill.
+
+### `objects`
+
+Array of directory paths. Loads all `.yml`/`.yaml` files recursively, sorted by filename.
+
+### `queries`
+
+Each query needs a `name` (used to reference it from checks/transforms/generators) and a `file_path` to the `.gql` file.
+
+### `check_definitions`
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier |
+| `file_path` | Yes | Path to Python file |
+| `class_name` | No | Python class name (inferred if omitted) |
+| `targets` | No | Group name; omit for global checks |
+| `parameters` | No | Maps query variables to target object attributes |
+
+### `python_transforms`
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier |
+| `file_path` | Yes | Path to Python file |
+| `class_name` | No | Python class name |
+| `convert_query_response` | No | Convert GraphQL response to SDK `InfrahubNode` objects |
+
+### `jinja2_transforms`
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier |
+| `query` | Yes | GraphQL query name |
+| `template_path` | Yes | Path to Jinja2 template |
+| `description` | No | Documentation text |
+
+### `artifact_definitions`
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier |
+| `artifact_name` | No | Human-readable display name |
+| `parameters` | Yes | Maps target object attributes to query variables |
+| `content_type` | Yes | MIME type (e.g., `text/plain`, `application/json`, `text/csv`) |
+| `targets` | Yes | Group name containing target objects |
+| `transformation` | Yes | Name of the transform to use |
+
+### `generator_definitions`
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique identifier |
+| `file_path` | Yes | Path to Python file |
+| `query` | Yes | GraphQL query name |
+| `targets` | Yes | Target group name (`CoreGeneratorGroup`) |
+| `class_name` | No | Python class name |
+| `parameters` | No | Maps query variables to target object attributes |
+| `convert_query_response` | No | Convert to SDK `InfrahubNode` objects |
+| `execute_in_proposed_change` | No | Run during proposed changes (default: true) |
+| `execute_after_merge` | No | Run after branch merge (default: true) |
+
+## The `parameters` Field
+
+The `parameters` field maps GraphQL query variables to target object attribute paths. The key is the query variable name, the value is the attribute path using `__` notation:
+
+```yaml
+parameters:
+  device: "name__value"          # Maps $device query variable to the target's name attribute
+  name: "name__value"            # Maps $name query variable
+```
+
+This enables targeted execution: when a check/transform/generator runs against a specific target object, the target's attribute values are injected as query variables.
+
+## Real-World Example (bundle-dc)
+
+```yaml
+---
+jinja2_transforms:
+  - name: topology_clab
+    description: Template to generate a containerlab topology
+    query: topology_simulator
+    template_path: templates/clab_topology.j2
+
+artifact_definitions:
+  - name: spine_config
+    artifact_name: spine
+    content_type: text/plain
+    targets: spines
+    transformation: spine
+    parameters:
+      device: name__value
+
+check_definitions:
+  - name: validate_leaf
+    class_name: CheckLeaf
+    file_path: checks/leaf.py
+    targets: leafs
+    parameters:
+      device: name__value
+
+python_transforms:
+  - name: spine
+    class_name: Spine
+    file_path: transforms/spine.py
+
+generator_definitions:
+  - name: create_dc
+    file_path: generators/generate_dc.py
+    targets: topologies_dc
+    query: topology_dc
+    class_name: DCTopologyGenerator
+    parameters:
+      name: name__value
+
+queries:
+  - name: topology_dc
+    file_path: queries/topology/dc.gql
+  - name: spine_config
+    file_path: queries/config/spine.gql
+
+schemas:
+  - schemas/
+
+menus:
+  - menus/menu-full.yml
+```

--- a/skills/common/rules/_sections.md
+++ b/skills/common/rules/_sections.md
@@ -1,0 +1,7 @@
+# Common Rules - Rule Sections
+
+These rules apply across multiple Infrahub skills (generators, checks, transforms, object loading). They capture shared gotchas and best practices that are not specific to any single workflow.
+
+1. **Deployment (deployment-)** -- CRITICAL. Git repository integration, CoreRepository vs CoreReadOnlyRepository, local dev setup, worker race conditions, file commit requirements.
+
+2. **Caching (caching-)** -- MEDIUM. Display label caching with parent relationships, batch loading timing issues, no-op mutation workarounds.

--- a/skills/common/rules/_template.md
+++ b/skills/common/rules/_template.md
@@ -1,0 +1,31 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+**Impact: MEDIUM**
+
+Brief explanation of the rule and why it matters across multiple Infrahub workflows (generators, checks, transforms, object loading, etc.).
+
+### Symptoms
+
+Describe what goes wrong when this rule is violated.
+
+### Cause
+
+Explain the underlying reason.
+
+### Fix
+
+```yaml
+# Corrective example
+```
+
+### Prevention
+
+Guidance on how to avoid hitting this issue in the first place.
+
+Reference: [Infrahub Docs](https://docs.infrahub.app)

--- a/skills/common/rules/caching-display-label.md
+++ b/skills/common/rules/caching-display-label.md
@@ -1,0 +1,46 @@
+---
+title: Display Label Caching with Parent Relationships
+impact: MEDIUM
+tags: display-label, parent, caching, batch-loading, object-loading
+---
+
+## Display Label Caching with Parent Relationships
+
+**Impact: MEDIUM**
+
+When a node's `display_label` template references a Parent relationship (e.g., `{{ device__name__value }} / {{ slot_name__value }}`), the label may compute incorrectly during batch object loading. The Parent relationship may not be fully resolved when `display_label` is first computed, resulting in `None` values.
+
+### Symptoms
+
+After loading objects via `infrahubctl object load`, nodes with Parent-referencing display labels show `None` in place of the parent's attribute:
+
+```
+None / PSU1          # Expected: "TEST-R660xs-1 / PSU1"
+None / NIC-OCP       # Expected: "TEST-R870-1 / NIC-OCP"
+```
+
+### Cause
+
+`display_label` is computed at object creation time and cached. During batch loading, the Parent relationship may not be established when the label is first generated.
+
+### Fix
+
+Run a no-op update (mutation) on affected objects to force display label recalculation:
+
+```graphql
+mutation {
+  DcimModuleInstallationUpdate(
+    data: { id: "<object-id>", description: { value: "" } }
+  ) {
+    ok
+  }
+}
+```
+
+For many objects, script the update in a loop. Any attribute change (even setting description to empty string) triggers recalculation.
+
+### Prevention
+
+When designing schemas with `display_label` templates that reference Parent relationships, be aware this caching behavior exists. Loading the parent objects first and child objects second reduces (but doesn't eliminate) the issue.
+
+Reference: [Infrahub Display Label Docs](https://docs.infrahub.app)

--- a/skills/common/rules/deployment-git-integration.md
+++ b/skills/common/rules/deployment-git-integration.md
@@ -1,0 +1,76 @@
+---
+title: Git Repository Integration for Infrahub Code
+impact: CRITICAL
+tags: deployment, git, repository, sync, infrahub-yml, generators, checks, transforms
+---
+
+## Git Repository Integration for Infrahub Code
+
+**Impact: CRITICAL**
+
+All executable code (generators, checks, transforms), GraphQL queries, and `.infrahub.yml` must be committed to git and synced via a `CoreRepository` or `CoreReadOnlyRepository` for Infrahub to discover and execute them. Infrahub reads these files from the **committed** git state, not the working directory.
+
+### Requirements
+
+1. **All files must be committed**: `.infrahub.yml`, `generators/*.py`, `checks/*.py`, `transforms/*.py`, `queries/*.gql`
+2. **A git repository must be registered** in Infrahub pointing to the repo
+3. **The repo must sync successfully** before definitions are available
+4. **Setup order matters**: Load schema first, create Infrahub branch, load objects, THEN register the git repo
+
+### CoreReadOnlyRepository (Recommended for Code-Only Repos)
+
+Use `CoreReadOnlyRepository` when the repo only provides code (generators, checks, transforms, queries, schemas). It does not try to push back to the remote, avoiding worktree errors with local mounts.
+
+```yaml
+# bootstrap/local-dev-repo.yml (load manually, NOT in objects/)
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: CoreReadOnlyRepository
+  data:
+    - name: my-repo
+      location: "/upstream"       # Or HTTPS URL for remote
+      ref: "branch-name"         # Git branch/tag to read from
+```
+
+Key differences from `CoreRepository`:
+- Uses `ref` attribute (not `default_branch`)
+- Does not push to remote (no worktree errors with local mounts)
+- No periodic sync -- imports once at creation time only
+- Suitable for generators, checks, transforms, and schema code
+
+### CoreRepository (When Infrahub Needs Write Access)
+
+Use `CoreRepository` when Infrahub needs to write back to the repo (e.g., generated configs):
+
+```yaml
+spec:
+  kind: CoreRepository
+  data:
+    - name: my-repo
+      location: "/upstream"
+      default_branch: "main"
+```
+
+**Warning**: `CoreRepository` tries to push to remote when setting up branch worktrees. This fails with local `/upstream` mounts if the remote isn't writable.
+
+### Local Development Setup
+
+For local development, mount the repo into the task-worker container:
+
+```yaml
+# docker-compose.override.yml
+services:
+  task-worker:
+    volumes:
+      - ./:/upstream
+```
+
+### Common Pitfalls
+
+- **Uncommitted changes are invisible**: Infrahub reads from committed git, not the working directory
+- **Worker race conditions**: When creating a repo with 2+ task workers, both may try to import simultaneously causing uniqueness constraint errors. Scale to 1 worker for initial repo creation (`docker compose -p <project> up -d --scale task-worker=1`), then scale back
+- **Bootstrap files in objects/**: Don't put repo definition files in `objects/` -- Infrahub auto-imports everything there during sync, causing validation errors or circular dependencies. Use a separate `bootstrap/` directory
+- **Read-only repos don't re-sync**: `CoreReadOnlyRepository` imports once at creation time. To pick up new commits, delete and re-create the repo registration
+
+Reference: [infrahub-yml-reference.md](../infrahub-yml-reference.md)

--- a/skills/generator-creator/SKILL.md
+++ b/skills/generator-creator/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: infrahub-generator-creator
+description: Create and manage Infrahub generators. Use when building design-driven automation that creates infrastructure objects from templates, topology definitions, or any design-to-implementation workflow in Infrahub.
+license: MIT
+metadata:
+  author: infrahub
+  version: 1.0.0
+---
+
+## Overview
+
+Expert guidance for creating Infrahub generators. Generators query data from Infrahub via GraphQL and create new nodes and relationships based on the result -- enabling design-driven automation where a "design" object automatically creates downstream infrastructure.
+
+## When to Use
+
+- Building design-driven automation (topology -> devices)
+- Creating objects from templates or design definitions
+- Implementing idempotent create-or-update workflows
+- Auto-generating infrastructure from high-level designs
+- Understanding the generator tracking system
+
+## Rule Categories
+
+| Priority | Category | Prefix | Description |
+|----------|----------|--------|-------------|
+| CRITICAL | Architecture | `architecture-` | Three components, target groups, execution triggers |
+| CRITICAL | Python Class | `python-` | InfrahubGenerator, async generate(), object creation API |
+| HIGH | Tracking | `tracking-` | delete_unused_nodes, allow_upsert, idempotent behavior |
+| HIGH | API Reference | `api-` | Constructor params, instance properties, methods |
+| HIGH | Registration | `registration-` | .infrahub.yml config, parameters mapping |
+| MEDIUM | Patterns | `patterns-` | Data cleaning, batch creation, local store |
+| LOW | Testing | `testing-` | infrahubctl generator commands |
+
+## Generator Basics
+
+Every generator has three components:
+
+1. **Target group** -- objects that trigger the generator
+2. **GraphQL query** (`.gql` file) -- fetches the design data
+3. **Python class** -- inherits from `InfrahubGenerator`, implements `generate()`
+
+```python
+from infrahub_sdk.generator import InfrahubGenerator
+
+class MyGenerator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        obj = await self.client.create(kind="DcimDevice", data={"name": "spine-01"})
+        await obj.save(allow_upsert=True)  # Idempotent: create or update
+```
+
+## Supporting References
+
+- **[examples.md](./examples.md)** -- Complete generator patterns (POP topology, network segment, minimal)
+- **[../common/graphql-queries.md](../common/graphql-queries.md)** -- GraphQL query writing reference
+- **[../common/infrahub-yml-reference.md](../common/infrahub-yml-reference.md)** -- .infrahub.yml project configuration
+- **[../common/rules/](../common/rules/)** -- Shared rules (git integration, caching gotchas) that apply across all skills
+- **[../schema-creator/SKILL.md](../schema-creator/SKILL.md)** -- Schema definitions generators work with
+- **[rules/](./rules/)** -- Individual rules organized by category prefix

--- a/skills/generator-creator/examples.md
+++ b/skills/generator-creator/examples.md
@@ -1,0 +1,381 @@
+# Infrahub Generator Examples
+
+Real-world examples extracted from production Infrahub repositories.
+
+---
+
+## 1. POP Topology Generator
+
+Creates network infrastructure for a colocation center from a topology design object.
+
+### Query: `queries/topology/pop.gql`
+
+```graphql
+query device($name: String!) {
+  TopologyColocationCenter(name__value: $name) {
+    edges {
+      node {
+        id
+        name { value }
+        description { value }
+        management_subnet {
+          node {
+            id
+            prefix { value }
+          }
+        }
+        technical_subnet {
+          node {
+            id
+            prefix { value }
+          }
+        }
+        location {
+          node { id }
+        }
+        design {
+          node {
+            name { value }
+            elements {
+              edges {
+                node {
+                  ... on DesignElement {
+                    quantity { value }
+                    role { value }
+                    template {
+                      node {
+                        id
+                        template_name { value }
+                        __typename
+                        ... on TemplateDcimDevice {
+                          interfaces {
+                            edges {
+                              node {
+                                ... on TemplateInterfacePhysical {
+                                  name { value }
+                                  role { value }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    device_type {
+                      node {
+                        id
+                        manufacturer { node { name { value } } }
+                        platform { node { id } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Generator: `generators/generate_pop.py`
+
+```python
+from infrahub_sdk.generator import InfrahubGenerator
+from .common import TopologyCreator, clean_data
+
+
+class PopTopologyGenerator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        # Clean the GraphQL response (unwrap value/node/edges)
+        cleaned_data = clean_data(data)
+        topology = cleaned_data["TopologyColocationCenter"][0]
+
+        # Initialize the topology creator helper
+        creator = TopologyCreator(
+            client=self.client,
+            log=self.logger,
+            branch=self.branch,
+            data=topology,
+        )
+
+        # Load and prepare topology data
+        await creator.load_data()
+
+        # Create infrastructure in dependency order
+        await creator.create_site()
+
+        # Set up IP address pools
+        subnets = []
+        if topology.get("management_subnet"):
+            subnets.append({
+                "type": "Management",
+                "prefix_id": topology["management_subnet"]["id"],
+            })
+        if topology.get("technical_subnet"):
+            subnets.append({
+                "type": "Loopback",
+                "prefix_id": topology["technical_subnet"]["id"],
+            })
+        await creator.create_address_pools(subnets)
+
+        # Create VLAN pool
+        await creator.create_L2_pool()
+
+        # Create devices with interfaces
+        await creator.create_devices()
+
+        # Create loopback interfaces
+        await creator.create_loopback("loopback0")
+
+        # Create OOB connections
+        await creator.create_oob_connections("management")
+        await creator.create_oob_connections("console")
+```
+
+### Config: `.infrahub.yml`
+
+```yaml
+queries:
+  - name: topology_pop
+    file_path: queries/topology/pop.gql
+
+generator_definitions:
+  - name: create_pop
+    file_path: generators/generate_pop.py
+    targets: topologies_pop              # CoreGeneratorGroup containing topology objects
+    query: topology_pop
+    class_name: PopTopologyGenerator
+    parameters:
+      name: name__value
+```
+
+---
+
+## 2. Network Segment Generator
+
+Creates VxLAN/VLAN configuration from a service network segment definition.
+
+### Query: `queries/segment/segment.gql`
+
+```graphql
+query segment($name: String!) {
+  ServiceNetworkSegment(name__value: $name) {
+    edges {
+      node {
+        id
+        name { value }
+        customer_name { value }
+        environment { value }
+        segment_type { value }
+        vlan_id { value }
+        status { value }
+        owner {
+          node {
+            id
+            name { value }
+          }
+        }
+        deployment {
+          node {
+            id
+            name { value }
+            ... on TopologyDataCenter {
+              devices {
+                edges {
+                  node {
+                    id
+                    name { value }
+                    ... on DcimDevice {
+                      role { value }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        prefix {
+          node {
+            id
+            prefix { value }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Generator: `generators/generate_segment.py`
+
+```python
+from infrahub_sdk.generator import InfrahubGenerator
+from .common import clean_data
+
+
+class NetworkSegmentGenerator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        cleaned = clean_data(data)
+        segment = cleaned["ServiceNetworkSegment"][0]
+
+        segment_name = segment["name"]
+        vlan_id = segment.get("vlan_id")
+
+        # Calculate VNI from VLAN ID
+        vni = vlan_id + 10000 if vlan_id else None
+
+        # Calculate Route Distinguisher
+        rd = f"65000:{vlan_id}" if vlan_id else None
+
+        # Get leaf devices from the deployment topology
+        deployment = segment.get("deployment", {})
+        devices = deployment.get("devices", [])
+        leaf_devices = [d for d in devices if d.get("role") == "leaf"]
+
+        # Create VLAN object
+        vlan = await self.client.create(
+            kind="IpamVLAN",
+            data={
+                "name": segment_name,
+                "vlan_id": vlan_id,
+                "status": "active",
+            }
+        )
+        await vlan.save(allow_upsert=True)
+
+        # Associate segment with leaf device interfaces
+        for device in leaf_devices:
+            # Create interface-to-segment mapping
+            mapping = await self.client.create(
+                kind="ServiceSegmentDeployment",
+                data={
+                    "segment": segment["id"],
+                    "device": device["id"],
+                    "vni": vni,
+                    "route_distinguisher": rd,
+                }
+            )
+            await mapping.save(allow_upsert=True)
+```
+
+---
+
+## 3. Minimal Generator Template
+
+The simplest possible generator:
+
+### Query: `queries/widget.gql`
+
+```graphql
+query widget($name: String!) {
+  MyWidget(name__value: $name) {
+    edges {
+      node {
+        id
+        name { value }
+        count { value }
+      }
+    }
+  }
+}
+```
+
+### Generator: `generators/widget_gen.py`
+
+```python
+from infrahub_sdk.generator import InfrahubGenerator
+
+
+class WidgetGenerator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        widget = data["MyWidget"]["edges"][0]["node"]
+        widget_name = widget["name"]["value"]
+        count = widget["count"]["value"]
+
+        for i in range(1, count + 1):
+            resource = await self.client.create(
+                kind="MyResource",
+                data={"name": f"{widget_name}-resource-{i:02d}"}
+            )
+            await resource.save(allow_upsert=True)
+```
+
+### Config: `.infrahub.yml`
+
+```yaml
+queries:
+  - name: widget_query
+    file_path: queries/widget.gql
+
+generator_definitions:
+  - name: widget_generator
+    file_path: generators/widget_gen.py
+    query: widget_query
+    targets: widgets
+    class_name: WidgetGenerator
+    parameters:
+      name: name__value
+```
+
+---
+
+## 4. Generator with convert_query_response
+
+When `convert_query_response: true`, the GraphQL response is converted to SDK `InfrahubNode` objects accessible via `self.nodes`:
+
+```python
+from infrahub_sdk.generator import InfrahubGenerator
+
+
+class TypedGenerator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        # With convert_query_response=True, use self.nodes
+        widget = self.nodes[0]
+
+        # Access attributes via .value
+        name = widget.name.value
+        count = widget.count.value
+
+        for i in range(1, count + 1):
+            resource = await self.client.create(
+                kind="MyResource",
+                data={"name": f"{name}-{i:02d}"}
+            )
+            await resource.save(allow_upsert=True)
+```
+
+```yaml
+generator_definitions:
+  - name: typed_generator
+    file_path: generators/typed_gen.py
+    query: widget_query
+    targets: widgets
+    class_name: TypedGenerator
+    convert_query_response: true         # Enable SDK object conversion
+    parameters:
+      name: name__value
+```
+
+---
+
+## Complete File Structure
+
+```
+project/
+  .infrahub.yml
+  generators/
+    __init__.py
+    common.py                    # TopologyCreator, clean_data, batch helpers
+    generate_dc.py               # DC topology generator
+    generate_pop.py              # POP topology generator
+    generate_segment.py          # Network segment generator
+  queries/
+    topology/
+      dc.gql
+      pop.gql
+    segment/
+      segment.gql
+```

--- a/skills/generator-creator/rules/_sections.md
+++ b/skills/generator-creator/rules/_sections.md
@@ -1,0 +1,15 @@
+# Infrahub Generator Creator - Rule Sections
+
+1. **Architecture (architecture-)** -- CRITICAL. Three-component structure (target group + query + Python), what triggers generators, execution on proposed changes and after merge.
+
+2. **Python Class (python-)** -- CRITICAL. InfrahubGenerator base class, async generate() method, object creation via self.client.create(), save with allow_upsert=True, relationship references by ID.
+
+3. **Tracking (tracking-)** -- HIGH. Automatic cleanup of stale objects via delete_unused_nodes=True, idempotent behavior, why allow_upsert is essential.
+
+4. **API Reference (api-)** -- HIGH. Constructor parameters, instance properties (client, nodes, store, branch), key methods, convert_query_response option.
+
+5. **Registration (registration-)** -- HIGH. .infrahub.yml generator_definitions config, query name matching, targets (CoreGeneratorGroup), parameters mapping.
+
+6. **Patterns (patterns-)** -- MEDIUM. Data cleaning helper, batch object creation, using the local store for inter-object references.
+
+7. **Testing (testing-)** -- LOW. infrahubctl generator commands, listing and running generators locally.

--- a/skills/generator-creator/rules/_template.md
+++ b/skills/generator-creator/rules/_template.md
@@ -1,0 +1,25 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+**Impact: MEDIUM**
+
+Brief explanation of the rule and why it matters for Infrahub generator creation.
+
+**Incorrect:**
+
+```python
+# Bad example
+```
+
+**Correct:**
+
+```python
+# Good example
+```
+
+Reference: [Infrahub Generator Docs](https://docs.infrahub.app)

--- a/skills/generator-creator/rules/api-reference.md
+++ b/skills/generator-creator/rules/api-reference.md
@@ -1,0 +1,45 @@
+---
+title: InfrahubGenerator API Reference
+impact: HIGH
+tags: api, constructor, properties, methods
+---
+
+## InfrahubGenerator API Reference
+
+**Impact: HIGH**
+
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `query` | `str` | required | GraphQL query name |
+| `client` | `InfrahubClient` | required | SDK client |
+| `branch` | `str` | `""` | Branch name (auto-detected from git) |
+| `root_directory` | `str` | `""` | Repository root path |
+| `params` | `dict` | `None` | Parameters for the query |
+| `convert_query_response` | `bool` | `False` | Convert response to SDK objects |
+| `execute_in_proposed_change` | `bool` | `True` | Run during proposed changes |
+| `execute_after_merge` | `bool` | `True` | Run after merge |
+
+### Instance Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.client` | `InfrahubClient` | Tracking-enabled client for creating/updating objects |
+| `self.nodes` | `list[InfrahubNode]` | SDK objects (when `convert_query_response=True`) |
+| `self.related_nodes` | property | Related nodes from data processing |
+| `self.store` | `NodeStore` | Populated during data collection |
+| `self.branch` / `self.branch_name` | `str` | Current branch name |
+| `self.root_directory` | `str` | Repository root path |
+| `self.logger` | `Logger` | Logger for operation tracking |
+| `self.params` | `dict` | Query parameters |
+
+### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `async generate(data: dict) -> None` | **You must implement this.** Your generation logic. |
+| `async collect_data()` | Executes the GraphQL query (called automatically) |
+| `async run(identifier, data=None)` | Orchestrates collection, tracking, and calls `generate()` |
+
+Reference: [Infrahub SDK Docs](https://docs.infrahub.app)

--- a/skills/generator-creator/rules/architecture-components.md
+++ b/skills/generator-creator/rules/architecture-components.md
@@ -1,0 +1,70 @@
+---
+title: Generator Architecture and Components
+impact: CRITICAL
+tags: architecture, components, target-group, triggers
+---
+
+## Generator Architecture and Components
+
+**Impact: CRITICAL**
+
+Generators consist of three components that work together for design-driven automation.
+
+### Three Components
+
+1. **Target group** -- a `CoreGeneratorGroup` containing objects that trigger generation
+2. **GraphQL query** (`.gql` file) -- fetches the design/template data
+3. **Python class** -- inherits from `InfrahubGenerator`, implements `generate()`
+
+### Execution Triggers
+
+Generators run automatically when:
+- Target objects change in proposed changes (`execute_in_proposed_change=True`, default)
+- After branch merges (`execute_after_merge=True`, default)
+
+### Example Query
+
+```graphql
+query topology($name: String!) {
+  TopologyDataCenter(name__value: $name) {
+    edges {
+      node {
+        id
+        name { value }
+        design {
+          node {
+            elements {
+              edges {
+                node {
+                  ... on DesignElement {
+                    quantity { value }
+                    role { value }
+                    device_type { node { id } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### File Organization
+
+```
+generators/
+  __init__.py                    # Optional: package init
+  common.py                      # Shared utilities
+  generate_dc.py                 # DC topology generator
+  generate_pop.py                # POP topology generator
+
+queries/
+  topology/
+    dc.gql                       # Query for DC topology data
+    pop.gql                      # Query for POP topology data
+```
+
+Reference: [examples.md](../examples.md) for complete generator examples.

--- a/skills/generator-creator/rules/patterns-common.md
+++ b/skills/generator-creator/rules/patterns-common.md
@@ -1,0 +1,73 @@
+---
+title: Common Generator Patterns
+impact: MEDIUM
+tags: patterns, data-cleaning, batch-creation, local-store
+---
+
+## Common Generator Patterns
+
+**Impact: MEDIUM**
+
+### Data Cleaning Helper
+
+```python
+def clean_data(data):
+    """Recursively unwrap value/node/edges from GraphQL response."""
+    if isinstance(data, dict):
+        result = {}
+        for key, value in data.items():
+            if isinstance(value, dict):
+                if set(value.keys()) == {"value"}:
+                    result[key] = value["value"]
+                elif "node" in value:
+                    result[key] = clean_data(value["node"])
+                elif "edges" in value:
+                    result[key] = clean_data(value["edges"])
+                else:
+                    result[key] = clean_data(value)
+            else:
+                result[key] = clean_data(value)
+        return result
+    if isinstance(data, list):
+        return [clean_data(item.get("node", item)) for item in data]
+    return data
+```
+
+### Batch Object Creation
+
+```python
+async def generate(self, data: dict) -> None:
+    for element in design["elements"]:
+        quantity = element["quantity"]
+        role = element["role"]
+
+        for i in range(1, quantity + 1):
+            device = await self.client.create(
+                kind="DcimDevice",
+                data={
+                    "name": f"{topology_name}-{role}-{i:02d}",
+                    "role": role,
+                    "status": "active",
+                }
+            )
+            await device.save(allow_upsert=True)
+```
+
+### Using the Local Store
+
+```python
+async def generate(self, data: dict) -> None:
+    site = await self.client.create(kind="LocationBuilding", data={"name": "PAR-1"})
+    await site.save(allow_upsert=True)
+
+    device = await self.client.create(
+        kind="DcimDevice",
+        data={
+            "name": "spine-01",
+            "location": site,  # Pass the SDK object directly
+        }
+    )
+    await device.save(allow_upsert=True)
+```
+
+Reference: [examples.md](../examples.md) for complete generator examples.

--- a/skills/generator-creator/rules/python-generate.md
+++ b/skills/generator-creator/rules/python-generate.md
@@ -1,0 +1,66 @@
+---
+title: Python Generator Class and Object Creation
+impact: CRITICAL
+tags: python, generate, create, save, allow_upsert, async
+---
+
+## Python Generator Class and Object Creation
+
+**Impact: CRITICAL**
+
+The `generate()` method must be async. Use `self.client` for all object operations inside it.
+
+### Basic Structure
+
+```python
+from infrahub_sdk.generator import InfrahubGenerator
+
+
+class MyGenerator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        topology = data["TopologyDataCenter"]["edges"][0]["node"]
+        name = topology["name"]["value"]
+
+        device = await self.client.create(
+            kind="DcimDevice",
+            data={
+                "name": f"{name}-spine-01",
+                "status": "active",
+            }
+        )
+        await device.save(allow_upsert=True)
+```
+
+### Object Creation API
+
+```python
+# Create a new object
+obj = await self.client.create(
+    kind="DcimDevice",
+    data={
+        "name": "my-device",
+        "status": "active",
+        "device_type": device_type_id,    # Use ID for relationships
+    }
+)
+await obj.save(allow_upsert=True)
+
+# Get an existing object
+existing = await self.client.get(kind="LocationBuilding", name__value="PAR-1")
+
+# Allocate from a pool
+ip = await self.client.allocate_next_ip_address(
+    resource_pool=pool,
+    identifier=f"{device_name}-loopback"
+)
+```
+
+### Critical Rules
+
+- **`generate()` must be async** -- use `await` for all client operations
+- **Always use `allow_upsert=True`** on `save()` for idempotent create-or-update
+- **Use `self.client`** (not `self._init_client`) inside `generate()` -- it has tracking enabled
+- **Use IDs for relationship references** in `data` dict
+- **Handle empty/missing data gracefully** -- GraphQL may return `None` for optional fields
+
+Reference: [Infrahub Generator Docs](https://docs.infrahub.app)

--- a/skills/generator-creator/rules/registration-config.md
+++ b/skills/generator-creator/rules/registration-config.md
@@ -1,0 +1,47 @@
+---
+title: Generator Registration in .infrahub.yml
+impact: HIGH
+tags: registration, config, infrahub-yml, targets, parameters
+---
+
+## Generator Registration in .infrahub.yml
+
+**Impact: HIGH**
+
+Generators must be registered in `.infrahub.yml` with query name, target group, and parameter mapping.
+
+### Configuration
+
+```yaml
+queries:
+  - name: topology_dc
+    file_path: queries/topology/dc.gql
+
+generator_definitions:
+  - name: create_dc
+    file_path: generators/generate_dc.py
+    query: topology_dc                     # Must match query name
+    targets: topologies_dc                 # CoreGeneratorGroup name
+    class_name: DCTopologyGenerator
+    parameters:
+      name: name__value                    # Maps $name to target's name attribute
+```
+
+### Field Reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique generator identifier |
+| `file_path` | Yes | Path to Python file |
+| `query` | Yes | Query name (must match `queries` entry) |
+| `targets` | Yes | CoreGeneratorGroup name |
+| `class_name` | Yes | Python class name |
+| `parameters` | Yes | Maps query variables to target attributes |
+
+### Critical Rules
+
+- **`query` must match** the query `name` in the `queries` section
+- **`targets`** references a `CoreGeneratorGroup` -- create the group first
+- **`parameters`** maps GraphQL `$variable` names to target object attribute paths (e.g., `name__value`)
+
+Reference: [../common/infrahub-yml-reference.md](../../common/infrahub-yml-reference.md)

--- a/skills/generator-creator/rules/testing-commands.md
+++ b/skills/generator-creator/rules/testing-commands.md
@@ -1,0 +1,32 @@
+---
+title: Testing Generators
+impact: LOW
+tags: testing, infrahubctl, commands
+---
+
+## Testing Generators
+
+**Impact: LOW (reference)**
+
+### Commands
+
+```bash
+# List available generators
+infrahubctl generator --list
+
+# Run a generator locally
+infrahubctl generator create_dc --branch=my-branch name=dc-topology-1
+
+# Generators also run automatically:
+# - When target objects change in proposed changes
+# - After branch merges (if execute_after_merge=True)
+```
+
+### Debugging Tips
+
+- Use `self.logger` inside `generate()` for operation tracking
+- Test with a small design first (1-2 elements) before scaling
+- Check that target `CoreGeneratorGroup` exists and has members
+- Verify query variables match `parameters` mapping in `.infrahub.yml`
+
+Reference: [Infrahub CLI Docs](https://docs.infrahub.app)

--- a/skills/generator-creator/rules/tracking-idempotent.md
+++ b/skills/generator-creator/rules/tracking-idempotent.md
@@ -1,0 +1,41 @@
+---
+title: Tracking System and Idempotent Behavior
+impact: HIGH
+tags: tracking, idempotent, delete_unused_nodes, allow_upsert
+---
+
+## Tracking System and Idempotent Behavior
+
+**Impact: HIGH**
+
+The `run()` method wraps your `generate()` call in a tracking context with `delete_unused_nodes=True`.
+
+### How Tracking Works
+
+1. Objects created/updated during `generate()` are tracked
+2. Objects from a previous run that are NOT created/updated in the current run are automatically deleted
+3. This ensures idempotent behavior: re-running a generator cleans up stale objects
+
+### Why `allow_upsert=True` Is Essential
+
+**Incorrect -- without upsert (fails on re-run):**
+
+```python
+device = await self.client.create(kind="DcimDevice", data={"name": "spine-01"})
+await device.save()  # Fails if spine-01 already exists!
+```
+
+**Correct -- idempotent with upsert:**
+
+```python
+device = await self.client.create(kind="DcimDevice", data={"name": "spine-01"})
+await device.save(allow_upsert=True)  # Creates or updates
+```
+
+### Implications
+
+- If you remove an element from your design, re-running the generator will automatically delete the corresponding objects
+- All objects created within a single `generate()` run are part of the same tracking group
+- Objects not touched in the current run are considered stale and removed
+
+Reference: [Infrahub Generator Docs](https://docs.infrahub.app)

--- a/skills/menu-creator/SKILL.md
+++ b/skills/menu-creator/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: infrahub-menu-creator
+description: Create and manage Infrahub custom menus. Use when designing navigation menus, organizing node types in the UI, or customizing the Infrahub web interface sidebar.
+license: MIT
+metadata:
+  author: infrahub
+  version: 1.0.0
+---
+
+## Overview
+
+Expert guidance for creating Infrahub custom menus. Menus control the left-side navigation in the web interface, organizing schema node types into a custom hierarchy.
+
+## When to Use
+
+- Designing navigation menus for the Infrahub web UI
+- Organizing node types into logical groups and hierarchies
+- Adding icons and labels to menu items
+- Setting up group headers (non-clickable) with nested children
+- Configuring schema nodes to use custom menus instead of auto-generated ones
+
+## Rule Categories
+
+| Priority | Category | Prefix | Description |
+|----------|----------|--------|-------------|
+| CRITICAL | File Format | `format-` | apiVersion, kind: Menu, spec structure |
+| CRITICAL | Item Properties | `item-` | name, namespace, label, kind, path, icon, children |
+| HIGH | Hierarchy | `hierarchy-` | Nesting children, group headers, children.data wrapping |
+| HIGH | Icons | `icons-` | MDI icon reference, common icon choices |
+| MEDIUM | Schema Integration | `schema-` | include_in_menu: false, kind links |
+| LOW | Patterns | `patterns-` | Flat menu, commented items, direct links |
+
+## Menu File Basics
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Menu
+spec:
+  data:
+    - namespace: Dcim
+      name: DeviceMenu
+      label: "Devices"
+      icon: "mdi:server"
+      kind: DcimDevice              # Links to schema node list view
+```
+
+`apiVersion`, `kind: Menu`, and `spec.data` are always required. Each menu item needs `name` and `namespace`.
+
+## Supporting References
+
+- **[../common/infrahub-yml-reference.md](../common/infrahub-yml-reference.md)** -- .infrahub.yml project configuration
+- **[../common/rules/](../common/rules/)** -- Shared rules (git integration, caching gotchas) that apply across all skills
+- **[../schema-creator/SKILL.md](../schema-creator/SKILL.md)** -- Schema node kinds that menus link to
+- **[rules/](./rules/)** -- Individual rules organized by category prefix

--- a/skills/menu-creator/rules/_sections.md
+++ b/skills/menu-creator/rules/_sections.md
@@ -1,0 +1,13 @@
+# Infrahub Menu Creator - Rule Sections
+
+1. **File Format (format-)** -- CRITICAL. apiVersion, kind: Menu, spec structure. Required top-level fields for every menu file.
+
+2. **Item Properties (item-)** -- CRITICAL. All menu item properties: name, namespace, label, kind, path, icon, order_weight, parent, children. Use kind OR path, not both.
+
+3. **Hierarchy (hierarchy-)** -- HIGH. Nesting children with children.data wrapping, group headers (no kind = non-clickable), unlimited nesting depth.
+
+4. **Icons (icons-)** -- HIGH. Material Design Icons (MDI) library reference with mdi: prefix. Common icon choices for infrastructure types.
+
+5. **Schema Integration (schema-)** -- MEDIUM. Setting include_in_menu: false on schema nodes when using custom menus, kind auto-resolves to correct URL.
+
+6. **Patterns (patterns-)** -- LOW. Ready-to-use patterns: flat menu, nested hierarchy, commented-out items, direct links to generic node lists.

--- a/skills/menu-creator/rules/_template.md
+++ b/skills/menu-creator/rules/_template.md
@@ -1,0 +1,25 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+**Impact: MEDIUM**
+
+Brief explanation of the rule and why it matters for Infrahub menu creation.
+
+**Incorrect:**
+
+```yaml
+# Bad example
+```
+
+**Correct:**
+
+```yaml
+# Good example
+```
+
+Reference: [Infrahub Menu Docs](https://docs.infrahub.app)

--- a/skills/menu-creator/rules/format-structure.md
+++ b/skills/menu-creator/rules/format-structure.md
@@ -1,0 +1,50 @@
+---
+title: Menu File Structure
+impact: CRITICAL
+tags: format, apiVersion, kind, Menu, spec
+---
+
+## Menu File Structure
+
+**Impact: CRITICAL**
+
+Every menu file must follow the exact YAML structure.
+
+### Required Fields
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| `apiVersion` | `infrahub.app/v1` | Always this value |
+| `kind` | `Menu` | Always `Menu` for navigation files |
+| `spec.data` | list | Array of top-level menu items |
+
+**Correct:**
+
+```yaml
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/menu/latest.json
+---
+apiVersion: infrahub.app/v1
+kind: Menu
+spec:
+  data:
+    - namespace: Dcim
+      name: DeviceMenu
+      label: Devices
+      icon: "mdi:server"
+      kind: DcimDevice
+```
+
+### .infrahub.yml Registration
+
+```yaml
+menus:
+  - menus/menu-full.yml
+```
+
+### Key Rules
+
+- Include the `$schema` comment for IDE validation
+- One menu file per project typically
+- The menu replaces the auto-generated sidebar navigation
+
+Reference: [../common/infrahub-yml-reference.md](../../common/infrahub-yml-reference.md)

--- a/skills/menu-creator/rules/hierarchy-nesting.md
+++ b/skills/menu-creator/rules/hierarchy-nesting.md
@@ -1,0 +1,87 @@
+---
+title: Menu Hierarchy and Nesting
+impact: HIGH
+tags: hierarchy, nesting, children, data, group-headers
+---
+
+## Menu Hierarchy and Nesting
+
+**Impact: HIGH**
+
+Menu items can be nested to any depth using `children.data`.
+
+**Incorrect -- children without data wrapper:**
+
+```yaml
+- namespace: Dcim
+  name: DeviceMenu
+  children:
+    - namespace: Dcim              # Wrong! Must be under `data` key
+      name: Servers
+```
+
+**Correct -- children with data wrapper:**
+
+```yaml
+- namespace: Dcim
+  name: DeviceMenu
+  label: Device Management
+  icon: "mdi:server"
+  children:
+    data:                          # Required wrapper
+      - namespace: Dcim
+        name: InfrastructureMenu
+        label: "Infrastructure"
+        icon: "mdi:server"
+        children:
+          data:
+            - namespace: Dcim
+              name: Server
+              label: Servers
+              kind: DcimServer
+              icon: mdi:server
+
+            - namespace: Dcim
+              name: Switch
+              label: Switches
+              kind: DcimSwitch
+              icon: mdi:switch
+
+      - namespace: Dcim
+        name: TypesMenu
+        label: "Types & Platforms"
+        icon: "mdi:cog"
+        children:
+          data:
+            - namespace: Organization
+              name: Manufacturer
+              label: Manufacturers
+              kind: OrganizationManufacturer
+              icon: "mdi:factory"
+```
+
+### Planning a Hierarchy
+
+Map out the navigation structure first:
+
+```
+Device Management
+  ├── Infrastructure
+  │   ├── Servers
+  │   ├── Switches
+  │   └── PDUs
+  ├── Types & Platforms
+  │   ├── Manufacturers
+  │   └── Device Types
+  └── Modules
+      ├── Module Types
+      └── Module Installations
+```
+
+### Key Rules
+
+- `children` must contain a `data` key wrapping the array of child items
+- Children follow the identical property structure (unlimited nesting depth)
+- Use YAML comments (`# --------- Section ---------`) for readability in large menus
+
+Reference: [Infrahub Menu Docs](https://docs.infrahub.app)

--- a/skills/menu-creator/rules/icons-reference.md
+++ b/skills/menu-creator/rules/icons-reference.md
@@ -1,0 +1,55 @@
+---
+title: MDI Icon Reference
+impact: HIGH
+tags: icons, mdi, material-design
+---
+
+## MDI Icon Reference
+
+**Impact: HIGH**
+
+Icons use the Material Design Icons (MDI) library with `mdi:` prefix.
+
+### Common Infrastructure Icons
+
+| Icon | Use For |
+|------|---------|
+| `mdi:server` | Servers, generic devices |
+| `mdi:switch` | Network switches |
+| `mdi:router-network` | Routers |
+| `mdi:power-socket` | PDUs |
+| `mdi:battery-charging` | UPS |
+| `mdi:factory` | Manufacturers, buildings |
+| `mdi:earth` | Regions |
+| `mdi:office-building` | Sites |
+| `mdi:door` | Rooms |
+| `mdi:map-marker` | Locations (generic) |
+| `mdi:cog` | Settings, types, config |
+| `mdi:package-variant` | Device types |
+| `mdi:chip` | Platforms |
+| `mdi:expansion-card` | Modules, cards |
+| `mdi:ethernet` | Interfaces |
+| `mdi:camera` | Cameras |
+| `mdi:snowflake` | Chillers, cooling |
+| `mdi:laser-pointer` | Lasers |
+| `mdi:tray` | Shelves |
+| `mdi:serial-port` | Serial servers |
+| `mdi:shield-lock` | Security |
+| `mdi:ip-network` | IP/Network |
+
+### Browse All Icons
+
+Full library: https://pictogrammers.com/library/mdi/
+
+### Usage
+
+```yaml
+- namespace: Dcim
+  name: Servers
+  label: Servers
+  kind: DcimServer
+  icon: mdi:server                # No quotes needed for simple icons
+  # icon: "mdi:server"           # Quotes also work
+```
+
+Reference: [Material Design Icons](https://pictogrammers.com/library/mdi/)

--- a/skills/menu-creator/rules/item-properties.md
+++ b/skills/menu-creator/rules/item-properties.md
@@ -1,0 +1,62 @@
+---
+title: Menu Item Properties
+impact: CRITICAL
+tags: item, name, namespace, label, kind, path, icon, children
+---
+
+## Menu Item Properties
+
+**Impact: CRITICAL**
+
+Every menu item has required and optional properties.
+
+### Property Reference
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | string | Yes | Unique identifier for the menu item |
+| `namespace` | string | Yes | Organizational grouping (e.g., `Dcim`, `Location`) |
+| `label` | string | No | Display text shown in the UI |
+| `kind` | string | No | Links to a schema node kind (e.g., `DcimServer`) |
+| `path` | string | No | Direct URL path (alternative to `kind`) |
+| `icon` | string | No | Icon from MDI library (e.g., `mdi:server`) |
+| `order_weight` | integer | No | Sort position (lower = higher in list) |
+| `parent` | string | No | Reference to parent menu item |
+| `children` | object | No | Nested menu items under a `data` key |
+
+### kind vs path
+
+Use **`kind`** to link to a schema node's list view (auto-resolves the URL):
+
+```yaml
+- namespace: Dcim
+  name: Servers
+  kind: DcimServer              # Auto-links to /objects/DcimServer
+```
+
+Use **`path`** for custom URLs (only when `kind` doesn't apply):
+
+```yaml
+- namespace: Custom
+  name: Dashboard
+  path: /dashboard              # Direct URL
+```
+
+**Never use both `kind` and `path` on the same item.**
+
+### Items Without kind or path
+
+A menu item without `kind` or `path` serves as a **group header** (non-clickable):
+
+```yaml
+- namespace: Dcim
+  name: DeviceManagementMenu
+  label: Device Management
+  icon: "mdi:server"
+  # No kind = just a header for grouping children
+  children:
+    data:
+      - ...
+```
+
+Reference: [Infrahub Menu Docs](https://docs.infrahub.app)

--- a/skills/menu-creator/rules/patterns-common.md
+++ b/skills/menu-creator/rules/patterns-common.md
@@ -1,0 +1,70 @@
+---
+title: Common Menu Patterns
+impact: LOW
+tags: patterns, flat-menu, commented-items, generic-links
+---
+
+## Common Menu Patterns
+
+**Impact: LOW (reference patterns)**
+
+### Flat Menu (No Nesting)
+
+For simple projects with few node types:
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Menu
+spec:
+  data:
+    - namespace: Dcim
+      name: Devices
+      label: Devices
+      kind: DcimDevice
+      icon: "mdi:server"
+
+    - namespace: Location
+      name: Locations
+      label: Locations
+      kind: LocationGeneric
+      icon: "mdi:map-marker"
+
+    - namespace: Organization
+      name: Manufacturers
+      label: Manufacturers
+      kind: OrganizationManufacturer
+      icon: "mdi:factory"
+```
+
+### Direct Link to Generic Node List
+
+```yaml
+- namespace: Location
+  name: AllLocations
+  label: All Locations
+  kind: LocationGeneric          # Shows all location types in one view
+  icon: "mdi:map-marker"
+```
+
+### Commented Out Items
+
+Use YAML comments to temporarily hide menu items:
+
+```yaml
+children:
+  data:
+    - namespace: Dcim
+      name: Switch
+      label: Switches
+      kind: DcimSwitch
+      icon: mdi:switch
+
+    # - namespace: Dcim
+    #   name: Interface
+    #   label: Interfaces
+    #   kind: DcimInterface
+    #   icon: mdi:ethernet
+```
+
+Reference: [Infrahub Menu Docs](https://docs.infrahub.app)

--- a/skills/menu-creator/rules/schema-integration.md
+++ b/skills/menu-creator/rules/schema-integration.md
@@ -1,0 +1,42 @@
+---
+title: Schema Integration
+impact: MEDIUM
+tags: schema, include_in_menu, kind-links
+---
+
+## Schema Integration
+
+**Impact: MEDIUM**
+
+When using a custom menu, configure schema nodes to prevent duplicate menu entries.
+
+### Set include_in_menu: false
+
+When you use a custom menu, set `include_in_menu: false` on all schema nodes:
+
+```yaml
+# In schema files
+nodes:
+  - name: Server
+    namespace: Dcim
+    include_in_menu: false     # Menu is controlled by custom menu file
+    # ...
+```
+
+Without this, Infrahub generates auto-menu entries alongside your custom menu, creating duplicates.
+
+### kind Auto-Resolution
+
+The `kind` property on menu items auto-resolves to the correct URL for the node's list view:
+
+```yaml
+- namespace: Location
+  name: AllLocations
+  label: All Locations
+  kind: LocationGeneric          # Shows all location types in one view
+  icon: "mdi:map-marker"
+```
+
+This is preferred over `path` because it stays correct even if URL patterns change.
+
+Reference: [../schema-creator/SKILL.md](../../schema-creator/SKILL.md)

--- a/skills/object-creator/SKILL.md
+++ b/skills/object-creator/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: infrahub-object-creator
+description: Create and manage Infrahub object data files. Use when populating infrastructure data, creating device instances, locations, organizations, module installations, or any other data objects for an Infrahub repository.
+license: MIT
+metadata:
+  author: infrahub
+  version: 1.0.0
+---
+
+## Overview
+
+Expert guidance for creating Infrahub object (data) files. Objects are YAML files that populate schema nodes with actual infrastructure data -- devices, locations, organizations, modules, and more.
+
+## When to Use
+
+- Creating new data files for infrastructure objects
+- Populating devices, locations, organizations, or other schema nodes
+- Setting up hierarchical data (location trees, tenant groups)
+- Referencing related objects across files
+- Managing component children (interfaces, modules)
+- Organizing object files for correct load order
+
+## Rule Categories
+
+| Priority | Category | Prefix | Description |
+|----------|----------|--------|-------------|
+| CRITICAL | File Format | `format-` | apiVersion, kind: Object, spec structure, required fields |
+| CRITICAL | Value Mapping | `value-` | How attributes, dropdowns, and relationship references map to schema types |
+| HIGH | Children | `children-` | Hierarchical nesting, component nesting, kind specification |
+| MEDIUM | Range Expansion | `range-` | Sequential interface expansion with expand_range |
+| MEDIUM | File Organization | `organization-` | Naming conventions, load order, multi-document files |
+| LOW | Common Patterns | `patterns-` | Flat lists, parent-child, devices, empty slots, git repos |
+
+## Object File Basics
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: <NodeKind>          # Schema node kind (e.g., DcimDellServer)
+  data:
+    - <attribute>: <value>  # List of object instances
+```
+
+`apiVersion`, `kind: Object`, `spec.kind`, and `spec.data` are always required. Each `spec` block targets a single node kind.
+
+## Supporting References
+
+- **[reference.md](./reference.md)** -- Object file format specification
+- **[examples.md](./examples.md)** -- 15 complete object patterns from production repos
+- **[../common/infrahub-yml-reference.md](../common/infrahub-yml-reference.md)** -- .infrahub.yml project configuration
+- **[../common/rules/](../common/rules/)** -- Shared rules (git integration, caching gotchas) that apply across all skills
+- **[../schema-creator/SKILL.md](../schema-creator/SKILL.md)** -- Schema definitions these objects conform to
+- **[rules/](./rules/)** -- Individual rules organized by category prefix

--- a/skills/object-creator/examples.md
+++ b/skills/object-creator/examples.md
@@ -1,0 +1,694 @@
+# Infrahub Object File Examples
+
+Real-world examples extracted from production Infrahub repositories.
+
+---
+
+## 1. Simple Flat List (Manufacturers)
+
+The simplest pattern -- attributes only, no relationships.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: OrganizationManufacturer
+  data:
+    - name: Acopian
+    - name: Chatsworth Products
+    - name: Dell
+    - name: Intel
+    - name: Juniper
+    - name: Nvidia
+    - name: Supermicro
+```
+
+**Key points:**
+- No relationships, so each item is just a `name` attribute
+- Load order: these have no dependencies, so they go first (prefix `01_`)
+
+---
+
+## 2. Parent-Child Inline (Tenant Groups with Tenants)
+
+Component/Parent relationships use inline `data` blocks.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: OrganizationTenantGroup
+  data:
+    - name: Quera-Internal
+      tenants:
+        data:
+          - name: Test and Engineering Infrastructure
+          - name: IT
+          - name: M4A
+          - name: M4B
+          - name: Castor
+    - name: External-Customers
+      tenants:
+        data:
+          - name: AIST
+```
+
+**Key points:**
+- `tenants` is a Component relationship on TenantGroup
+- Children are nested inline under `data:` (no `kind` needed since only one type of tenant exists)
+- The parent and all its children are created atomically
+
+---
+
+## 3. Groups (CoreStandardGroup)
+
+Groups are standalone objects that devices reference via `member_of_groups`.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: CoreStandardGroup
+  data:
+    - name: edge_routers
+      description: Edge Routers
+    - name: leafs
+      description: All leaf switches
+    - name: spines
+      description: All spine switches
+    - name: firewalls
+      description: All firewalls
+    - name: linux_devices
+      description: Linux Devices
+```
+
+**Key points:**
+- Groups should be created early (before devices that reference them)
+- Devices reference groups via `member_of_groups` list
+
+---
+
+## 4. Device Types (Referencing Manufacturers)
+
+Device types reference manufacturers by `human_friendly_id` (which is `name` for manufacturers).
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimDeviceType
+  data:
+    # PDUs
+    - model: EA-5007
+      manufacturer: Chatsworth Products
+      part_number: EA-5007-C / EA-5007-E / EA-5007-CE
+      role: PDU
+      airflow: passive
+      weight: 18
+      weight_unit: lb
+      description: "8.6kW Switched PDU with 24x C13 outlets."
+
+    # Servers
+    - model: PowerEdge R660xs
+      manufacturer: Dell
+      part_number: R660xs
+      u_height: 1
+      is_full_depth: true
+      airflow: front-to-rear
+
+    - model: PowerEdge R960
+      manufacturer: Dell
+      part_number: R960
+      u_height: 4
+      is_full_depth: true
+      airflow: front-to-rear
+      description: "4u 12x Gen5 PCIe server"
+
+    # Switches
+    - model: EX4100-48MP
+      manufacturer: Juniper
+      part_number: EX4100-48MP
+      u_height: 1
+      is_full_depth: false
+      airflow: front-to-rear
+```
+
+**Key points:**
+- `manufacturer: Dell` references `OrganizationManufacturer` by its `human_friendly_id` (`[name__value]`)
+- Dropdown values use `name` not `label`: `airflow: front-to-rear` (not "Front to Rear")
+- Manufacturers must be loaded before device types
+
+---
+
+## 5. Module Types
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimModuleType
+  data:
+    # PSU Modules
+    - model: Dell-KRT01-800W
+      manufacturer: Dell
+      part_number: KRT01
+      module_category: psu
+      description: Dell 800W AC Titanium Hot-Plug PSU
+
+    # GPU Modules
+    - model: Nvidia-T1000
+      manufacturer: Nvidia
+      part_number: T1000
+      module_category: gpu
+      description: Nvidia T1000 PCIe 3.0 x16 GPU
+
+    # NIC Modules (OCP)
+    - model: Dell-E810-XXVDA4-OCP
+      manufacturer: Dell
+      part_number: Y4VV5
+      module_category: nic
+      description: Intel E810-XXVDA4 Quad Port 10/25GbE SFP28 Adapter, OCP NIC 3.0
+
+    # NIC Modules (PCIe)
+    - model: Intel-E810-2CQDA2
+      manufacturer: Intel
+      part_number: E810-2CQDA2
+      module_category: nic
+      description: 2x 100GbE QSFP28
+```
+
+**Key points:**
+- `module_category` is a Dropdown -- use the choice `name` value
+- `manufacturer` references by `human_friendly_id`
+
+---
+
+## 6. Module Bay Templates
+
+Bay templates define available slots on a device type. They reference device types by `human_friendly_id` (which is `[model__value]`).
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimModuleBayTemplate
+  data:
+    # Dell PowerEdge R660xs PSU bays
+    - name: PSU1
+      device_type: PowerEdge R660xs
+      bay_type: psu
+      label: PSU1
+      position: Left from Rear
+
+    - name: PSU2
+      device_type: PowerEdge R660xs
+      bay_type: psu
+      label: PSU2
+      position: Right from Rear
+
+    # Dell PowerEdge R660xs OCP slot
+    - name: OCP Slot 1
+      device_type: PowerEdge R660xs
+      bay_type: ocp
+      description: OCP 3.0 Slot PCIe Gen4 x16
+
+    # Dell PowerEdge R660xs PCIe slots
+    - name: PCIe Slot 1
+      device_type: PowerEdge R660xs
+      bay_type: pcie
+      label: "1"
+      description: Half-height / Low Profile (LP) PCIe Gen4 x16 slot
+
+    - name: PCIe Slot 2
+      device_type: PowerEdge R660xs
+      bay_type: pcie
+      label: "2"
+      description: Half-height / Low Profile (LP) PCIe Gen5 x8 slot
+```
+
+**Key points:**
+- `device_type: PowerEdge R660xs` references `DcimDeviceType` by model
+- Bay templates must be created after device types but before module installations
+- The `name` + `device_type` pair forms the `human_friendly_id` for this template
+
+---
+
+## 7. Hierarchical Location Tree
+
+Locations nest inline from Region down to Rack, specifying `kind` at each level.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+version: "1.0"
+kind: Object
+spec:
+  kind: LocationRegion
+  data:
+    - name: "AMERICAS"
+      shortname: "amer"
+      description: "North and South America"
+      children:
+        kind: LocationSite
+        data:
+          - name: "1284 Soldier's Field Road"
+            shortname: "sfr"
+            description: "Main facility"
+            address: |
+              1284 Soldier's Field Road
+              Boston, MA 02135
+              United States
+            timezone: "America/New_York"
+            children:
+              kind: LocationRoom
+              data:
+                - name: "01-4"
+                  shortname: "01-4"
+                  description: "Lab area 01-4"
+                  children:
+                    kind: LocationRack
+                    data:
+                      - name: "TEST-RACK1"
+                        shortname: "test-rack1"
+                        description: "Test rack in lab 01-4"
+                        height: 42
+                        width: 600
+                        depth: 1200
+```
+
+**Key points:**
+- `children.kind` is always required (specifies which hierarchical child type)
+- The full tree is created atomically from one `spec` block
+- `shortname` is critical -- it's used in `human_friendly_id` for rooms and racks
+- Multiple regions can be defined as separate items in the top-level `data` list
+
+### Deeper Location Hierarchy (bundle-dc pattern)
+
+When schemas define more location levels (Region > Country > Metro > Building):
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+version: "1.0"
+kind: Object
+spec:
+  kind: LocationRegion
+  data:
+    - name: "EMEA"
+      shortname: "emea"
+      children:
+        kind: LocationCountry
+        data:
+          - name: "France"
+            shortname: "fr"
+            children:
+              kind: LocationMetro
+              data:
+                - name: "Paris"
+                  shortname: "par"
+                  children:
+                    kind: LocationBuilding
+                    data:
+                      - name: "PAR-1"
+                        shortname: "par-1"
+          - name: "Germany"
+            shortname: "de"
+            children:
+              kind: LocationMetro
+              data:
+                - name: "Frankfurt"
+                  shortname: "fra"
+                  children:
+                    kind: LocationBuilding
+                    data:
+                      - name: "FRA-1"
+                        shortname: "fra-1"
+```
+
+---
+
+## 8. Devices (With Type and Location References)
+
+Devices reference device types and racks by `human_friendly_id`.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimDellServer
+  data:
+    - name: TEST-R660xs-1
+      device_type: PowerEdge R660xs
+      rack: ["01-4", "TEST-RACK1"]       # [room_shortname, rack_name]
+      rack_u_position: 33
+      rack_face: front
+      status: active
+      serial: "SN12345"
+      warranty_expire_date: "2222-01-01"
+      asset_tag: "1234567890"
+      purchase_order: "[1234567890](https://app.bellwethercorp.com)"
+
+    - name: TEST-R960-1
+      device_type: PowerEdge R960
+      rack: ["01-4", "TEST-RACK1"]
+      rack_u_position: 23
+      rack_face: front
+      status: active
+      serial: "qwertyuiop"
+```
+
+**Key points:**
+- `device_type: PowerEdge R660xs` -- scalar because DcimDeviceType has single-element `human_friendly_id` (`[model__value]`)
+- `rack: ["01-4", "TEST-RACK1"]` -- list because LocationRack has multi-element `human_friendly_id` (`[parent__shortname__value, name__value]`)
+- `rack_face` and `status` are Dropdowns -- use the `name` value
+- `warranty_expire_date` is a DateTime, formatted as ISO string
+
+---
+
+## 9. Multiple Document Types in One File
+
+A single file can contain multiple YAML documents (separated by `---`), each targeting a different node kind.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimDellServer
+  data:
+    - name: TEST-R660xs-1
+      device_type: PowerEdge R660xs
+      rack: ["01-4", "TEST-RACK1"]
+      rack_u_position: 33
+      rack_face: front
+      status: active
+
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimSwitch
+  data:
+    - name: TEST-SP-EX4100-48
+      device_type: EX4100-48MP
+      rack: ["south-pole", "TEST-SP-RACK"]
+      rack_u_position: 42
+      rack_face: front
+      status: active
+      serial: "SN12345789"
+
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimPDU
+  data:
+    - name: TEST-CPI-5007-A
+      device_type: EA-5007
+      rack: ["01-4", "TEST-RACK1"]
+      rack_face: rear
+      status: active
+      serial: "asdfghjkl"
+      pdu_type: switched
+```
+
+**Key points:**
+- Each `---` separated document has its own `apiVersion`, `kind`, and `spec`
+- Each `spec.kind` targets exactly one node kind
+- Documents are processed in order within the file
+
+---
+
+## 10. Devices with Inline Interfaces
+
+Devices can include interfaces as inline Component children.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: SecurityFirewall
+  data:
+    - name: corp-firewall
+      role: edge_firewall
+      device_type: SRX-1500
+      platform: [Juniper, JunOS]          # Multi-element human_friendly_id
+      location: PAR-1
+      status: active
+      member_of_groups:
+        - juniper_firewall
+      interfaces:
+        kind: InterfacePhysical
+        data:
+          - name: fxp0
+            role: management
+            status: active
+          - name: ge-0/0/0
+            role: leaf
+            status: active
+          - name: ge-0/0/1
+            role: leaf
+            status: active
+```
+
+**Key points:**
+- `platform: [Juniper, JunOS]` -- list because DcimPlatform has `human_friendly_id: [manufacturer__name__value, name__value]`
+- `interfaces.kind: InterfacePhysical` -- required because the relationship peer may be a Generic
+- `member_of_groups` -- simple list of group names
+
+---
+
+## 11. Devices with Interface Range Expansion
+
+Use `expand_range: true` to auto-generate sequential interfaces.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimDevice
+  data:
+    - name: cisco-switch-01
+      role: leaf
+      device_type: N9K-C93108TC-FX
+      platform: [Cisco, NX-OS]
+      location: LON-1
+      status: active
+      member_of_groups:
+        - leafs
+      interfaces:
+        kind: InterfacePhysical
+        parameters:
+          expand_range: true
+        data:
+          - name: mgmt0
+            role: management
+            status: active
+          - name: Ethernet1/[1-4]         # Expands to Ethernet1/1 through Ethernet1/4
+            role: customer
+            status: active
+
+    - name: juniper-switch-01
+      role: spine
+      device_type: QFX5220-32CD
+      platform: [Juniper, JunOS]
+      location: FRA-1
+      status: active
+      interfaces:
+        kind: InterfacePhysical
+        parameters:
+          expand_range: true
+        data:
+          - name: fxp0
+            role: management
+            status: active
+          - name: et-0/0/[0-3]            # Expands to et-0/0/0 through et-0/0/3
+            role: leaf
+            status: active
+```
+
+**Key points:**
+- `parameters.expand_range: true` goes on the relationship block, NOT on individual interfaces
+- Range syntax: `[N-M]` in the interface name
+- All attributes from the template entry are copied to each expanded interface
+- Non-range interfaces (like `mgmt0`, `fxp0`) in the same block are not affected
+
+---
+
+## 12. Module Installations (Occupied Slots)
+
+Module installations connect devices to module types via bay templates.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimModuleInstallation
+  data:
+    # PSU installations
+    - device: TEST-R660xs-1
+      slot_name: PSU1
+      bay:
+        - PowerEdge R660xs              # device_type model (first element of bay's human_friendly_id)
+        - PSU1                           # bay name (second element)
+      module_type: Dell-KRT01-800W       # References DcimModuleType by model
+      status: active
+
+    - device: TEST-R660xs-1
+      slot_name: PSU2
+      bay:
+        - PowerEdge R660xs
+        - PSU2
+      module_type: Dell-KRT01-800W
+      status: active
+
+    # OCP NIC installation
+    - device: TEST-R660xs-1
+      slot_name: OCP Slot 1
+      bay:
+        - PowerEdge R660xs
+        - OCP Slot 1
+      module_type: Dell-E810-XXVDA4-OCP
+      status: active
+
+    # PCIe GPU installation
+    - device: TEST-R660xs-1
+      slot_name: PCIe Slot 1
+      bay:
+        - PowerEdge R660xs
+        - PCIe Slot 1
+      module_type: PNY-RTX4000-ADA-SFF
+      status: active
+```
+
+**Key points:**
+- `device: TEST-R660xs-1` -- references the device by name (`human_friendly_id: [name__value]`)
+- `bay` is a list: `[device_type_model, bay_name]` matching `DcimModuleBayTemplate`'s `human_friendly_id: [device_type__model__value, name__value]`
+- `module_type: Dell-KRT01-800W` -- references `DcimModuleType` by model
+- Requires: devices, bay templates, and module types all loaded first
+
+---
+
+## 13. Empty/Vacant Slots
+
+Track unoccupied module bays -- same structure as installations but with `status: empty` and no `module_type`.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimModuleInstallation
+  data:
+    - device: TEST-R660xs-1
+      slot_name: PCIe Slot 3
+      bay:
+        - PowerEdge R660xs
+        - PCIe Slot 3
+      status: empty                      # No module_type = vacant slot
+
+    - device: TEST-R960-1
+      slot_name: PSU1
+      bay:
+        - PowerEdge R960
+        - PSU1
+      status: empty
+
+    - device: TEST-R960-1
+      slot_name: OCP Slot 1
+      bay:
+        - PowerEdge R960
+        - OCP Slot 1
+      status: empty
+```
+
+**Key points:**
+- No `module_type` field -- the slot is tracked as vacant
+- Useful for inventory visibility: "which slots are available?"
+- Typically in a separate file (e.g., `07_empty_slots.yml`) loaded after occupied installations
+
+---
+
+## 14. IP Prefixes
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: IpamPrefix
+  data:
+    - prefix: 10.0.0.0/8
+      status: active
+    - prefix: 10.10.0.0/16
+      status: active
+    - prefix: 172.16.0.0/16
+      status: active
+    - prefix: 192.168.0.0/16
+      status: active
+    - prefix: 192.168.1.0/24
+      status: active
+    - prefix: fd00:1000::/32
+      status: active
+```
+
+**Key points:**
+- IPv4 and IPv6 prefixes use the `IPNetwork` attribute kind
+- CIDR notation is required
+
+---
+
+## 15. Git Repository
+
+Special `CoreRepository` object for Infrahub's git integration.
+
+```yaml
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: CoreRepository
+  data:
+    - name: bundle-dc
+      location: "/upstream"
+      default_branch: "main"
+```
+
+**Key points:**
+- `location` is the git remote URL or path
+- Typically in a subdirectory like `objects/git-repo/`
+- The `---` document separator is optional for the first document in a file
+
+---
+
+## Complete File Organization Example
+
+```
+objects/
+  01_manufacturers.yml          # OrganizationManufacturer (no deps)
+  02_organizations.yml          # OrganizationTenantGroup + Tenants (no deps)
+  03_device_types.yml           # DcimDeviceType (depends on manufacturers)
+  04_module_types.yml           # DcimModuleType (depends on manufacturers)
+  04a_module_bay_templates.yml  # DcimModuleBayTemplate (depends on device types)
+  05_locations.yml              # LocationRegion tree (self-contained hierarchy)
+  06_devices.yml                # DcimDellServer, DcimSwitch, etc. (depends on types + locations)
+  06_module_installations.yml   # DcimModuleInstallation (depends on devices + bays + module types)
+  07_empty_slots.yml            # DcimModuleInstallation with status: empty (depends on devices + bays)
+  git-repo/
+    local-dev.yml               # CoreRepository (independent, subdirectory)
+```
+
+**Loading order:**
+1. Files are sorted by filename within each directory
+2. Subdirectories are processed alphabetically after files
+3. Numeric prefixes (`01_`, `02_`) enforce correct dependency order
+4. Use letter suffixes (`04a_`) to insert between existing numbers

--- a/skills/object-creator/reference.md
+++ b/skills/object-creator/reference.md
@@ -1,0 +1,188 @@
+# Infrahub Object File Reference
+
+## Document Structure
+
+```yaml
+---
+apiVersion: infrahub.app/v1       # Required. Always this value.
+version: "1.0"                     # Optional. Version string.
+kind: Object                       # Required. Always "Object" for data files.
+spec:
+  kind: <NodeKind>                 # Required. Schema node kind (e.g., DcimDellServer).
+  data:                            # Required. List of object instances.
+    - <field>: <value>
+```
+
+## Value Types by Schema Attribute Kind
+
+| Schema Attribute Kind | YAML Value Type | Example |
+|----------------------|-----------------|---------|
+| `Text` | string | `name: "My Device"` |
+| `TextArea` | string (multiline ok) | `description: "Long text"` |
+| `Number` | integer | `rack_u_position: 33` |
+| `Boolean` | boolean | `is_full_depth: true` |
+| `Dropdown` | string (choice `name`) | `status: active` |
+| `DateTime` | string (ISO format) | `created: "2024-01-15T10:30:00Z"` |
+| `IPHost` | string | `address: "192.168.1.1/24"` |
+| `IPNetwork` | string | `prefix: "10.0.0.0/8"` |
+| `MacAddress` | string | `mac: "00:1A:2B:3C:4D:5E"` |
+| `Email` | string | `email: "admin@example.com"` |
+| `URL` | string | `website: "https://example.com"` |
+| `JSON` | object/string | `config: {"key": "value"}` |
+| `Password` | string | `password: "secret"` |
+
+## Relationship Value Formats
+
+### cardinality: one (Simple Reference)
+
+Reference the target object by its `human_friendly_id`:
+
+```yaml
+# Target has human_friendly_id: [name__value]
+manufacturer: Dell
+
+# Target has human_friendly_id: [model__value]
+device_type: PowerEdge R960
+
+# Target has human_friendly_id: [parent__shortname__value, name__value]
+rack: ["room-shortname", "rack-name"]
+
+# Target has human_friendly_id: [manufacturer__name__value, name__value]
+platform: [Juniper, JunOS]
+```
+
+**Rule**: Single-element `human_friendly_id` = scalar value. Multi-element = list of values.
+
+### cardinality: many (Inline Data)
+
+For Component children or nested relationships:
+
+```yaml
+# Simple component children
+tenants:
+  data:
+    - name: "Tenant A"
+    - name: "Tenant B"
+
+# Component children with specified kind
+interfaces:
+  kind: InterfacePhysical
+  data:
+    - name: eth0
+      status: active
+
+# Hierarchical children (location trees)
+children:
+  kind: LocationSite
+  data:
+    - name: "Boston"
+      shortname: "bos"
+```
+
+### cardinality: many (Group Membership)
+
+```yaml
+member_of_groups:
+  - group_name_1
+  - group_name_2
+```
+
+## Inline Children Block Structure
+
+When nesting children inline:
+
+```yaml
+<relationship_name>:
+  kind: <ChildNodeKind>           # Required when multiple child types possible
+  parameters:                      # Optional
+    expand_range: true             # Enable interface range expansion
+  data:
+    - <child_field>: <value>
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `kind` | Sometimes | Child node kind. Required for hierarchical children and when the relationship peer is a Generic. |
+| `parameters` | No | Processing parameters (e.g., `expand_range`) |
+| `data` | Yes | List of child object instances |
+
+## Interface Range Expansion
+
+When `expand_range: true` is set in parameters, interface names with `[N-M]` syntax are expanded:
+
+```yaml
+interfaces:
+  kind: InterfacePhysical
+  parameters:
+    expand_range: true
+  data:
+    - name: Ethernet1/[1-4]       # Creates Ethernet1/1, Ethernet1/2, Ethernet1/3, Ethernet1/4
+      role: customer
+      status: active
+    - name: et-0/0/[0-3]          # Creates et-0/0/0, et-0/0/1, et-0/0/2, et-0/0/3
+      role: leaf
+      status: active
+```
+
+All attributes on the template entry are copied to each expanded interface.
+
+## Special Object Types
+
+### CoreRepository (Git Integration)
+
+```yaml
+spec:
+  kind: CoreRepository
+  data:
+    - name: my-repo
+      location: "/upstream"        # Git remote URL or path
+      default_branch: "main"
+```
+
+### CoreStandardGroup
+
+```yaml
+spec:
+  kind: CoreStandardGroup
+  data:
+    - name: leafs
+      description: All leaf switches
+```
+
+## File Loading Behavior
+
+- Files in the `objects/` directory (as specified in `.infrahub.yml`) are loaded recursively
+- Files are sorted by filename within each directory
+- Use numeric prefixes (`01_`, `02_`) to control load order
+- Multiple YAML documents per file (separated by `---`) are processed in order
+- Subdirectories are processed alphabetically
+
+## Dependency Resolution
+
+Objects reference each other by `human_friendly_id`. The referenced object must exist (or be defined earlier in the same batch) when the referencing object is loaded.
+
+**Dependency chain example:**
+```
+Manufacturers (no deps)
+  -> Device Types (depend on Manufacturers)
+    -> Module Bay Templates (depend on Device Types)
+Locations (hierarchy, self-contained)
+  -> Devices (depend on Device Types + Locations)
+    -> Module Installations (depend on Devices + Bay Templates + Module Types)
+```
+
+## Matching human_friendly_id
+
+To reference a target object, you need to know its `human_friendly_id` from the schema:
+
+| Schema Node | human_friendly_id | How to Reference |
+|-------------|-------------------|-----------------|
+| `OrganizationManufacturer` | `[name__value]` | `manufacturer: Dell` |
+| `DcimDeviceType` | `[model__value]` | `device_type: PowerEdge R960` |
+| `DcimModuleType` | `[model__value]` | `module_type: Dell-KRT01-800W` |
+| `LocationRack` | `[parent__shortname__value, name__value]` | `rack: ["room-shortname", "Rack-A"]` |
+| `LocationRoom` | `[parent__name__value, name__value]` | (usually via hierarchical nesting) |
+| `DcimModuleBayTemplate` | `[device_type__model__value, name__value]` | `bay: ["PowerEdge R960", "PSU1"]` |
+| `DcimPlatform` | `[manufacturer__name__value, name__value]` | `platform: [Juniper, JunOS]` |
+| `DcimGenericDevice` (any device) | `[name__value]` | `device: my-server-01` |
+| `OrganizationTenant` | `[name__value]` | `tenant: Engineering` |

--- a/skills/object-creator/rules/_sections.md
+++ b/skills/object-creator/rules/_sections.md
@@ -1,0 +1,13 @@
+# Infrahub Object Creator - Rule Sections
+
+1. **File Format (format-)** -- CRITICAL. apiVersion, kind: Object, spec structure, required and optional fields. Every object file must follow this exact structure.
+
+2. **Value Mapping (value-)** -- CRITICAL. How schema attribute types map to YAML values. Dropdown name vs label, relationship references by human_friendly_id (scalar vs list), group membership.
+
+3. **Children (children-)** -- HIGH. Nesting hierarchical children (location trees) and component children (interfaces, modules). Always requires `kind` specification on the nested block.
+
+4. **Range Expansion (range-)** -- MEDIUM. Using `expand_range: true` to generate sequential interfaces (e.g., Ethernet1/[1-4]). Must be set on the relationship block via `parameters`.
+
+5. **File Organization (organization-)** -- MEDIUM. Numeric prefix naming convention, dependency load order, multi-document files, one kind per document rule.
+
+6. **Common Patterns (patterns-)** -- LOW. Ready-to-use patterns: flat lists, parent-child inline, devices with references, empty slots, git repos.

--- a/skills/object-creator/rules/_template.md
+++ b/skills/object-creator/rules/_template.md
@@ -1,0 +1,25 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+**Impact: MEDIUM**
+
+Brief explanation of the rule and why it matters for Infrahub object creation.
+
+**Incorrect:**
+
+```yaml
+# Bad example
+```
+
+**Correct:**
+
+```yaml
+# Good example
+```
+
+Reference: [Infrahub Object Docs](https://docs.infrahub.app)

--- a/skills/object-creator/rules/children-components.md
+++ b/skills/object-creator/rules/children-components.md
@@ -1,0 +1,59 @@
+---
+title: Component Children Nesting
+impact: HIGH
+tags: children, components, interfaces, modules
+---
+
+## Component Children Nesting
+
+**Impact: HIGH**
+
+For Component relationships (interfaces, modules), nest children inline under the relationship name with `kind` specified.
+
+**Incorrect -- missing kind on component children:**
+
+```yaml
+data:
+  - name: "my-switch"
+    interfaces:
+      data:
+        - name: fxp0                  # What kind? Ambiguous!
+```
+
+**Correct -- kind specified:**
+
+```yaml
+data:
+  - name: "my-switch"
+    device_type: QFX5220-32CD
+    location: PAR-1
+    status: active
+    interfaces:
+      kind: InterfacePhysical         # Specify the component kind
+      data:
+        - name: fxp0
+          role: management
+          status: active
+        - name: et-0/0/0
+          role: core
+          status: active
+```
+
+### Parent-Child Inline (Non-Hierarchical)
+
+For Component/Parent relationships like TenantGroup/Tenant:
+
+```yaml
+spec:
+  kind: OrganizationTenantGroup
+  data:
+    - name: Internal
+      tenants:
+        data:
+          - name: Engineering
+          - name: IT
+```
+
+Note: Non-hierarchical component children don't always require `kind` if the schema relationship unambiguously identifies the child type.
+
+Reference: [Infrahub Object Docs](https://docs.infrahub.app)

--- a/skills/object-creator/rules/children-hierarchy.md
+++ b/skills/object-creator/rules/children-hierarchy.md
@@ -1,0 +1,53 @@
+---
+title: Hierarchical Children Nesting
+impact: HIGH
+tags: children, hierarchy, locations, nesting
+---
+
+## Hierarchical Children Nesting
+
+**Impact: HIGH**
+
+For hierarchical nodes (location trees), nest children inline with the `kind` field specified on each level.
+
+**Incorrect -- missing kind on children:**
+
+```yaml
+data:
+  - name: "AMERICAS"
+    children:
+      data:
+        - name: "Boston HQ"          # What kind is this? Ambiguous!
+```
+
+**Correct -- kind specified at each level:**
+
+```yaml
+data:
+  - name: "AMERICAS"
+    shortname: "amer"
+    children:
+      kind: LocationSite              # Must specify child kind
+      data:
+        - name: "Boston HQ"
+          shortname: "bos"
+          children:
+            kind: LocationRoom
+            data:
+              - name: "Lab-1"
+                shortname: "lab-1"
+                children:
+                  kind: LocationRack
+                  data:
+                    - name: "Rack-A"
+                      height: 42
+```
+
+### Rules
+
+- `children` must contain a `kind` field and a `data` array
+- `kind` specifies the schema node type of the child objects
+- Nesting depth is unlimited -- matches your schema hierarchy
+- The hierarchy auto-resolves parent references
+
+Reference: [Infrahub Object Docs](https://docs.infrahub.app)

--- a/skills/object-creator/rules/format-structure.md
+++ b/skills/object-creator/rules/format-structure.md
@@ -1,0 +1,80 @@
+---
+title: Object File Structure
+impact: CRITICAL
+tags: format, apiVersion, kind, spec, structure
+---
+
+## Object File Structure
+
+**Impact: CRITICAL**
+
+Every object file must follow the exact YAML structure. Missing or misplaced fields cause silent failures.
+
+### Required Fields
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| `apiVersion` | `infrahub.app/v1` | Always this value |
+| `kind` | `Object` | Always `Object` for data files |
+| `spec.kind` | Node kind | Schema node these objects are instances of (e.g., `DcimDellServer`) |
+| `spec.data` | list | List of object instances |
+
+### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| `version` | `"1.0"` -- Optional version string |
+
+**Incorrect:**
+
+```yaml
+# Missing apiVersion
+kind: Object
+spec:
+  kind: DcimDevice
+  data:
+    - name: my-device
+
+# Data not under spec
+apiVersion: infrahub.app/v1
+kind: Object
+data:
+  - name: my-device
+```
+
+**Correct:**
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimDevice
+  data:
+    - name: my-device
+      status: active
+```
+
+### One Kind per Document
+
+Each `spec` block targets a single node kind. To create objects of different kinds, use separate YAML documents (separated by `---`) or separate files.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: SecurityFirewall
+  data:
+    - name: corp-firewall
+
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimDevice
+  data:
+    - name: cisco-switch-01
+```
+
+Reference: [reference.md](../reference.md) for full format specification.

--- a/skills/object-creator/rules/organization-load-order.md
+++ b/skills/object-creator/rules/organization-load-order.md
@@ -1,0 +1,92 @@
+---
+title: File Organization and Load Order
+impact: MEDIUM
+tags: organization, naming, load-order, dependencies
+---
+
+## File Organization and Load Order
+
+**Impact: MEDIUM**
+
+Objects must be loaded in dependency order. A device can't reference a rack that hasn't been created yet.
+
+### Naming Convention
+
+Use numeric prefixes for load order:
+
+```
+objects/
+  01_manufacturers.yml          # Base data first (no dependencies)
+  02_organizations.yml          # Groups/tenants
+  03_device_types.yml           # Types (depend on manufacturers)
+  04_module_types.yml           # Module types (depend on manufacturers)
+  04a_module_bay_templates.yml  # Bay templates (depend on device types)
+  05_locations.yml              # Location hierarchy
+  06_devices.yml                # Devices (depend on types, locations)
+  06_module_installations.yml   # Module installs (depend on devices, bays, types)
+  07_empty_slots.yml            # Empty slots (depend on devices, bays)
+  git-repo/
+    local-dev.yml               # Git repo config for local development
+```
+
+### Dependency Order
+
+1. **Independent objects**: Manufacturers, groups, tenant groups
+2. **Type definitions**: Device types, module types, platforms
+3. **Templates**: Module bay templates, interface templates
+4. **Locations**: Regions > Sites > Rooms > Racks (hierarchy auto-resolves)
+5. **Instances**: Devices, modules, installations
+6. **Metadata**: Tags, empty slots, connections
+
+### Multi-Document Files
+
+A single YAML file can contain multiple documents separated by `---`:
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: SecurityFirewall
+  data:
+    - name: corp-firewall
+
+---
+apiVersion: infrahub.app/v1
+kind: Object
+spec:
+  kind: DcimDevice
+  data:
+    - name: cisco-switch-01
+```
+
+### Bootstrap Files Must Live Outside `objects/`
+
+When `.infrahub.yml` specifies `objects: - objects`, Infrahub auto-imports **every** YAML file in that directory during git sync. Files that define infrastructure config (like `CoreRepository` or `CoreReadOnlyRepository` definitions) will be imported as objects, which can cause validation errors or circular dependencies.
+
+**Incorrect -- bootstrap file inside objects/:**
+
+```
+objects/
+  git-repo/
+    local-dev.yml          # CoreReadOnlyRepository definition
+  01_manufacturers.yml     # Will ALL be auto-imported during sync
+```
+
+**Correct -- bootstrap files in a separate directory:**
+
+```
+bootstrap/
+  local-dev-repo.yml       # Loaded manually, never auto-imported
+objects/
+  01_manufacturers.yml     # Only real data objects here
+```
+
+### .infrahub.yml Registration
+
+```yaml
+objects:
+  - objects              # Loads all files in the objects/ directory recursively
+```
+
+Reference: [../common/infrahub-yml-reference.md](../../common/infrahub-yml-reference.md) | See also: [deployment-git-integration.md](../../common/rules/deployment-git-integration.md)

--- a/skills/object-creator/rules/patterns-common.md
+++ b/skills/object-creator/rules/patterns-common.md
@@ -1,0 +1,65 @@
+---
+title: Common Object Patterns
+impact: LOW
+tags: patterns, flat-list, parent-child, devices, git-repo
+---
+
+## Common Object Patterns
+
+**Impact: LOW (reference patterns)**
+
+### Flat List (No Relationships)
+
+```yaml
+spec:
+  kind: OrganizationManufacturer
+  data:
+    - name: Dell
+    - name: Intel
+    - name: Juniper
+```
+
+### Device with All References
+
+```yaml
+spec:
+  kind: DcimDellServer
+  data:
+    - name: prod-server-01
+      device_type: PowerEdge R960
+      rack: ["lab-1", "Rack-A"]
+      rack_u_position: 1
+      rack_face: front
+      status: active
+      serial: "ABC123"
+      asset_tag: "DELL-001"
+      warranty_expire_date: "2027-01-01"
+      tenant: Engineering
+```
+
+### Empty/Vacant Slots
+
+```yaml
+spec:
+  kind: DcimModuleInstallation
+  data:
+    - device: prod-server-01
+      slot_name: PCIe Slot 3
+      bay:
+        - PowerEdge R960
+        - PCIe Slot 3
+      status: empty              # No module_type = vacant slot
+```
+
+### Git Repository Object
+
+```yaml
+spec:
+  kind: CoreRepository
+  data:
+    - name: my-repo
+      location: "/upstream"
+      default_branch: "main"
+```
+
+See [examples.md](../examples.md) for 15 complete patterns.

--- a/skills/object-creator/rules/range-expansion.md
+++ b/skills/object-creator/rules/range-expansion.md
@@ -1,0 +1,51 @@
+---
+title: Interface Range Expansion
+impact: MEDIUM
+tags: range, expansion, interfaces, sequential
+---
+
+## Interface Range Expansion
+
+**Impact: MEDIUM**
+
+For interfaces with sequential names, use range syntax with `expand_range: true` to avoid repetitive entries.
+
+**Incorrect -- expand_range on individual items:**
+
+```yaml
+interfaces:
+  kind: InterfacePhysical
+  data:
+    - name: Ethernet1/[1-4]
+      expand_range: true              # Wrong! Goes on parameters, not data items
+      role: customer
+```
+
+**Correct -- expand_range in parameters block:**
+
+```yaml
+interfaces:
+  kind: InterfacePhysical
+  parameters:
+    expand_range: true                # Set on the relationship block
+  data:
+    - name: Ethernet1/[1-4]           # Expands to Ethernet1/1, Ethernet1/2, Ethernet1/3, Ethernet1/4
+      role: customer
+      status: active
+```
+
+### Range Syntax
+
+| Pattern | Expands To |
+|---------|-----------|
+| `Ethernet1/[1-4]` | Ethernet1/1, Ethernet1/2, Ethernet1/3, Ethernet1/4 |
+| `et-0/0/[0-31]` | et-0/0/0 through et-0/0/31 |
+| `GigE[1-48]` | GigE1 through GigE48 |
+
+### Key Rules
+
+- `expand_range: true` goes under `parameters`, not on individual data items
+- All expanded interfaces share the same attribute values (role, status, etc.)
+- Range uses inclusive bounds: `[1-4]` means 1, 2, 3, and 4
+
+Reference: [Infrahub Object Docs](https://docs.infrahub.app)

--- a/skills/object-creator/rules/value-attributes.md
+++ b/skills/object-creator/rules/value-attributes.md
@@ -1,0 +1,45 @@
+---
+title: Attribute Value Mapping
+impact: CRITICAL
+tags: values, attributes, dropdown, text, number, boolean
+---
+
+## Attribute Value Mapping
+
+**Impact: CRITICAL**
+
+Schema attribute types map directly to YAML values. The most common mistake is using a Dropdown `label` instead of `name`.
+
+### Type Mapping
+
+| Schema Kind | YAML Value | Example |
+|------------|------------|---------|
+| Text | string | `name: "My Device"` |
+| Number | integer | `rack_u_position: 33` |
+| Boolean | true/false | `is_full_depth: true` |
+| Dropdown | choice name | `status: active` |
+| DateTime | ISO string | `warranty_expire_date: "2027-01-01"` |
+
+### Dropdown Values
+
+**Incorrect -- using the label:**
+
+```yaml
+data:
+  - name: my-device
+    status: Active            # Wrong! "Active" is the label
+    rack_face: Front          # Wrong! "Front" is the label
+```
+
+**Correct -- using the choice name:**
+
+```yaml
+data:
+  - name: my-device
+    status: active            # "active" is the choice name
+    rack_face: front          # "front" is the choice name
+```
+
+The `name` value from `choices` in the schema is what you use, not the `label`.
+
+Reference: [Infrahub Object Docs](https://docs.infrahub.app)

--- a/skills/object-creator/rules/value-relationships.md
+++ b/skills/object-creator/rules/value-relationships.md
@@ -1,0 +1,65 @@
+---
+title: Relationship Reference Mapping
+impact: CRITICAL
+tags: values, relationships, human_friendly_id, references
+---
+
+## Relationship Reference Mapping
+
+**Impact: CRITICAL**
+
+Reference related objects by their `human_friendly_id`. The format depends on whether the target's `human_friendly_id` has one or multiple elements.
+
+### Single-Element human_friendly_id (scalar)
+
+When the target has `human_friendly_id: [name__value]`:
+
+```yaml
+data:
+  - name: "PowerEdge R660xs"
+    manufacturer: Dell                # Scalar -- matches OrganizationManufacturer by name
+```
+
+### Multi-Element human_friendly_id (list)
+
+When the target has `human_friendly_id: [parent__shortname__value, name__value]`:
+
+```yaml
+data:
+  - name: "My Server"
+    rack: ["lab-1", "Rack-A"]         # List -- matches [room_shortname, rack_name]
+```
+
+### Platform References
+
+```yaml
+data:
+  - name: "my-switch"
+    platform: [Juniper, JunOS]        # [manufacturer_name, platform_name]
+```
+
+### Module Bay References
+
+When the target has `human_friendly_id: [device_type__model__value, name__value]`:
+
+```yaml
+data:
+  - device: TEST-R660xs-1
+    bay:
+      - PowerEdge R660xs              # device_type model
+      - PSU1                          # bay name
+```
+
+### Group Membership (cardinality: many)
+
+```yaml
+data:
+  - name: "my-device"
+    member_of_groups:
+      - leafs
+      - cisco_leaf
+```
+
+**Key rule**: The value you provide must match the target node's `human_friendly_id`. Scalar for single-element, list for multi-element.
+
+Reference: [Infrahub Object Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/SKILL.md
+++ b/skills/schema-creator/SKILL.md
@@ -1,93 +1,62 @@
 ---
 name: infrahub-schema-creator
-description: Create, validate, and modify Infrahub schema(s). Use when designing data models, creating schema nodes with attributes and relationships, validating schema definitions, or planning schema migrations for Infrahub.
+description: Create, validate, and modify Infrahub schemas. Use when designing data models, creating schema nodes with attributes and relationships, validating schema definitions, or planning schema migrations for Infrahub.
+license: MIT
+metadata:
+  author: infrahub
+  version: 1.0.0
 ---
 
-# Infrahub Schema Creator
+## Overview
 
-Create, validate, and modify Infrahub schema(s) for infrastructure data management.
-
-## Description
-
-This skill assists with designing and implementing Infrahub schemas. Infrahub is an infrastructure data management platform where schemas define data structure using YAML format. This skill covers the full schema lifecycle: creation, validation, and modification.
-
-## Capabilities
-
-- Create new Infrahub schema from natural language requirements
-- Design nodes with appropriate attributes and relationships
-- Create generics for shared properties and inheritance
-- Validate schemas against Infrahub conventions
-- Migrate and update existing schemas
-- Generate human-friendly IDs and uniqueness constraints
+Expert guidance for designing and building Infrahub schemas. Schemas are YAML files defining nodes (concrete types), generics (abstract base types), attributes, relationships, and extensions.
 
 ## When to Use
 
-This skill is invoked when:
+- Designing new data models or schema nodes
+- Adding attributes or relationships to existing schemas
+- Setting up hierarchical location trees or component/parent patterns
+- Configuring display properties (human_friendly_id, display_label)
+- Migrating or refactoring existing schemas
+- Debugging schema validation errors
 
-- Creating new Infrahub schema definitions
-- Modeling infrastructure data (devices, sites, networks, etc.)
-- Adding or modifying nodes, attributes, or relationships
-- Designing schema inheritance with generics
-- Validating existing schemas
-- Planning schema migrations
+## Rule Categories
 
-## Quick Start
+| Priority | Category | Prefix | Description |
+|----------|----------|--------|-------------|
+| CRITICAL | Naming | `naming-` | Namespace, node, attribute naming patterns and kind derivation |
+| CRITICAL | Relationships | `relationship-` | Identifier matching, peer references, component/parent pairs, defaults |
+| HIGH | Attributes | `attribute-` | Mandatory defaults, dropdown choices, deprecated fields |
+| HIGH | Hierarchy | `hierarchy-` | Hierarchical generics, parent/children setup |
+| HIGH | Display | `display-` | human_friendly_id, order_weight conventions |
+| MEDIUM | Extensions | `extension-` | Cross-file relationships via extensions block |
+| MEDIUM | Uniqueness | `uniqueness-` | Constraint format with __value suffix |
+| MEDIUM | Migration | `migration-` | Adding/removing attributes, state: absent |
+| LOW | Validation | `validation-` | Common errors, pre-check checklist |
 
-### Basic Schema Structure
-
-```yaml
----
-version: "1.0"
-generics:
-  - name: GenericName
-    namespace: Namespace
-    # ... definition
-nodes:
-  - name: NodeName
-    namespace: Namespace
-    # ... definition
-extensions:
-    nodes:
-    # ... definition
-```
-
-### Simple Node Example
+## Schema File Basics
 
 ```yaml
 ---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
 version: "1.0"
-nodes:
-  - name: Device
-    namespace: Network
-    label: Network Device
-    icon: mdi:server
-    human_friendly_id:
-      - "hostname__value"
-    attributes:
-      - name: hostname
-        kind: Text
-        unique: true
-      - name: model
-        kind: Text
-        optional: true
+
+generics:      # Abstract base definitions (shared attributes/relationships)
+  - ...
+nodes:         # Concrete object types
+  - ...
+extensions:    # Add attributes/relationships to existing nodes from other files
+  nodes:
+    - ...
 ```
 
-## Documentation
+Always include the `$schema` comment for IDE validation. Only `version` is required at the top level.
 
-- [Schema Reference](reference.md) - Complete node, attribute, and relationship properties
-- [Validation Guide](validation.md) - Schema validation and migration commands
-- [Example Templates](examples.md) - Ready-to-use schema patterns
+## Supporting References
 
-## Best Practices Summary
-
-1. **Naming**: PascalCase for nodes/generics/namespaces, snake_case for attributes/relationships
-2. **Generics**: Use when multiple nodes share attributes or need polymorphic relationships
-3. **Relationships**: Always set `identifier` for bidirectional relationships
-4. **Human-friendly IDs**: Design readable identifiers using attribute paths
-5. **Migrations**: Use `state: absent` to remove elements, always validate before loading
-
-## Resources
-
-- [Infrahub Schema Documentation](https://docs.infrahub.app/topics/schema)
-- [Creating a Schema Guide](https://docs.infrahub.app/guides/create-schema)
-- [Schema Library](https://github.com/opsmill/schema-library)
+- **[reference.md](./reference.md)** -- Complete property tables for nodes, generics, attributes, and relationships
+- **[examples.md](./examples.md)** -- Full schema patterns extracted from production repos
+- **[validation.md](./validation.md)** -- `infrahubctl` commands, migration strategies, pre-validation checklist
+- **[../common/infrahub-yml-reference.md](../common/infrahub-yml-reference.md)** -- .infrahub.yml project configuration
+- **[../common/rules/](../common/rules/)** -- Shared rules (git integration, caching gotchas) that apply across all skills
+- **[rules/](./rules/)** -- Individual rules organized by category prefix

--- a/skills/schema-creator/examples.md
+++ b/skills/schema-creator/examples.md
@@ -1,506 +1,935 @@
-# Schema Examples
+# Infrahub Schema Examples
 
-Ready-to-use Infrahub schema templates and patterns.
+Real-world schema patterns extracted from production Infrahub deployments. Use these as templates for common infrastructure modeling scenarios.
 
-## Basic Node with Attributes
+## Organization Schema (Simplest Pattern)
 
-A simple node with various attribute types:
-
-```yaml
----
-version: "1.0"
-nodes:
-  - name: Device
-    namespace: Network
-    label: Network Device
-    icon: mdi:server
-    description: A network device such as router, switch, or firewall
-    human_friendly_id:
-      - "hostname__value"
-    attributes:
-      - name: hostname
-        kind: Text
-        unique: true
-        description: Unique hostname identifier
-      - name: model
-        kind: Text
-        optional: true
-      - name: serial_number
-        kind: Text
-        optional: true
-      - name: status
-        kind: Dropdown
-        choices:
-          - name: active
-            color: "#00FF00"
-          - name: maintenance
-            color: "#FFA500"
-          - name: decommissioned
-            color: "#FF0000"
-        default_value: active
-```
-
-## Attributes with Parameters
-
-Attributes that support validation parameters (`Number`, `NumberPool`, `Text`, `TextArea`):
+A generic base with simple nodes inheriting from it. Good starting point for any domain.
 
 ```yaml
 ---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
 version: "1.0"
-nodes:
-  - name: Server
-    namespace: Infrastructure
-    human_friendly_id:
-      - "hostname__value"
-    attributes:
-      - name: hostname
-        kind: Text
-        unique: true
-        parameters:
-          regex: "^[a-z][a-z0-9-]+$"
-          min_length: 3
-          max_length: 63
-      - name: rack_position
-        kind: Number
-        parameters:
-          min_value: 1
-          max_value: 48
-      - name: cpu_cores
-        kind: Number
-        parameters:
-          min_value: 1
-          excluded_values: [13]
-      - name: description
-        kind: TextArea
-        optional: true
-        parameters:
-          max_length: 1000
-```
 
-## Node with Relationships
-
-Parent-child relationship between Device and Interface:
-
-```yaml
----
-version: "1.0"
-nodes:
-  - name: Device
-    namespace: Network
-    human_friendly_id:
-      - "hostname__value"
-    attributes:
-      - name: hostname
-        kind: Text
-        unique: true
-    relationships:
-      - name: site
-        peer: OrganizationSite
-        kind: Attribute
-        cardinality: one
-        optional: true
-        identifier: "site__devices"
-      - name: interfaces
-        peer: NetworkInterface
-        kind: Component
-        cardinality: many
-        identifier: "device__interfaces"
-
-  - name: Interface
-    namespace: Network
-    human_friendly_id:
-      - "device__hostname__value"
-      - "name__value"
-    attributes:
-      - name: name
-        kind: Text
-      - name: description
-        kind: Text
-        optional: true
-      - name: mtu
-        kind: Number
-        default_value: 1500
-      - name: enabled
-        kind: Boolean
-        default_value: true
-    relationships:
-      - name: device
-        peer: NetworkDevice
-        kind: Parent
-        cardinality: one
-        optional: false
-        identifier: "device__interfaces"
-```
-
-## Generic with Inheritance
-
-Base interface generic with specialized implementations:
-
-```yaml
----
-version: "1.0"
 generics:
-  - name: Interface
-    namespace: Network
-    description: Base interface generic
+  - name: Generic
+    namespace: Organization
+    label: Organization
+    description: Base organization entity
+    icon: mdi:domain
+    include_in_menu: true
     human_friendly_id:
-      - "device__hostname__value"
       - "name__value"
+    order_by:
+      - name__value
+    display_label: name__value
     attributes:
       - name: name
         kind: Text
+        unique: true
+        order_weight: 1000
       - name: description
         kind: Text
         optional: true
-      - name: enabled
-        kind: Boolean
-        default_value: true
+        order_weight: 1200
     relationships:
-      - name: device
-        peer: NetworkDevice
-        kind: Parent
-        cardinality: one
-        optional: false
+      - name: tags
+        peer: BuiltinTag
+        cardinality: many
+        kind: Attribute
+        optional: true
+        order_weight: 3000
 
 nodes:
-  - name: PhysicalInterface
-    namespace: Network
+  - name: Manufacturer
+    namespace: Organization
+    description: Device and module manufacturer
+    icon: mdi:factory
     inherit_from:
-      - NetworkInterface
-    icon: mdi:ethernet
-    attributes:
-      - name: speed
-        kind: Bandwidth
-        optional: true
-      - name: mac_address
-        kind: MacAddress
-        optional: true
+      - OrganizationGeneric
+    include_in_menu: true
+    menu_placement: OrganizationGeneric
 
-  - name: LogicalInterface
-    namespace: Network
+  - name: TenantGroup
+    namespace: Organization
+    description: Grouping of tenants
+    icon: mdi:folder-account
     inherit_from:
-      - NetworkInterface
-    icon: mdi:lan
-    attributes:
-      - name: vlan_id
-        kind: Number
-        optional: true
+      - OrganizationGeneric
+    include_in_menu: true
+    menu_placement: OrganizationGeneric
+    relationships:
+      - name: tenants
+        peer: OrganizationTenant
+        kind: Component             # TenantGroup OWNS Tenants
+        cardinality: many
+        identifier: "tenantgroup__tenants"
+
+  - name: Tenant
+    namespace: Organization
+    description: Tenant or customer organization
+    icon: mdi:account-group
+    inherit_from:
+      - OrganizationGeneric
+    include_in_menu: true
+    menu_placement: OrganizationGeneric
+    relationships:
+      - name: group
+        peer: OrganizationTenantGroup
+        kind: Parent                # Tenant belongs to TenantGroup
+        cardinality: one
+        optional: false
+        identifier: "tenantgroup__tenants"  # Must match Component side
 ```
 
-## Complete Infrastructure Schema
+**Key patterns:**
+- Generic defines shared `name`, `description`, `tags`
+- Nodes inherit and add specific relationships
+- Component/Parent pair with matching `identifier`
+- `menu_placement` groups nodes under the generic in the UI
 
-Full example with locations, devices, and interfaces:
+---
+
+## Hierarchical Location Schema
+
+Location trees using `hierarchical: true`. Each level defines `parent` and `children`.
 
 ```yaml
 ---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
 version: "1.0"
+
 generics:
   - name: Generic
     namespace: Location
-    description: Base location type
-    icon: mdi:map-marker
+    description: Generic Location
+    label: Location
+    icon: mingcute:location-line
+    hierarchical: true             # Enables parent/children hierarchy
+    include_in_menu: false
+    order_by:
+      - name__value
+    display_label: "{{ name__value }}"
     attributes:
       - name: name
         kind: Text
+        order_weight: 1000
         unique: true
+      - name: shortname
+        kind: Text
+        unique: true
+        order_weight: 1100
       - name: description
         kind: Text
         optional: true
-
-nodes:
-  - name: Site
-    namespace: Organization
-    inherit_from:
-      - LocationGeneric
-    icon: mdi:office-building
-    human_friendly_id:
-      - "name__value"
-    attributes:
-      - name: address
-        kind: TextArea
-        optional: true
-      - name: site_type
-        kind: Dropdown
-        choices:
-          - name: datacenter
-          - name: office
-          - name: remote
-    relationships:
-      - name: devices
-        peer: NetworkDevice
-        kind: Component
-        cardinality: many
-        identifier: "site__devices"
-
-  - name: Device
-    namespace: Network
-    icon: mdi:server-network
-    human_friendly_id:
-      - "hostname__value"
-    attributes:
-      - name: hostname
-        kind: Text
-        unique: true
-      - name: management_ip
-        kind: IPHost
-        optional: true
-      - name: platform
-        kind: Text
-        optional: true
-    relationships:
-      - name: site
-        peer: OrganizationSite
-        kind: Parent
-        cardinality: one
-        optional: false
-        identifier: "site__devices"
-      - name: interfaces
-        peer: NetworkInterface
-        kind: Component
-        cardinality: many
-        identifier: "device__interfaces"
-
-  - name: Interface
-    namespace: Network
-    icon: mdi:ethernet
-    human_friendly_id:
-      - "device__hostname__value"
-      - "name__value"
-    attributes:
-      - name: name
-        kind: Text
-      - name: ip_address
-        kind: IPHost
-        optional: true
-      - name: enabled
-        kind: Boolean
-        default_value: true
-    relationships:
-      - name: device
-        peer: NetworkDevice
-        kind: Parent
-        cardinality: one
-        optional: false
-        identifier: "device__interfaces"
-```
-
-## IP Address Management (IPAM) Schema
-
-Schema for managing IP prefixes and addresses:
-
-```yaml
----
-version: "1.0"
-nodes:
-  - name: Prefix
-    namespace: Ipam
-    icon: mdi:ip-network
-    human_friendly_id:
-      - "prefix__value"
-    attributes:
-      - name: prefix
-        kind: IPNetwork
-        unique: true
-      - name: description
-        kind: Text
-        optional: true
+        order_weight: 1200
       - name: status
         kind: Dropdown
+        optional: true
+        default_value: active
+        order_weight: 1150
         choices:
           - name: active
-          - name: reserved
-          - name: deprecated
-        default_value: active
+            label: Active
+            color: "#00FF00"
+          - name: planned
+            label: Planned
+            color: "#0000FF"
+          - name: staging
+            label: Staging
+            color: "#FFA500"
+          - name: decommissioning
+            label: Decommissioning
+            color: "#808080"
     relationships:
-      - name: parent
-        peer: IpamPrefix
-        kind: Parent
-        cardinality: one
-        optional: true
-        identifier: "prefix__children"
-      - name: children
-        peer: IpamPrefix
-        kind: Component
-        cardinality: many
-        identifier: "prefix__children"
-      - name: addresses
-        peer: IpamAddress
-        kind: Component
-        cardinality: many
-        identifier: "prefix__addresses"
-
-  - name: Address
-    namespace: Ipam
-    icon: mdi:ip
-    human_friendly_id:
-      - "address__value"
-    attributes:
-      - name: address
-        kind: IPHost
-        unique: true
-      - name: description
-        kind: Text
-        optional: true
-    relationships:
-      - name: prefix
-        peer: IpamPrefix
-        kind: Parent
-        cardinality: one
-        optional: true
-        identifier: "prefix__addresses"
-      - name: interface
-        peer: NetworkInterface
+      - name: tags
+        peer: BuiltinTag
         kind: Attribute
-        cardinality: one
         optional: true
-        identifier: "interface__addresses"
-```
-
-## VLAN Management Schema
-
-Schema for VLAN and VLAN group management:
-
-```yaml
----
-version: "1.0"
-nodes:
-  - name: VlanGroup
-    namespace: Network
-    icon: mdi:folder-network
-    human_friendly_id:
-      - "name__value"
-    attributes:
-      - name: name
-        kind: Text
-        unique: true
-      - name: description
-        kind: Text
-        optional: true
-    relationships:
-      - name: vlans
-        peer: NetworkVlan
-        kind: Component
         cardinality: many
-        identifier: "vlangroup__vlans"
-
-  - name: Vlan
-    namespace: Network
-    icon: mdi:lan
-    human_friendly_id:
-      - "group__name__value"
-      - "vlan_id__value"
-    uniqueness_constraints:
-      - ["group", "vlan_id"]
-    attributes:
-      - name: vlan_id
-        kind: Number
-        parameters:
-          min_value: 1
-          max_value: 4094
-      - name: name
-        kind: Text
-      - name: description
-        kind: Text
-        optional: true
-      - name: status
-        kind: Dropdown
-        choices:
-          - name: active
-          - name: reserved
-          - name: deprecated
-        default_value: active
-    relationships:
-      - name: group
-        peer: NetworkVlanGroup
-        kind: Parent
-        cardinality: one
-        optional: false
-        identifier: "vlangroup__vlans"
-```
-
-## Rack and Location Schema
-
-Schema for physical infrastructure locations:
-
-```yaml
----
-version: "1.0"
-generics:
-  - name: Location
-    namespace: Dcim
-    description: Physical location
-    hierarchical: true
-    attributes:
-      - name: name
-        kind: Text
-      - name: description
-        kind: Text
-        optional: true
+        order_weight: 3000
 
 nodes:
   - name: Region
-    namespace: Dcim
+    namespace: Location
+    label: Region
     inherit_from:
-      - DcimLocation
-    icon: mdi:earth
-    human_friendly_id:
-      - "name__value"
-    attributes:
-      - name: name
-        kind: Text
-        unique: true
+      - LocationGeneric
+    include_in_menu: false
+    icon: "carbon:cics-region-target"
+    parent: null                   # Root of hierarchy
+    children: LocationSite
+    uniqueness_constraints:
+      - ["name__value"]
 
   - name: Site
-    namespace: Dcim
+    namespace: Location
+    label: Site
     inherit_from:
-      - DcimLocation
+      - LocationGeneric
+    include_in_menu: false
     icon: mdi:office-building
+    parent: LocationRegion
+    children: LocationRoom
+    uniqueness_constraints:
+      - ["shortname__value", "parent"]   # Unique shortname within parent
     human_friendly_id:
-      - "name__value"
+      - parent__name__value              # Parent's name
+      - shortname__value                 # This site's shortname
     attributes:
-      - name: name
-        kind: Text
-        unique: true
       - name: address
         kind: TextArea
         optional: true
+        order_weight: 1100
+      - name: timezone
+        kind: Text
+        optional: true
+        order_weight: 1300
       - name: latitude
         kind: Number
         optional: true
+        order_weight: 1400
       - name: longitude
         kind: Number
         optional: true
+        order_weight: 1500
 
   - name: Room
-    namespace: Dcim
+    namespace: Location
+    description: Room or area within a site
     inherit_from:
-      - DcimLocation
+      - LocationGeneric
+    include_in_menu: false
     icon: mdi:door
+    parent: LocationSite
+    children: LocationRack
+    uniqueness_constraints:
+      - ["name__value", "parent"]
     human_friendly_id:
-      - "site__name__value"
-      - "name__value"
+      - parent__name__value
+      - name__value
 
   - name: Rack
-    namespace: Dcim
+    namespace: Location
+    description: Equipment rack
+    inherit_from:
+      - LocationGeneric
+    include_in_menu: false
     icon: mdi:server
+    parent: LocationRoom
+    # No children - leaf of hierarchy
+    uniqueness_constraints:
+      - ["name__value", "parent"]
     human_friendly_id:
-      - "room__name__value"
+      - "parent__shortname__value"
       - "name__value"
     attributes:
-      - name: name
-        kind: Text
       - name: height
         kind: Number
         default_value: 42
         description: Rack height in U
-      - name: description
+        order_weight: 1100
+    relationships:
+      - name: devices
+        peer: DcimGenericDevice
+        kind: Generic
+        cardinality: many
+        optional: true
+        identifier: "rack__devices"
+        on_delete: "no-action"
+```
+
+**Key patterns:**
+- Generic has `hierarchical: true`
+- Region has `parent: null` (root)
+- Each level specifies `parent` and `children`
+- Rack (leaf) has no `children`
+- `uniqueness_constraints` scoped to parent: `["name__value", "parent"]`
+- `human_friendly_id` traverses parent chain: `parent__name__value`
+
+---
+
+## Device Management with Generics and Inheritance
+
+Complex schema showing multiple generics, computed attributes, and specialized nodes.
+
+```yaml
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: "1.0"
+
+generics:
+  # Base device generic - shared by ALL device types
+  - name: GenericDevice
+    namespace: Dcim
+    description: Physical device instance
+    label: Device
+    icon: mdi:server
+    include_in_menu: false
+    human_friendly_id:
+      - name__value
+    uniqueness_constraints:
+      - ["rack", "rack_u_position__value"]
+    attributes:
+      - name: name
+        kind: Text
+        unique: true
+        order_weight: 1000
+      - name: serial
         kind: Text
         optional: true
+        order_weight: 1100
+      - name: asset_tag
+        kind: Text
+        optional: true
+        order_weight: 1200
+      - name: rack_u_position
+        label: Rack Position (U)
+        kind: Number
+        optional: true
+        order_weight: 1300
+      - name: rack_face
+        kind: Dropdown
+        optional: true
+        default_value: front
+        order_weight: 1400
+        choices:
+          - name: front
+            label: Front
+          - name: rear
+            label: Rear
+      - name: status
+        kind: Dropdown
+        default_value: active
+        order_weight: 1500
+        choices:
+          - name: active
+            label: Active
+            color: "#00FF00"
+          - name: planned
+            label: Planned
+            color: "#0000FF"
+          - name: staged
+            label: Staged
+            color: "#FFA500"
+          - name: failed
+            label: Failed
+            color: "#FF0000"
+          - name: decommissioning
+            label: Decommissioning
+            color: "#808080"
     relationships:
-      - name: room
-        peer: DcimRoom
-        kind: Parent
+      - name: device_type
+        peer: DcimDeviceType
+        kind: Attribute
         cardinality: one
         optional: false
-        identifier: "room__racks"
+        identifier: "devicetype__devices"
+        order_weight: 900
+      - name: rack
+        peer: LocationRack
+        kind: Attribute
+        cardinality: one
+        optional: false
+        identifier: "rack__devices"
+        order_weight: 950
+      - name: tags
+        peer: BuiltinTag
+        cardinality: many
+        kind: Attribute
+        optional: true
+        order_weight: 3000
+
+  # Vendor-specific generic with computed attributes
+  - name: GenericDellDevice
+    namespace: Dcim
+    description: Dell-specific device attributes
+    label: DellDevice
+    icon: mdi:server
+    include_in_menu: false
+    attributes:
+      - name: dell_asset_tag
+        label: Dell Asset Tag
+        kind: Text
+        computed_attribute:
+          kind: Jinja2
+          jinja2_template: "{% if asset_tag__value %}[{{ asset_tag__value }}](https://www.dell.com/support/contents/en-us/category/product-support/self-support-knowledgebase/locate-service-tag){% else %}N/A{% endif %}"
+        optional: false
+        read_only: true
+        order_weight: 2100
+
+nodes:
+  # Device Type (standalone, not inheriting)
+  - name: DeviceType
+    namespace: Dcim
+    description: A model/type of device
+    label: Device Type
+    icon: mdi:devices
+    include_in_menu: false
+    human_friendly_id:
+      - "model__value"
+    order_by:
+      - model__value
+    display_label: "{{ manufacturer__name__value }} {{ model__value }}"
+    attributes:
+      - name: model
+        kind: Text
+        unique: true
+        order_weight: 1000
+      - name: u_height
+        label: Height (U)
+        kind: Number
+        default_value: 1
+        order_weight: 1300
+      - name: is_full_depth
+        label: Full Depth
+        kind: Boolean
+        default_value: true
+        order_weight: 1400
+    relationships:
+      - name: manufacturer
+        peer: OrganizationManufacturer
+        kind: Attribute
+        cardinality: one
+        optional: false
+        identifier: "manufacturer__device_types"
+        order_weight: 900
+
+  # Multiple inheritance: GenericDevice + GenericDellDevice
+  - name: DellServer
+    namespace: Dcim
+    include_in_menu: false
+    inherit_from:
+      - DcimGenericDevice
+      - DcimGenericDellDevice      # Gets dell_asset_tag computed attribute
+
+  # Simple inheritance nodes
+  - name: Switch
+    namespace: Dcim
+    description: Network Switch
+    icon: mdi:switch
+    include_in_menu: false
+    inherit_from:
+      - DcimGenericDevice
+
+  - name: Router
+    namespace: Dcim
+    description: Network Router
+    icon: mdi:router-network
+    include_in_menu: false
+    inherit_from:
+      - DcimGenericDevice
+
+  - name: UPS
+    namespace: Dcim
+    description: Uninterruptible Power Supply
+    icon: mdi:battery-charging
+    include_in_menu: false
+    inherit_from:
+      - DcimGenericDevice
+```
+
+**Key patterns:**
+- `GenericDevice` defines all shared device attributes
+- `GenericDellDevice` adds vendor-specific computed attributes
+- `DellServer` uses **multiple inheritance** to combine both generics
+- Simple devices (`Switch`, `Router`, `UPS`) inherit only from `GenericDevice`
+- `DeviceType` is a standalone node (not a device itself)
+- `display_label` uses Jinja2 to combine manufacturer + model
+
+---
+
+## Component Pattern (Modules/Slots)
+
+Parent-child ownership with Component/Parent relationships.
+
+```yaml
+nodes:
+  # Module type definition
+  - name: ModuleType
+    namespace: Dcim
+    description: A type of installable module
+    icon: mdi:expansion-card
+    include_in_menu: false
+    human_friendly_id:
+      - "model__value"
+    attributes:
+      - name: model
+        kind: Text
+        unique: true
+        order_weight: 1000
+      - name: module_category
+        kind: Dropdown
+        order_weight: 1150
+        choices:
+          - name: psu
+            label: Power Supply
+          - name: gpu
+            label: GPU
+          - name: nic
+            label: Network Interface Card
+    relationships:
+      - name: manufacturer
+        peer: OrganizationManufacturer
+        kind: Attribute
+        cardinality: one
+        optional: false
+        identifier: "manufacturer__module_types"
+        order_weight: 900
+
+  # Module bay template (slot definition on a device type)
+  - name: ModuleBayTemplate
+    namespace: Dcim
+    description: Slot for installing modules
+    icon: mdi:slot-machine
+    include_in_menu: false
+    human_friendly_id:
+      - "device_type__model__value"
+      - "name__value"
+    uniqueness_constraints:
+      - ["device_type", "name__value"]   # Unique bay name per device type
+    attributes:
+      - name: name
+        kind: Text
+        order_weight: 1000
+      - name: bay_type
+        kind: Dropdown
+        order_weight: 1150
+        choices:
+          - name: psu
+            label: Power Supply
+          - name: pcie
+            label: PCIe Slot
+    relationships:
+      - name: device_type
+        peer: DcimDeviceType
+        kind: Parent                     # Bay belongs to a DeviceType
+        cardinality: one
+        optional: false
+        identifier: "devicetype__module_bay_templates"
+
+  # Module installation (tracks which module is in which slot)
+  - name: ModuleInstallation
+    namespace: Dcim
+    description: Module installed in a device bay
+    icon: mdi:expansion-card-variant
+    include_in_menu: false
+    human_friendly_id:
+      - "device__name__value"
+      - "slot_name__value"
+    display_label: "{{ device__name__value }} / {{ slot_name__value }}"
+    uniqueness_constraints:
+      - ["device", "slot_name__value"]   # One module per slot per device
+    attributes:
+      - name: slot_name
+        kind: Text
+        order_weight: 1000
+      - name: status
+        kind: Dropdown
+        default_value: active
+        order_weight: 1100
+        choices:
+          - name: active
+            label: Active
+            color: "#00FF00"
+          - name: empty
+            label: Empty
+            color: "#808080"
+    relationships:
+      - name: device
+        peer: DcimGenericDevice
+        kind: Parent                     # Installation belongs to a Device
+        cardinality: one
+        optional: false
+        identifier: "device__modules"
+        order_weight: 900
+      - name: bay
+        peer: DcimModuleBayTemplate
+        kind: Attribute
+        cardinality: one
+        optional: false
+        identifier: "modulebay__installations"
+        order_weight: 920
+      - name: module_type
+        peer: DcimModuleType
+        kind: Attribute
+        cardinality: one
+        optional: true                   # Empty if slot is vacant
+        identifier: "moduletype__installations"
+        order_weight: 950
+```
+
+**Key patterns:**
+- `ModuleBayTemplate` -> `DeviceType` via Parent/Component
+- `ModuleInstallation` -> `Device` via Parent/Component
+- `uniqueness_constraints` ensure one module per slot per device
+- `display_label` combines device name + slot name with Jinja2
+
+---
+
+## IPAM Schema (Inheriting Built-in Types)
+
+IP address management inheriting from Infrahub built-in types.
+
+```yaml
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: "1.0"
+
+nodes:
+  - name: IPAddress
+    namespace: Ipam
+    description: IP Address
+    label: IP Address
+    icon: mdi:ip
+    include_in_menu: false
+    inherit_from:
+      - BuiltinIPAddress           # Built-in type provides address field
+    order_by:
+      - address__value
+    display_label: address__value
+    uniqueness_constraints:
+      - [address__value, ip_namespace]
+    human_friendly_id:
+      - address__value
+      - ip_namespace__name__value
+    attributes:
+      - name: fqdn
+        label: FQDN
+        kind: Text
+        optional: true
+        regex: "(?=^.{1,253}$)(^(((?!-)[a-zA-Z0-9-]{1,63}(?<!-))|((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63})$)"
+    relationships:
+      - name: interface
+        peer: InterfaceLayer3
+        optional: true
+        cardinality: one
+
+  - name: Prefix
+    namespace: Ipam
+    description: IPv4 or IPv6 network
+    icon: mdi:ip-network
+    include_in_menu: false
+    inherit_from:
+      - BuiltinIPPrefix            # Built-in type provides prefix field
+    order_by:
+      - prefix__value
+    display_label: prefix__value
+    uniqueness_constraints:
+      - [prefix__value, ip_namespace]
+    human_friendly_id:
+      - prefix__value
+      - ip_namespace__name__value
+    attributes:
+      - name: status
+        kind: Dropdown
+        choices:
+          - name: active
+            label: Active
+          - name: deprecated
+            label: Deprecated
+          - name: reserved
+            label: Reserved
+    relationships:
+      - name: organization
+        peer: OrganizationGeneric
+        optional: true
+        cardinality: one
+        kind: Attribute
+        order_weight: 1200
+      - name: gateway
+        label: L3 Gateway
+        identifier: prefix__gateway    # Identifier for same-type relationship
+        peer: IpamIPAddress
+        optional: true
+        cardinality: one
+        kind: Attribute
+        order_weight: 1500
+```
+
+**Key patterns:**
+- Inherits from `BuiltinIPAddress` / `BuiltinIPPrefix` (provides address/prefix fields)
+- `regex` validation on FQDN attribute
+- `identifier` on gateway relationship (same peer type as other IP relationships)
+- `uniqueness_constraints` combines attribute with namespace relationship
+
+---
+
+## Extensions Pattern (Cross-File Relationships)
+
+Adding relationships between nodes defined in different schema files.
+
+```yaml
+---
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
+version: "1.0"
+
+# Define new nodes
+nodes:
+  - name: VLAN
+    namespace: Ipam
+    description: Isolated layer two domain
+    icon: mdi:lan-pending
+    menu_placement: IpamL2Domain
+    uniqueness_constraints:
+      - [vlan_id__value, l2domain]
+    human_friendly_id:
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+      - name: vlan_id
+        kind: Number
+      - name: status
+        kind: Dropdown
+        choices:
+          - name: active
+            label: Active
+            color: "#7fbf7f"
+    relationships:
+      - name: l2domain
+        peer: IpamL2Domain
+        optional: false
+        cardinality: one
+        kind: Attribute
+        order_weight: 1200
+
+# Extend EXISTING nodes from other schema files
+extensions:
+  nodes:
+    - kind: IpamPrefix             # Add VLAN relationship to Prefix
+      relationships:
+        - name: vlan
+          peer: IpamVLAN
+          optional: true
+          cardinality: one
+          kind: Attribute
+          order_weight: 1400
+
+    - kind: InterfaceLayer2        # Add VLAN relationships to L2 interfaces
+      relationships:
+        - name: untagged_vlan
+          label: Untagged VLAN
+          peer: IpamVLAN
+          optional: true
+          cardinality: one
+          kind: Generic
+          identifier: interface_l2__untagged_vlan
+        - name: tagged_vlan
+          label: Tagged VLANs
+          peer: IpamVLAN
+          optional: true
+          cardinality: many
+          kind: Generic
+          identifier: interface_l2__tagged_vlan
+```
+
+**Key patterns:**
+- `extensions.nodes` adds to existing nodes without modifying their schema file
+- Each extension references existing node by `kind`
+- New relationships/attributes are added to the existing node's definition
+- Keeps schemas modular -- each file can focus on its domain
+
+---
+
+## Network Interface Schema (Multiple Generics Composing Behavior)
+
+Advanced pattern showing interface composition with multiple generics.
+
+```yaml
+generics:
+  # Base interface
+  - name: Interface
+    namespace: Dcim
+    description: Generic Network Interface
+    include_in_menu: false
+    display_label: name__value
+    order_by: [device__name__value, name__value]
+    uniqueness_constraints:
+      - [device, name__value]
+    human_friendly_id:
+      - device__name__value
+      - name__value
+    attributes:
+      - name: name
+        kind: Text
+        order_weight: 1000
+      - name: mtu
+        label: MTU
+        kind: Number
+        default_value: 1514
+        order_weight: 1300
+      - name: status
+        kind: Dropdown
+        default_value: active
+        order_weight: 1200
+        choices:
+          - name: active
+            label: Active
+            color: "#A9CCE3"
+          - name: disabled
+            label: Disabled
+            color: "#D3D3D3"
+    relationships:
+      - name: device
+        peer: DcimGenericDevice
+        identifier: device__interface
+        kind: Parent
+        cardinality: one
+        order_weight: 1025
+
+  # Layer 2 mixin
+  - name: Layer2
+    namespace: Interface
+    include_in_menu: false
+    attributes:
+      - name: l2_mode
+        label: Layer2 Mode
+        kind: Dropdown
+        optional: true
+        order_weight: 1500
+        choices:
+          - name: access
+            label: Access
+          - name: trunk
+            label: Trunk
+
+  # Layer 3 mixin
+  - name: Layer3
+    namespace: Interface
+    include_in_menu: false
+    attributes:
+      - name: mac_address
+        kind: Text
+        optional: true
+        order_weight: 1550
+    relationships:
+      - name: ip_addresses
+        peer: IpamIPAddress
+        cardinality: many
+        kind: Attribute
+        optional: true
+        order_weight: 1150
+
+nodes:
+  # Physical interface: compose all three generics
+  - name: Physical
+    namespace: Interface
+    label: Physical Interface
+    description: Physical network port
+    inherit_from:
+      - DcimInterface
+      - InterfaceLayer2
+      - InterfaceLayer3
+    include_in_menu: false
+
+  # Virtual interface: L2 + L3 but no physical endpoint
+  - name: Virtual
+    namespace: Interface
+    label: Virtual Interface
+    description: Virtual interface (VLAN, Loopback)
+    inherit_from:
+      - DcimInterface
+      - InterfaceLayer2
+      - InterfaceLayer3
+    include_in_menu: false
+```
+
+**Key patterns:**
+- Separate generics for L2 and L3 behavior (composition over inheritance)
+- Physical interfaces combine all three generics
+- Virtual interfaces can selectively include/exclude generics
+- `identifier` on device relationship matches the Component side on GenericDevice
+
+---
+
+## Custom Menu File
+
+Full custom menu with nested groups.
+
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Menu
+spec:
+  data:
+    - namespace: Dcim
+      name: DeviceManagementMenu
+      label: Device Management
+      icon: "mdi:server"
+      children:
+        data:
+          - namespace: Dcim
+            name: DevicesMenu
+            label: Infrastructure
+            icon: "mdi:server"
+            children:
+              data:
+                - namespace: Dcim
+                  name: DellServers
+                  label: Dell Servers
+                  kind: DcimDellServer
+                  icon: mdi:server
+                - namespace: Dcim
+                  name: Switches
+                  label: Switches
+                  kind: DcimSwitch
+                  icon: mdi:switch
+          - namespace: Dcim
+            name: TypesMenu
+            label: Types & Platforms
+            icon: "mdi:cog"
+            children:
+              data:
+                - namespace: Organization
+                  name: Manufacturers
+                  label: Manufacturers
+                  kind: OrganizationManufacturer
+                  icon: "mdi:factory"
+                - namespace: Dcim
+                  name: DeviceTypes
+                  label: Device Types
+                  kind: DcimDeviceType
+                  icon: "mdi:package-variant"
+
+    - namespace: Location
+      name: LocationsMenu
+      label: Locations
+      icon: "mdi:map-marker"
+      children:
+        data:
+          - namespace: Location
+            name: Regions
+            label: Regions
+            kind: LocationRegion
+            icon: "mdi:earth"
+          - namespace: Location
+            name: Sites
+            label: Sites
+            kind: LocationSite
+            icon: "mdi:office-building"
+          - namespace: Location
+            name: Racks
+            label: Racks
+            kind: LocationRack
+            icon: "mdi:server"
+```
+
+---
+
+## State Management (Removing Attributes)
+
+Use `state: absent` to remove attributes during schema migration:
+
+```yaml
+nodes:
+  - name: ModuleInstallation
+    namespace: Dcim
+    attributes:
+      - name: old_field_name
+        kind: Text
+        state: absent              # This attribute will be removed
+      - name: new_field_name
+        kind: Text
+        order_weight: 1000         # Replacement attribute
 ```

--- a/skills/schema-creator/reference.md
+++ b/skills/schema-creator/reference.md
@@ -1,330 +1,339 @@
-# Schema Reference
+# Infrahub Schema Property Reference
 
-Complete reference for Infrahub schema properties.
+Complete reference for all schema properties. JSON Schema validation available at:
+`https://schema.infrahub.app/infrahub/schema/latest.json`
+
+## Top-Level Schema File
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `version` | string | **Yes** | - | Schema version, always `"1.0"` |
+| `generics` | list | No | `[]` | List of GenericSchema definitions |
+| `nodes` | list | No | `[]` | List of NodeSchema definitions |
+| `extensions` | object | No | `{}` | SchemaExtension block for extending existing nodes |
+
+---
 
 ## Node Properties
 
-| Property | Required | Description |
-|----------|----------|-------------|
-| `name` | Yes | PascalCase, 2-32 chars, pattern: `^[A-Z][a-zA-Z0-9]+$` |
-| `namespace` | Yes | PascalCase, 3-32 chars, pattern: `^[A-Z][a-z0-9]+$` |
-| `description` | No | Max 128 chars |
-| `label` | No | Human-readable name, max 64 chars |
-| `icon` | No | Material Design Icons ref (e.g., `mdi:server`) |
-| `branch` | No | `aware` (default), `agnostic`, or `local` |
-| `inherit_from` | No | List of generic kinds to inherit from |
-| `human_friendly_id` | No | List of attribute paths for readable IDs |
-| `uniqueness_constraints` | No | Multi-field uniqueness rules |
-| `display_label` | No | Jinja2 template for display |
-| `order_by` | No | Default sorting fields |
-| `default_filter` | No | Default query filter field |
-| `include_in_menu` | No | Show in UI sidebar (default: true) |
-| `menu_placement` | No | Menu location path |
-| `hierarchical` | No | Enable parent-child structures |
-| `attributes` | No | List of attribute definitions |
-| `relationships` | No | List of relationship definitions |
+Properties for entries in the `nodes:` list. **Required: `name`, `namespace`.**
 
-## Attribute Kinds
+### Identity & Display
 
-| Category | Kinds |
-|----------|-------|
-| **Text** | `Text`, `TextArea`, `Email`, `URL`, `Password`, `HashedPassword`, `File`, `MacAddress`, `Color` |
-| **Numeric** | `Number`, `NumberPool`, `Bandwidth` |
-| **Network** | `IPHost`, `IPNetwork` |
-| **Boolean** | `Boolean`, `Checkbox` |
-| **Temporal** | `DateTime` |
-| **Selection** | `Dropdown` (requires `choices`) |
-| **Complex** | `List`, `JSON`, `Any` |
-| **System** | `ID` |
+| Property | Type | Default | Constraints | Description |
+|----------|------|---------|-------------|-------------|
+| `name` | string | *required* | 2-32 chars, `^[A-Z][a-zA-Z0-9]+$` | Node name (PascalCase) |
+| `namespace` | string | *required* | 3-32 chars, `^[A-Z][a-z0-9]+$` | Namespace (first letter uppercase only) |
+| `description` | string | null | Max 128 chars | Short description |
+| `label` | string | null | Max 64 chars | Human-friendly display name (auto-generated if omitted) |
+| `icon` | string | null | Valid Iconify value | Icon identifier (e.g., `mdi:server`, `mingcute:location-line`) |
+| `display_label` | string | null | - | Attribute name or Jinja2 template (e.g., `"{{ manufacturer__name__value }} {{ name__value }}"`) |
+| `human_friendly_id` | list[string] | null | - | Attribute/relationship paths forming human-readable ID (e.g., `["parent__name__value", "name__value"]`) |
+| `order_by` | list[string] | null | - | Default sort order (e.g., `["name__value"]`) |
 
-## Attribute Properties
+### Menu & Visibility
 
-| Property | Required | Description |
-|----------|----------|-------------|
-| `name` | Yes | snake_case, 3-32 chars |
-| `kind` | Yes | Attribute type from list above |
-| `label` | No | Human-readable name |
-| `description` | No | Max 128 chars |
-| `optional` | No | Allow null values (default: false) |
-| `unique` | No | Enforce uniqueness (default: false) |
-| `default_value` | No | Default when not specified |
-| `choices` | No | For Dropdown: list of `{name, color, description}` |
-| `enum` | No | List of allowed values |
-| `parameters` | No | Nested object for kind-specific constraints (see Attribute Parameters below) |
-| `read_only` | No | Prevent modifications |
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `include_in_menu` | boolean | null | Whether to show in navigation menu |
+| `menu_placement` | string | null | Kind of parent generic to group under in menu |
+| `documentation` | string | null | URL to documentation |
 
-## Attribute Parameters
+### Inheritance & Hierarchy
 
-Only certain attribute kinds support parameters. Parameters must be nested under the `parameters` key:
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `inherit_from` | list[string] | `[]` | Generic kinds to inherit from (e.g., `["DcimGenericDevice"]`) |
+| `parent` | string | null | Expected parent kind in hierarchy (set to `null` or `""` for root) |
+| `children` | string | null | Expected child kind in hierarchy |
+| `hierarchy` | string | null | Internal - hierarchy name (auto-set) |
 
-| Kind | Parameter | Default | Description |
-|------|-----------|---------|-------------|
-| `Number` | `min_value` | None | Minimum allowed value |
-| `Number` | `max_value` | None | Maximum allowed value |
-| `Number` | `excluded_values` | None | List of disallowed values |
-| `NumberPool` | `start_range` | 1 | Start of the number pool range |
-| `NumberPool` | `end_range` | 9223372036854775807 | End of the number pool range |
-| `Text` | `regex` | None | Validation pattern |
-| `Text` | `min_length` | None | Minimum string length |
-| `Text` | `max_length` | None | Maximum string length |
-| `TextArea` | `regex` | None | Validation pattern |
-| `TextArea` | `min_length` | None | Minimum string length |
-| `TextArea` | `max_length` | None | Maximum string length |
+### Constraints
 
-**Example:**
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `uniqueness_constraints` | list[list[string]] | null | Multi-element uniqueness. Use `__value` for attributes, bare name for relationships. E.g., `[["rack", "name__value"]]` |
+| `branch` | enum | `"aware"` | Branch support: `aware`, `agnostic`, `local` |
 
-```yaml
-attributes:
-  - name: vlan_id
-    kind: Number
-    parameters:
-      min_value: 1
-      max_value: 4094
-  - name: hostname
-    kind: Text
-    parameters:
-      regex: "^[a-z][a-z0-9-]+$"
-      min_length: 3
-      max_length: 63
-```
+### Advanced
 
-**Note:** When schema strict mode is enabled, Infrahub validates that `min_value < max_value` and `min_length < max_length`.
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `state` | enum | `"present"` | `present` or `absent` (for removing nodes) |
+| `generate_profile` | boolean | `true` | Auto-generate a Profile schema |
+| `generate_template` | boolean | `false` | Auto-generate a Template schema |
 
-## Relationship Kinds
-
-| Kind | Purpose | Use Case |
-|------|---------|----------|
-| `Generic` | Flexible connection | Default, no special behavior |
-| `Attribute` | Inline display | Related entity properties shown inline |
-| `Component` | Composition | Parent contains children, cascade delete option |
-| `Parent` | Hierarchical | Child belongs to parent (mandatory) |
-| `Group` | Membership | System-managed groupings |
-| `Profile` | Configuration | Template/profile assignments |
-
-## Relationship Properties
-
-| Property | Required | Description |
-|----------|----------|-------------|
-| `name` | Yes | snake_case, 3-32 chars |
-| `peer` | Yes | Target node/generic kind |
-| `kind` | No | Relationship type (default: `Generic`) |
-| `cardinality` | No | `one` or `many` (default: `many`) |
-| `optional` | No | Allow null (default: false) |
-| `identifier` | No | Unique relationship ID for bidirectional |
-| `direction` | No | `bidirectional`, `outbound`, `inbound` |
-| `on_delete` | No | `no-action` or `cascade` |
-| `min_count` / `max_count` | No | Cardinality constraints |
+---
 
 ## Generic Properties
 
-Generics share most properties with nodes, plus:
+Generics use **all the same properties as nodes**, plus:
 
-| Property | Description |
-|----------|-------------|
-| `used_by` | List of node kinds using this generic |
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `hierarchical` | boolean | `false` | Enable hierarchical mode (for location-style trees) |
+| `used_by` | list[string] | `[]` | Internal - nodes referencing this generic |
 
-Nodes inherit from generics via `inherit_from`. Properties can be overridden at the node level.
+**Generics do NOT have**: `inherit_from`, `parent`, `children`.
 
-## Naming Conventions
+---
 
-1. **Nodes & Generics**: PascalCase (e.g., `NetworkDevice`, `PhysicalInterface`)
-2. **Namespaces**: PascalCase, domain-based (e.g., `Network`, `Organization`, `Infrastructure`)
-3. **Attributes**: snake_case (e.g., `hostname`, `ip_address`, `serial_number`)
-4. **Relationships**: snake_case, descriptive (e.g., `interfaces`, `primary_site`, `assigned_device`)
+## Attribute Types
 
-## When to Use Generics
+| Kind | Description | Special Properties |
+|------|-------------|--------------------|
+| `Text` | Standard text | `regex`, `min_length`, `max_length` (via `parameters`) |
+| `TextArea` | Multi-line text | Same as Text |
+| `Number` | Integer | `min_value`, `max_value`, `excluded_values` (via `parameters`) |
+| `Boolean` | True/false | - |
+| `Checkbox` | Boolean variant | - |
+| `DateTime` | Date and time | - |
+| `Dropdown` | Selection list | Requires `choices` |
+| `IPHost` | IP host (e.g., 192.168.1.1/24) | - |
+| `IPNetwork` | IP network (e.g., 192.168.0.0/24) | - |
+| `MacAddress` | MAC address | - |
+| `Email` | Email address | - |
+| `URL` | URL | - |
+| `Password` | Encrypted password | - |
+| `HashedPassword` | Pre-hashed password | - |
+| `JSON` | JSON data | - |
+| `Any` | Any type | - |
+| `List` | List of values | - |
+| `File` | File reference | - |
+| `Bandwidth` | Bandwidth value | - |
+| `Color` | Hex color | - |
 
-Use generics when:
-- Multiple nodes share common attributes or relationships
-- You need polymorphic relationships (one relationship targeting multiple node types)
-- Creating type hierarchies (e.g., `Interface` generic with `PhysicalInterface`, `LogicalInterface` nodes)
+**Deprecated**: `String` (use `Text`), `NumberPool` (special internal use)
 
-## Relationship Modeling Patterns
+## Attribute Properties
 
-### Component/Parent Pairs
+| Property | Type | Default | Constraints | Description |
+|----------|------|---------|-------------|-------------|
+| `name` | string | *required* | 3-32 chars, `^[a-z0-9\_]+$` | Attribute name (snake_case) |
+| `kind` | string | *required* | Valid AttributeKind | Attribute type (see table above) |
+| `label` | string | null | Max 32 chars | Display label (auto-generated if omitted) |
+| `description` | string | null | Max 128 chars | Help text |
+| `default_value` | any | null | - | Default value |
+| `unique` | boolean | `false` | - | Must be globally unique for this model |
+| `optional` | boolean | **`false`** | - | **Attributes are mandatory by default** |
+| `read_only` | boolean | `false` | - | Cannot be modified |
+| `order_weight` | integer | null | - | Display order (lower = first) |
+| `enum` | list | null | - | List of valid values |
+| `choices` | list[DropdownChoice] | null | - | Dropdown choices (for `Dropdown` kind) |
+| `allow_override` | enum | `"any"` | `"none"` or `"any"` | Profile override behavior |
+| `state` | enum | `"present"` | `present` or `absent` | Use `absent` to remove |
+| `deprecation` | string | null | Max 128 chars | Deprecation message |
 
-Use for containment relationships (Device has Interfaces):
+### Attribute Parameters (kind-specific)
+
+**Text/TextArea parameters:**
+```yaml
+- name: hostname
+  kind: Text
+  parameters:
+    regex: "^[a-zA-Z0-9-]+$"
+    min_length: 3
+    max_length: 64
+```
+
+**Number parameters:**
+```yaml
+- name: vlan_id
+  kind: Number
+  parameters:
+    min_value: 1
+    max_value: 4094
+    excluded_values: "1,4094"    # Comma-separated values or ranges: "100,150-200,300-400"
+```
+
+### Computed Attributes
 
 ```yaml
-# Parent side (Device)
-relationships:
-  - name: interfaces
-    peer: NetworkInterface
-    kind: Component
-    cardinality: many
-    identifier: "device__interfaces"
-
-# Child side (Interface)
-relationships:
-  - name: device
-    peer: NetworkDevice
-    kind: Parent
-    cardinality: one
-    optional: false
-    identifier: "device__interfaces"
+- name: computed_field
+  kind: Text
+  read_only: true
+  computed_attribute:
+    kind: Jinja2                 # Options: User, Jinja2, TransformPython
+    jinja2_template: "{% if asset_tag__value %}[{{ asset_tag__value }}](https://example.com){% else %}N/A{% endif %}"
 ```
 
-### Bidirectional Relationships
-
-Set matching `identifier` on both sides:
+### Dropdown Choices
 
 ```yaml
-# On Device
-- name: site
-  peer: OrganizationSite
-  identifier: "site__devices"
-
-# On Site
-- name: devices
-  peer: NetworkDevice
-  identifier: "site__devices"
+- name: status
+  kind: Dropdown
+  default_value: active
+  choices:
+    - name: active               # Internal value (required)
+      label: Active              # Display text (optional)
+      description: "Operational" # Help text (optional)
+      color: "#00FF00"           # Hex color (optional)
+    - name: planned
+      label: Planned
+      color: "#0000FF"
 ```
 
-### Hierarchical Structures
+---
 
-Enable `hierarchical: true` on the node for tree structures.
+## Relationship Properties
 
-## Human-Friendly IDs (HFID)
+| Property | Type | Default | Constraints | Description |
+|----------|------|---------|-------------|-------------|
+| `name` | string | *required* | 3-32 chars, `^[a-z0-9\_]+$` | Relationship name (snake_case) |
+| `peer` | string | *required* | `^[A-Z][a-zA-Z0-9]+$` | Target kind (e.g., `DcimDeviceType`) |
+| `kind` | enum | `"Generic"` | See table below | Relationship type |
+| `label` | string | null | Max 32 chars | Display label |
+| `description` | string | null | Max 128 chars | Help text |
+| `identifier` | string | null | Max 128 chars, `^[a-z0-9\_]+$` | Must match on both sides of bidirectional relationships |
+| `cardinality` | enum | **`"many"`** | `"one"` or `"many"` | How many related objects |
+| `optional` | boolean | **`true`** | - | **Relationships are optional by default** |
+| `direction` | enum | `"bidirectional"` | `bidirectional`, `outbound`, `inbound` | Relationship direction |
+| `on_delete` | enum | null | `"no-action"` or `"cascade"` | Delete behavior |
+| `order_weight` | integer | null | - | Display order |
+| `min_count` | integer | 0 | - | Minimum related objects |
+| `max_count` | integer | 0 | - | Maximum related objects (0 = unlimited) |
+| `read_only` | boolean | `false` | - | Cannot be modified |
+| `allow_override` | enum | `"any"` | `"none"` or `"any"` | Profile override behavior |
+| `state` | enum | `"present"` | `present` or `absent` | Use `absent` to remove |
+| `common_parent` | string | null | - | Peer must share same parent |
+| `common_relatives` | list[string] | null | - | Peers must share same relatives |
+| `deprecation` | string | null | Max 128 chars | Deprecation message |
 
-Design readable identifiers using attribute paths:
+### Relationship Kinds
+
+| Kind | Use Case | Typical Pattern |
+|------|----------|-----------------|
+| `Generic` | Standard relationship between independent objects | Default. No special semantics. |
+| `Attribute` | "Belongs to" style, displayed inline | `Device -> DeviceType`, `Device -> Rack` |
+| `Component` | Parent owns children | `Device -> Interfaces` (parent side, `cardinality: many`) |
+| `Parent` | Child points to parent | `Interface -> Device` (child side, `cardinality: one`) |
+| `Group` | Group membership | Special group relationships |
+| `Hierarchy` | Internal for hierarchical locations | Auto-managed by `hierarchical: true` |
+
+### Component/Parent Pattern
+
+Always define both sides with matching `identifier`:
 
 ```yaml
-human_friendly_id:
-  - "hostname__value"           # Single attribute
-  - "site__name__value"         # Through relationship
-  - "rack__name__value"         # Multiple for compound IDs
+# On the parent (Device):
+- name: interfaces
+  peer: DcimInterface
+  kind: Component
+  cardinality: many
+  identifier: "device__interface"
+
+# On the child (Interface):
+- name: device
+  peer: DcimGenericDevice
+  kind: Parent
+  cardinality: one
+  identifier: "device__interface"
 ```
 
-## Common Pitfalls
+---
 
-### YAML Boolean Quoting
+## Extensions
 
-Quote values that look like booleans:
+Add attributes/relationships to nodes defined in other schema files:
 
 ```yaml
-# Wrong - YAML interprets as boolean
-choices:
-  - name: on
-
-# Correct
-choices:
-  - name: "on"
+extensions:
+  nodes:
+    - kind: OrganizationProvider     # Existing node kind to extend
+      attributes:                    # New attributes to add
+        - name: website
+          kind: URL
+          optional: true
+      relationships:                 # New relationships to add
+        - name: sites
+          peer: LocationSite
+          cardinality: many
+          optional: true
 ```
 
-### Missing Relationship Identifiers
+### NodeExtensionSchema Properties
 
-Always set `identifier` for bidirectional relationships to ensure consistency.
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `kind` | string | **Yes** | Kind of existing node to extend |
+| `attributes` | list | No | New attributes to add |
+| `relationships` | list | No | New relationships to add |
+| `inherit_from` | list[string] | No | Additional generics to inherit |
 
-### Optional on Parent Relationships
+---
 
-Child-side of Component/Parent should have `optional: false` to enforce the containment relationship.
+## Menu Configuration
 
-## Best Practices
+Menus are defined in separate YAML files:
 
-### General
-
-1. Ensure that every node has a human friendly ID so items can be created idempotently.
-2. Ensure that each relationship has an identifier on it that matches its peer's identifier.
-3. Prefer creating schemas in a top-level directory called `schemas/`.
-
-### Schema File Organization
-
-Organize schema files based on complexity and team ownership:
-
-#### Single File (Small Projects)
-Use one file when:
-- Total schema is under ~200 lines
-- Single team owns all schema definitions
-- Few nodes with simple relationships
-
-```
-schemas/
-└── schema.yml
-```
-
-#### Split by Domain (Medium Projects)
-Split into separate files when:
-- Schema exceeds ~200 lines
-- Distinct functional domains exist (network, organization, IPAM)
-- Different teams own different domains
-- You want to load domains independently
-
-```
-schemas/
-├── base.yml           # Core generics and shared definitions
-├── organization.yml   # Sites, teams, contacts
-├── network.yml        # Devices, interfaces, circuits
-└── ipam.yml           # Prefixes, addresses, VLANs
+```yaml
+---
+apiVersion: infrahub.app/v1
+kind: Menu
+spec:
+  data:
+    - namespace: Dcim
+      name: DeviceManagement
+      label: Device Management
+      icon: "mdi:server"
+      children:
+        data:
+          - namespace: Dcim
+            name: Devices
+            label: Devices
+            kind: DcimGenericDevice    # Links to a node kind
+            icon: "mdi:server"
 ```
 
-#### Split by Domain Folders (Large Projects)
-Use folders when:
-- Each domain has multiple related files
-- Domains have their own extensions
-- Complex inheritance hierarchies exist
-- Multiple teams collaborate on schemas
+### Menu Item Properties
 
-```
-schemas/
-├── base/
-│   ├── generics.yml       # Shared generics
-│   └── core.yml           # Core node types
-├── organization/
-│   ├── locations.yml      # Regions, sites, rooms
-│   └── contacts.yml       # Teams, people
-├── network/
-│   ├── devices.yml        # Device types
-│   ├── interfaces.yml     # Interface types
-│   └── circuits.yml       # Circuit definitions
-├── ipam/
-│   ├── addressing.yml     # Prefixes, addresses
-│   └── vlans.yml          # VLANs, VLAN groups
-└── extensions/
-    └── custom.yml         # Organization-specific extensions
-```
+| Property | Type | Description |
+|----------|------|-------------|
+| `namespace` | string | Namespace for the menu item |
+| `name` | string | Unique name |
+| `label` | string | Display text |
+| `icon` | string | MDI/Iconify icon |
+| `kind` | string | Optional - node kind for leaf items |
+| `children.data` | list | Nested sub-menu items |
 
-### When to Split a Schema File
+---
 
-Split an existing file when:
-- **File exceeds 200-300 lines** - becomes hard to navigate
-- **Multiple namespaces** - each namespace can be its own file
-- **Independent loading needed** - some domains are optional
-- **Team boundaries** - different teams own different parts
-- **Reusability** - a domain (like IPAM) could be shared across projects
+## Built-in Types
 
-### File Naming Conventions
+These types are built into Infrahub and can be referenced without defining them:
 
-- Use lowercase with underscores: `network_devices.yml`
-- Match filename to primary namespace: `organization.yml` for `Organization` namespace
-- Use descriptive names: `ipam_addressing.yml` not `ip.yml`
-- Keep extensions in a separate folder: `extensions/custom.yml`
+| Type | Description |
+|------|-------------|
+| `BuiltinTag` | Tag system (use in `tags` relationships) |
+| `BuiltinIPAddress` | Base IP address (inherit from for IPAM) |
+| `BuiltinIPPrefix` | Base IP prefix (inherit from for IPAM) |
+| `CoreArtifactTarget` | Artifact generation target |
 
-### Loading Multiple Schema Files
+---
 
-Load schema files in dependency order:
+## order_weight Convention
 
-```bash
-# Load base schemas first (generics and core types)
-infrahubctl schema load schemas/base.yml
+| Range | Purpose |
+|-------|---------|
+| 900-999 | Primary relationships (manufacturer, rack, device_type) |
+| 1000-1099 | Primary identifying attributes (name, model) |
+| 1100-1499 | Secondary attributes (serial, part_number, description) |
+| 1500-1999 | Tertiary attributes (optional fields, settings) |
+| 2000-2999 | Advanced/computed/metadata fields |
+| 3000+ | Tags and generic relationships (always last) |
 
-# Then load dependent schemas
-infrahubctl schema load schemas/organization.yml
-infrahubctl schema load schemas/network.yml
-infrahubctl schema load schemas/ipam.yml
+---
 
-# Finally load extensions
-infrahubctl schema load schemas/extensions/custom.yml
-```
+## Naming Constraints Summary
 
-Or load all at once (Infrahub resolves dependencies):
-
-```bash
-infrahubctl schema load schemas/
-```
-
-### Cross-File References
-
-When splitting schemas, ensure referenced types exist:
-- Generics must be loaded before nodes that inherit from them
-- Relationship peers must exist when the schema is loaded
-- Use `extensions` to add to nodes defined in other files
+| Element | Convention | Pattern | Length |
+|---------|-----------|---------|--------|
+| Node name | PascalCase | `^[A-Z][a-zA-Z0-9]+$` | 2-32 |
+| Namespace | First upper, rest lower | `^[A-Z][a-z0-9]+$` | 3-32 |
+| Attribute name | snake_case | `^[a-z0-9\_]+$` | 3-32 |
+| Relationship name | snake_case | `^[a-z0-9\_]+$` | 3-32 |
+| Identifier | snake_case | `^[a-z0-9\_]+$` | max 128 |
+| Kind (auto) | Namespace + Name | - | - |
+| Description | Free text | - | max 128 |
+| Label (attr/rel) | Free text | - | max 32 |
+| Label (node) | Free text | - | max 64 |

--- a/skills/schema-creator/rules/_sections.md
+++ b/skills/schema-creator/rules/_sections.md
@@ -1,0 +1,19 @@
+# Infrahub Schema Creator - Rule Sections
+
+1. **Naming Conventions (naming-)** — CRITICAL. Namespace, node, generic, and attribute naming patterns. Kind derivation rules. Violations cause schema validation failures.
+
+2. **Relationships (relationship-)** — CRITICAL. Bidirectional identifier matching, peer references, Component/Parent pairing, cardinality and optional defaults. Incorrect relationships cause silent data model bugs.
+
+3. **Attributes (attribute-)** — HIGH. Mandatory-by-default behavior, Dropdown choices format, deprecated field names. Misunderstanding defaults leads to unexpected required fields.
+
+4. **Hierarchy (hierarchy-)** — HIGH. Setting up hierarchical generics and nodes with parent/children fields. Required for location trees and any parent-child taxonomy.
+
+5. **Display (display-)** — HIGH. human_friendly_id, display_label, and order_weight configuration. Controls how objects are identified and displayed in the UI and object references.
+
+6. **Extensions (extension-)** — MEDIUM. Adding attributes/relationships to nodes defined in other schema files. Enables modular schema design across multiple files.
+
+7. **Uniqueness (uniqueness-)** — MEDIUM. Uniqueness constraint format with __value suffix for attributes. Incorrect format causes validation errors.
+
+8. **Migration (migration-)** — MEDIUM. Adding, removing, and renaming attributes safely. Using state: absent. Strategies for non-breaking schema changes.
+
+9. **Validation (validation-)** — LOW. Common validation errors and their fixes. Pre-validation checklist before running infrahubctl schema check.

--- a/skills/schema-creator/rules/_template.md
+++ b/skills/schema-creator/rules/_template.md
@@ -1,0 +1,25 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+**Impact: MEDIUM**
+
+Brief explanation of the rule and why it matters for Infrahub schema design.
+
+**Incorrect:**
+
+```yaml
+# Bad example
+```
+
+**Correct:**
+
+```yaml
+# Good example
+```
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/attribute-defaults-and-types.md
+++ b/skills/schema-creator/rules/attribute-defaults-and-types.md
@@ -1,0 +1,74 @@
+---
+title: Attribute Defaults, Dropdowns, and Deprecated Fields
+impact: HIGH
+tags: attribute, optional, dropdown, choices, deprecated
+---
+
+## Attribute Defaults, Dropdowns, and Deprecated Fields
+
+**Impact: HIGH**
+
+### Attributes Are Mandatory by Default
+
+Unlike relationships (which default to optional), attributes default to `optional: false`. If you add a new attribute without `optional: true`, all existing objects will need a value.
+
+**Incorrect -- adding a new required attribute without a default:**
+
+```yaml
+- name: serial_number
+  kind: Text
+  # optional defaults to false -- existing objects will fail validation!
+```
+
+**Correct -- add as optional first, or provide a default:**
+
+```yaml
+- name: serial_number
+  kind: Text
+  optional: true              # Safe for existing data
+
+# OR
+- name: serial_number
+  kind: Text
+  default_value: "unknown"    # Provides fallback for existing data
+```
+
+### Dropdown Choices Format
+
+Each choice needs at minimum a `name` field. `label`, `description`, `color` are optional.
+
+**Incorrect:**
+
+```yaml
+- name: status
+  kind: Dropdown
+  choices:
+    - active                  # Must be an object with name field, not a bare string
+    - planned
+```
+
+**Correct:**
+
+```yaml
+- name: status
+  kind: Dropdown
+  choices:
+    - name: active
+      label: Active
+      color: "#00FF00"
+    - name: planned
+      label: Planned
+      color: "#0000FF"
+```
+
+When referencing dropdown values in object files, use the `name` value (not `label`): `status: active` not `status: Active`.
+
+### Deprecated Fields to Avoid
+
+| Deprecated | Use Instead |
+|-----------|-------------|
+| `display_labels` | `display_label` |
+| `default_filter` | `human_friendly_id` |
+| `String` (attribute kind) | `Text` |
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/display-human-friendly-id.md
+++ b/skills/schema-creator/rules/display-human-friendly-id.md
@@ -1,0 +1,69 @@
+---
+title: Always Set human_friendly_id on Nodes
+impact: HIGH
+tags: display, human_friendly_id, identity
+---
+
+## Always Set human_friendly_id on Nodes
+
+**Impact: HIGH**
+
+`human_friendly_id` determines how objects are identified in the UI and how they're referenced from object data files. Without it, objects can only be referenced by internal UUID.
+
+**Incorrect -- no human_friendly_id:**
+
+```yaml
+nodes:
+  - name: DeviceType
+    namespace: Dcim
+    # No human_friendly_id -- objects can't be easily referenced
+```
+
+**Correct:**
+
+```yaml
+nodes:
+  - name: DeviceType
+    namespace: Dcim
+    human_friendly_id:
+      - model__value               # Single element = scalar reference
+```
+
+### Path Syntax
+
+- Local attributes: `attribute_name__value`
+- Traverse relationships: `relationship__attribute__value`
+- Multi-level: `parent__shortname__value`
+
+### Single vs Multi-Element
+
+| Elements | Object Reference Style | Example |
+|----------|----------------------|---------|
+| 1 element | Scalar | `device_type: PowerEdge R960` |
+| 2+ elements | List | `rack: ["room-shortname", "Rack-A"]` |
+
+### Examples
+
+```yaml
+# Simple -- referenced as: manufacturer: Dell
+human_friendly_id:
+  - name__value
+
+# Composite -- referenced as: rack: ["01-4", "TEST-RACK1"]
+human_friendly_id:
+  - parent__shortname__value
+  - name__value
+
+# Through relationship -- referenced as: bay: ["PowerEdge R960", "PSU1"]
+human_friendly_id:
+  - device_type__model__value
+  - name__value
+```
+
+Also set `display_label` for UI rendering (supports Jinja2):
+
+```yaml
+display_label: "{{ manufacturer__name__value }} {{ name__value }}"
+```
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/display-order-weight.md
+++ b/skills/schema-creator/rules/display-order-weight.md
@@ -1,0 +1,47 @@
+---
+title: Order Weight Conventions
+impact: MEDIUM
+tags: display, order_weight, ui
+---
+
+## Order Weight Conventions
+
+**Impact: MEDIUM**
+
+`order_weight` controls the display order of attributes and relationships in the Infrahub UI. Lower values appear first. Use consistent ranges across your schema.
+
+**Recommended convention:**
+
+| Range | Use For |
+|-------|---------|
+| 800-900 | Key relationships (rack, device_type, manufacturer) |
+| 1000-1999 | Core attributes (name, model, status) |
+| 2000-2999 | Secondary attributes (description, serial, weight) |
+| 3000+ | Tags and metadata relationships |
+
+**Example:**
+
+```yaml
+attributes:
+  - name: name
+    kind: Text
+    order_weight: 1000
+  - name: status
+    kind: Dropdown
+    order_weight: 1500
+  - name: description
+    kind: Text
+    optional: true
+    order_weight: 2000
+relationships:
+  - name: rack
+    peer: LocationRack
+    order_weight: 900            # Key relationship appears before attributes
+  - name: tags
+    peer: BuiltinTag
+    order_weight: 3000           # Tags at the bottom
+```
+
+**Tip:** Leave gaps between values (1000, 1100, 1200) so you can insert new fields without renumbering everything.
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/extension-cross-file.md
+++ b/skills/schema-creator/rules/extension-cross-file.md
@@ -1,0 +1,54 @@
+---
+title: Extensions for Cross-File Relationships
+impact: MEDIUM
+tags: extension, cross-file, modular
+---
+
+## Extensions for Cross-File Relationships
+
+**Impact: MEDIUM**
+
+When schema file A defines `OrganizationTenant` and schema file B defines `LocationRack`, use the `extensions` block to add a relationship from Rack to Tenant without modifying file A.
+
+**Incorrect -- modifying the original schema file to add a cross-dependency:**
+
+If you add the relationship directly to `organization.yml`, that file now depends on `location.yml` existing, creating a circular dependency risk.
+
+**Correct -- using extensions block:**
+
+```yaml
+# In a separate file (e.g., extensions/location.yml):
+extensions:
+  nodes:
+    - kind: LocationRack           # Target node (must already exist)
+      relationships:
+        - name: tenant
+          peer: OrganizationTenant
+          kind: Attribute
+          cardinality: one
+          optional: true
+          identifier: "tenant__racks"
+```
+
+**Alternative -- add directly on the node that owns the relationship:**
+
+```yaml
+# In location.yml where Rack is defined:
+nodes:
+  - name: Rack
+    namespace: Location
+    relationships:
+      - name: tenant
+        peer: OrganizationTenant
+        kind: Attribute
+        cardinality: one
+        optional: true
+        identifier: "tenant__racks"
+```
+
+**When to use extensions:**
+- Adding relationships to nodes you don't own (e.g., BuiltinTag, CoreRepository)
+- Keeping schema files focused on their domain
+- Avoiding circular dependencies between schema files
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/hierarchy-setup.md
+++ b/skills/schema-creator/rules/hierarchy-setup.md
@@ -1,0 +1,78 @@
+---
+title: Setting Up Hierarchical Nodes
+impact: HIGH
+tags: hierarchy, parent, children, generic, location
+---
+
+## Setting Up Hierarchical Nodes
+
+**Impact: HIGH**
+
+Hierarchical nodes (like location trees) require three things: a generic with `hierarchical: true`, nodes with `parent`/`children` fields, and inheritance from that generic.
+
+### Step 1: Generic with hierarchical: true
+
+```yaml
+generics:
+  - name: Generic
+    namespace: Location
+    hierarchical: true            # Enables the parent/children hierarchy
+    attributes:
+      - name: name
+        kind: Text
+        unique: true
+      - name: shortname
+        kind: Text
+```
+
+### Step 2: Nodes with parent and children
+
+```yaml
+nodes:
+  - name: Region
+    namespace: Location
+    inherit_from: [LocationGeneric]
+    parent: null                   # Root of hierarchy (no parent)
+    children: LocationSite         # Expected child kind
+
+  - name: Site
+    namespace: Location
+    inherit_from: [LocationGeneric]
+    parent: LocationRegion         # Expected parent kind
+    children: LocationRoom         # Expected child kind
+
+  - name: Room
+    namespace: Location
+    inherit_from: [LocationGeneric]
+    parent: LocationSite
+    children: LocationRack
+
+  - name: Rack
+    namespace: Location
+    inherit_from: [LocationGeneric]
+    parent: LocationRoom
+    children: null                 # Leaf of hierarchy (no children)
+```
+
+**Incorrect -- missing any of the three requirements:**
+
+```yaml
+# Missing hierarchical: true on generic
+generics:
+  - name: Generic
+    namespace: Location
+    # hierarchical: true  <-- MISSING
+
+# Missing inherit_from
+nodes:
+  - name: Region
+    namespace: Location
+    parent: null                   # Will fail without hierarchical generic
+```
+
+**Key rules:**
+- Root nodes: `parent: null`
+- Leaf nodes: `children: null` (or omit)
+- Use full kind for `parent` and `children` values: `LocationSite` not `Site`
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/migration-state-absent.md
+++ b/skills/schema-creator/rules/migration-state-absent.md
@@ -1,0 +1,66 @@
+---
+title: Schema Migration Patterns
+impact: MEDIUM
+tags: migration, state, absent, adding, removing
+---
+
+## Schema Migration Patterns
+
+**Impact: MEDIUM**
+
+Schema changes on live data require careful migration strategies.
+
+### Removing an Attribute
+
+Use `state: absent` to remove an attribute. Don't just delete it from the YAML.
+
+```yaml
+- name: old_field
+  kind: Text
+  state: absent                  # Marks for removal
+```
+
+### Adding a New Attribute Safely
+
+Add as optional first (or with a default), then tighten later after data is populated.
+
+**Risky -- adding mandatory attribute to existing data:**
+
+```yaml
+- name: serial_number
+  kind: Text
+  # optional defaults to false -- existing objects will fail!
+```
+
+**Safe -- two-step approach:**
+
+```yaml
+# Step 1: Add as optional
+- name: serial_number
+  kind: Text
+  optional: true
+
+# Step 2 (after populating data): Make mandatory with default
+- name: serial_number
+  kind: Text
+  optional: false
+  default_value: "unknown"
+```
+
+### Renaming an Attribute
+
+No direct rename -- use a three-step migration:
+
+1. Add new attribute (optional)
+2. Migrate data from old to new (via script or manual update)
+3. Remove old attribute with `state: absent`
+
+### Changing Attribute Type
+
+Safest approach:
+
+1. Add new attribute with new type
+2. Migrate data
+3. Remove old attribute with `state: absent`
+
+Reference: [validation.md](../validation.md) for `infrahubctl` commands and branch-based schema changes.

--- a/skills/schema-creator/rules/naming-conventions.md
+++ b/skills/schema-creator/rules/naming-conventions.md
@@ -1,0 +1,84 @@
+---
+title: Naming Conventions and Kind Derivation
+impact: CRITICAL
+tags: naming, namespace, node, attribute, kind
+---
+
+## Naming Conventions and Kind Derivation
+
+**Impact: CRITICAL**
+
+Infrahub enforces strict naming patterns via JSON schema validation. Violations cause immediate validation errors.
+
+### Namespace
+
+Pattern: `^[A-Z][a-z0-9]+$` (first letter uppercase, rest lowercase). Min 3, max 32 chars.
+
+**Incorrect:**
+
+```yaml
+namespace: DCIM          # All uppercase
+namespace: dcim          # No uppercase
+namespace: DC            # Too short (min 3)
+```
+
+**Correct:**
+
+```yaml
+namespace: Dcim
+namespace: Location
+namespace: Organization
+namespace: Ipam
+```
+
+### Node and Generic Names
+
+Pattern: `^[A-Z][a-zA-Z0-9]+$` (PascalCase). Min 2, max 32 chars.
+
+**Incorrect:**
+
+```yaml
+name: my_node            # snake_case
+name: X                  # Too short
+```
+
+**Correct:**
+
+```yaml
+name: DeviceType
+name: GenericDevice
+name: ModuleBayTemplate
+```
+
+### Attribute and Relationship Names
+
+Pattern: `^[a-z0-9_]+$` (snake_case). Min 3, max 32 chars.
+
+**Incorrect:**
+
+```yaml
+- name: id               # Too short (min 3 chars)
+- name: MyAttribute      # Must be lowercase
+```
+
+**Correct:**
+
+```yaml
+- name: obj_id           # Use obj_id instead of id
+- name: my_attribute
+- name: rack_u_position
+```
+
+### Kind Derivation
+
+Kind = Namespace + Name. This is how you reference nodes everywhere.
+
+```
+Dcim + DeviceType = DcimDeviceType
+Location + Rack = LocationRack
+Organization + Manufacturer = OrganizationManufacturer
+```
+
+Use the full kind when referencing in `inherit_from`, `peer`, `parent`, `children`.
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/relationship-component-parent.md
+++ b/skills/schema-creator/rules/relationship-component-parent.md
@@ -1,0 +1,52 @@
+---
+title: Component/Parent Pairs Must Match
+impact: CRITICAL
+tags: relationship, component, parent, identifier
+---
+
+## Component/Parent Pairs Must Match
+
+**Impact: CRITICAL**
+
+Component and Parent relationships are paired. The Component side (parent owns children) must be `cardinality: many`, the Parent side (child points to parent) must be `cardinality: one`. Both must share the same `identifier`.
+
+**Incorrect:**
+
+```yaml
+# TenantGroup has tenants (Component side)
+- name: tenants
+  peer: OrganizationTenant
+  kind: Component
+  cardinality: one               # WRONG - Component should be many
+
+# Tenant belongs to group (Parent side)
+- name: group
+  peer: OrganizationTenantGroup
+  kind: Parent
+  cardinality: many              # WRONG - Parent should be one
+```
+
+**Correct:**
+
+```yaml
+# TenantGroup has tenants (Component side)
+- name: tenants
+  peer: OrganizationTenant
+  kind: Component
+  cardinality: many              # Component = many children
+  identifier: "group__tenants"
+
+# Tenant belongs to group (Parent side)
+- name: group
+  peer: OrganizationTenantGroup
+  kind: Parent
+  cardinality: one               # Parent = one parent
+  identifier: "group__tenants"   # Same identifier
+```
+
+**Rule summary:**
+- Component side: `kind: Component`, `cardinality: many`
+- Parent side: `kind: Parent`, `cardinality: one`
+- Both: same `identifier`
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/relationship-defaults.md
+++ b/skills/schema-creator/rules/relationship-defaults.md
@@ -1,0 +1,45 @@
+---
+title: Relationship Default Values
+impact: CRITICAL
+tags: relationship, defaults, cardinality, optional
+---
+
+## Relationship Default Values
+
+**Impact: CRITICAL**
+
+Relationship defaults are different from attribute defaults. Getting these wrong leads to unexpected behavior.
+
+| Property | Default | Notes |
+|----------|---------|-------|
+| `cardinality` | `many` | Explicitly set `one` for single references |
+| `optional` | `true` | Unlike attributes (which default to mandatory) |
+| `direction` | `bidirectional` | Rarely needs changing |
+| `kind` | `Generic` | Set explicitly for Component, Parent, Attribute |
+
+**Common mistake -- forgetting cardinality defaults to many:**
+
+```yaml
+# Incorrect: Missing cardinality, defaults to many
+- name: rack
+  peer: LocationRack
+  kind: Attribute
+  # cardinality defaults to "many" -- probably not what you want for a rack reference!
+```
+
+```yaml
+# Correct: Explicitly set cardinality: one
+- name: rack
+  peer: LocationRack
+  kind: Attribute
+  cardinality: one
+```
+
+**Key contrast with attributes:** Attributes are `optional: false` by default (mandatory). Relationships are `optional: true` by default.
+
+| Type | Default `optional` |
+|------|-------------------|
+| Attributes | `false` (mandatory) |
+| Relationships | `true` (optional) |
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/relationship-identifiers.md
+++ b/skills/schema-creator/rules/relationship-identifiers.md
@@ -1,0 +1,51 @@
+---
+title: Bidirectional Relationships Need Matching Identifiers
+impact: CRITICAL
+tags: relationship, identifier, bidirectional
+---
+
+## Bidirectional Relationships Need Matching Identifiers
+
+**Impact: CRITICAL**
+
+When two nodes reference each other, both sides of the relationship MUST share the same `identifier` string. Mismatched identifiers create duplicate relationships instead of one bidirectional link.
+
+**Incorrect:**
+
+```yaml
+# On Device:
+- name: modules
+  peer: DcimModuleInstallation
+  kind: Component
+  cardinality: many
+  identifier: "device__modules"
+
+# On ModuleInstallation:
+- name: device
+  peer: DcimGenericDevice
+  kind: Parent
+  cardinality: one
+  identifier: "module__device"       # WRONG - doesn't match!
+```
+
+**Correct:**
+
+```yaml
+# On Device:
+- name: modules
+  peer: DcimModuleInstallation
+  kind: Component
+  cardinality: many
+  identifier: "device__modules"
+
+# On ModuleInstallation:
+- name: device
+  peer: DcimGenericDevice
+  kind: Parent
+  cardinality: one
+  identifier: "device__modules"      # MUST match the other side
+```
+
+**Convention:** Use `snake_case` with `__` separator: `"parent__children"`, `"rack__devices"`, `"tenant__racks"`.
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/relationship-peer-kind.md
+++ b/skills/schema-creator/rules/relationship-peer-kind.md
@@ -1,0 +1,35 @@
+---
+title: Peer Must Reference Full Kind
+impact: CRITICAL
+tags: relationship, peer, kind
+---
+
+## Peer Must Reference Full Kind
+
+**Impact: CRITICAL**
+
+The `peer` field on a relationship must use the full kind (Namespace + Name), not just the name. Using just the name causes a "peer not found" validation error.
+
+**Incorrect:**
+
+```yaml
+relationships:
+  - name: device_type
+    peer: DeviceType              # Missing namespace!
+    kind: Attribute
+    cardinality: one
+```
+
+**Correct:**
+
+```yaml
+relationships:
+  - name: device_type
+    peer: DcimDeviceType          # Full kind: Dcim + DeviceType
+    kind: Attribute
+    cardinality: one
+```
+
+This applies everywhere a kind is referenced: `peer`, `inherit_from`, `parent`, `children`, `menu_placement`.
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/uniqueness-constraints.md
+++ b/skills/schema-creator/rules/uniqueness-constraints.md
@@ -1,0 +1,48 @@
+---
+title: Uniqueness Constraint Format
+impact: MEDIUM
+tags: uniqueness, constraints, validation
+---
+
+## Uniqueness Constraint Format
+
+**Impact: MEDIUM**
+
+Uniqueness constraints use `__value` suffix for attributes but bare names for relationships. Getting this wrong causes a "references unknown field" validation error.
+
+**Incorrect:**
+
+```yaml
+uniqueness_constraints:
+  - ["name", "rack"]             # Missing __value on attribute
+  - ["name__value", "rack__value"]  # __value on relationship
+```
+
+**Correct:**
+
+```yaml
+uniqueness_constraints:
+  - ["name__value", "rack"]      # __value for attributes, bare name for relationships
+```
+
+### Format Rules
+
+| Field Type | Format | Example |
+|-----------|--------|---------|
+| Attribute | `attribute_name__value` | `name__value`, `model__value` |
+| Relationship | bare name | `rack`, `device_type`, `manufacturer` |
+
+### Example: Unique Device Name per Rack
+
+```yaml
+nodes:
+  - name: PDU
+    namespace: Dcim
+    uniqueness_constraints:
+      - ["rack", "name__value"]   # Name must be unique within each rack
+    human_friendly_id:
+      - name__value
+      - rack__name__value
+```
+
+Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/schema-creator/rules/validation-common-errors.md
+++ b/skills/schema-creator/rules/validation-common-errors.md
@@ -1,0 +1,65 @@
+---
+title: Common Validation Errors and Fixes
+impact: LOW
+tags: validation, errors, debugging, additionalProperties
+---
+
+## Common Validation Errors and Fixes
+
+**Impact: LOW (but saves debugging time)**
+
+The Infrahub JSON schema uses `additionalProperties: false`, meaning any typo in property names causes a validation error. Here are the most common errors and fixes.
+
+### "Unknown field"
+
+A typo in a property name:
+
+```yaml
+# BAD - typo
+- name: MyNode
+  namspace: Dcim         # Should be "namespace"
+```
+
+### "Name must match pattern"
+
+Naming convention violation. See the [naming-conventions](./naming-conventions.md) rule.
+
+### "Peer not found"
+
+Missing namespace in peer reference. See the [relationship-peer-kind](./relationship-peer-kind.md) rule.
+
+### "Identifier mismatch"
+
+Bidirectional relationship identifiers don't match. See the [relationship-identifiers](./relationship-identifiers.md) rule.
+
+### "Uniqueness constraint references unknown field"
+
+Wrong format in constraints. See the [uniqueness-constraints](./uniqueness-constraints.md) rule.
+
+### Pre-Validation Checklist
+
+Before running `infrahubctl schema check`, verify:
+
+- [ ] Every schema file starts with `version: "1.0"`
+- [ ] All node/generic names are PascalCase
+- [ ] All namespaces match `^[A-Z][a-z0-9]+$`
+- [ ] All attribute/relationship names are snake_case, 3+ chars
+- [ ] All `peer` values use full kind (namespace + name)
+- [ ] All bidirectional relationships have matching `identifier`
+- [ ] All Component relationships have a matching Parent
+- [ ] All hierarchical nodes inherit from a `hierarchical: true` generic
+- [ ] Root hierarchical nodes have `parent: null`
+- [ ] All Dropdown attributes have `choices` defined
+- [ ] `human_friendly_id` is set on user-facing nodes
+- [ ] `uniqueness_constraints` use `__value` for attributes
+- [ ] The `$schema` comment is present for IDE validation
+
+```bash
+# Validate
+infrahubctl schema check schemas/
+
+# Load
+infrahubctl schema load schemas/ --branch main
+```
+
+Reference: [validation.md](../validation.md) for full validation and migration guide.

--- a/skills/schema-creator/validation.md
+++ b/skills/schema-creator/validation.md
@@ -1,262 +1,271 @@
-# Schema Validation Guide
-
-Commands and practices for validating and loading Infrahub schemas.
+# Schema Validation & Migration Guide
 
 ## Validation Commands
 
-### Check Schema Before Loading
+### Check Schema (Dry Run)
 
-Always validate schemas before applying them:
+Validate schema files without loading them:
 
 ```bash
-infrahubctl schema check --branch <branch-name> schema.yml
+# Check a directory of schemas
+infrahubctl schema check schemas/
+
+# Check specific files
+infrahubctl schema check schemas/base/dcim.yml schemas/base/location.yml
+
+# Check against a specific branch
+infrahubctl schema check schemas/ --branch develop
 ```
 
-This command:
-- Validates YAML syntax
-- Checks naming conventions
-- Verifies relationship references
-- Identifies constraint violations
+This will:
+1. Parse YAML files
+2. Validate against the Infrahub schema spec (Pydantic models)
+3. Show validation errors if any
+4. Show a diff of what would change vs current schema in Infrahub
 
 ### Load Schema
 
-After validation passes:
+Load schemas into a running Infrahub instance:
 
 ```bash
-infrahubctl schema load --branch <branch-name> schema.yml
+# Load all schemas from directory
+infrahubctl schema load schemas/
+
+# Load to a specific branch
+infrahubctl schema load schemas/ --branch feature-branch
+
+# Load and wait for convergence
+infrahubctl schema load schemas/ --wait 30
 ```
 
-## Recommended Workflow
+### Using invoke tasks (project-specific)
 
-### 1. Create a Branch
-
-Always make schema changes in a branch:
+If the project has `tasks.py`:
 
 ```bash
-infrahubctl branch create my-schema-branch
+uv run invoke load-schema
 ```
 
-### 2. Validate Changes
+## Project Configuration
 
-```bash
-infrahubctl schema check --branch my-schema-branch schema.yml
-```
-
-### 3. Load to Branch
-
-```bash
-infrahubctl schema load --branch my-schema-branch schema.yml
-```
-
-### 4. Test in Branch
-
-- Create test data using the new schema
-- Verify relationships work correctly
-- Test queries and filters
-
-### 5. Merge to Main
-
-```bash
-infrahubctl branch merge my-schema-branch
-```
-
-## Schema Migrations
-
-### Adding Elements
-
-Simply add new nodes, attributes, or relationships to the schema file and reload.
-
-### Removing Elements
-
-Use `state: absent` to mark elements for removal:
+The `.infrahub.yml` file defines what gets loaded:
 
 ```yaml
-attributes:
-  - name: deprecated_field
-    kind: Text
-    state: absent
+---
+schemas:
+  - schemas              # Loads all .yml/.yaml/.json files recursively
+
+menus:
+  - menus/menu-full.yml
+
+objects:
+  - objects              # Data files to populate
+
+queries:
+  - name: query_name
+    file_path: queries/query.gql
+
+check_definitions:
+  - name: check_name
+    class_name: CheckClassName
+    file_path: checks/check.py
 ```
-
-```yaml
-relationships:
-  - name: old_relationship
-    peer: SomeNode
-    state: absent
-```
-
-```yaml
-nodes:
-  - name: DeprecatedNode
-    namespace: Legacy
-    state: absent
-```
-
-### Modifying Elements
-
-Most properties can be updated by changing the value and reloading. However, some properties cannot be changed:
-
-**Cannot be modified:**
-- `branch` on nodes, attributes, or relationships
-- `direction` on relationships
-- `hierarchical` on relationships
-
-### Renaming Elements
-
-Renaming requires including the internal UUID temporarily. The safer approach is to:
-
-1. Add the new element
-2. Migrate data
-3. Remove the old element with `state: absent`
-
-## Validation Checklist
-
-### Node Validation
-
-- [ ] `name` is PascalCase, 2-32 characters
-- [ ] `namespace` is PascalCase, 3-32 characters
-- [ ] `description` is under 128 characters
-- [ ] `label` is under 64 characters
-- [ ] `icon` uses valid Material Design Icons format (`mdi:icon-name`)
-- [ ] `branch` is one of: `aware`, `agnostic`, `local`
-- [ ] `inherit_from` references existing generics with full kind (e.g., `NetworkInterface`)
-
-### Attribute Validation
-
-- [ ] `name` is snake_case, 3-32 characters
-- [ ] `kind` is a valid attribute type
-- [ ] `description` is under 128 characters
-- [ ] `choices` is provided for `Dropdown` kind
-- [ ] `default_value` matches the attribute kind
-- [ ] `parameters` is only used with supported kinds: `Number`, `NumberPool`, `Text`, `TextArea`
-- [ ] For `Number`: `parameters.min_value` < `parameters.max_value` (if both set)
-- [ ] For `NumberPool`: `parameters.start_range` < `parameters.end_range`
-- [ ] For `Text`/`TextArea`: `parameters.min_length` < `parameters.max_length` (if both set)
-- [ ] For `Text`/`TextArea`: `parameters.regex` is valid regular expression syntax
-
-### Relationship Validation
-
-- [ ] `name` is snake_case, 3-32 characters
-- [ ] `peer` references an existing node or generic kind
-- [ ] `cardinality` is either `one` or `many`
-- [ ] `direction` is one of: `bidirectional`, `outbound`, `inbound`
-- [ ] `identifier` matches on both sides of bidirectional relationships
-- [ ] `on_delete` is either `no-action` or `cascade`
-- [ ] Component/Parent pairs are correctly configured
-
-### Generic Validation
-
-- [ ] Same rules as nodes apply
-- [ ] `used_by` references valid node kinds (if specified)
 
 ## Common Validation Errors
 
-### "Invalid node name"
+### "Unknown field"
+The JSON schema has `additionalProperties: false`. Any typo causes this:
 
-Node names must be PascalCase and match `^[A-Z][a-zA-Z0-9]+$`.
-
-```yaml
-# Wrong
-- name: network_device
-- name: networkDevice
-- name: NETWORKDEVICE
-
-# Correct
-- name: NetworkDevice
+```
+# BAD - typo in property name
+- name: MyNode
+  namspace: Dcim         # Should be "namespace"
 ```
 
-### "Invalid attribute name"
+### "Name must match pattern"
+Names have strict regex patterns:
 
-Attribute names must be snake_case and match `^[a-z0-9_]+$`.
+```
+# Node name: ^[A-Z][a-zA-Z0-9]+$
+- name: my_node          # BAD - must start with uppercase, no underscores
+- name: MyNode           # GOOD
 
-```yaml
-# Wrong
-- name: hostName
-- name: HostName
-- name: host-name
+# Namespace: ^[A-Z][a-z0-9]+$
+- namespace: DCIM        # BAD - only first letter uppercase
+- namespace: Dcim        # GOOD
 
-# Correct
-- name: hostname
-- name: host_name
+# Attribute name: ^[a-z0-9\_]+$
+- name: MyAttribute      # BAD - must be lowercase
+- name: my_attribute     # GOOD
 ```
 
-### "Unknown peer"
+### "Name too short/long"
+```
+# Node name: 2-32 chars
+- name: X                # BAD - too short
 
-The relationship peer must reference an existing node or generic using the full kind (namespace + name).
+# Namespace: 3-32 chars
+- namespace: DC          # BAD - too short
 
-```yaml
-# Wrong (missing namespace)
-peer: Device
-
-# Correct
-peer: NetworkDevice
+# Attribute/Relationship name: 3-32 chars
+- name: id               # BAD - too short, use "obj_id" or similar
 ```
 
-### "Duplicate identifier"
+### "Peer not found"
+Relationship peer must reference the full kind (namespace + name):
 
-Each relationship identifier must be unique within the schema, used only by the two sides of a bidirectional relationship.
+```
+# BAD
+- peer: DeviceType       # Missing namespace
 
-### "Missing choices for Dropdown"
-
-Dropdown attributes require a `choices` list:
-
-```yaml
-- name: status
-  kind: Dropdown
-  choices:
-    - name: active
-    - name: inactive
+# GOOD
+- peer: DcimDeviceType
 ```
 
-## Strict Mode
+### "Identifier mismatch"
+Bidirectional relationships need matching identifiers:
 
-Infrahub has a strict mode (`INFRAHUB_SCHEMA_STRICT_MODE`) that enforces additional validators by default:
+```yaml
+# On Device:
+- name: interfaces
+  peer: DcimInterface
+  identifier: "device__interface"    # Must match
 
-- Relationship parent constraints
-- Numeric parameter validation
+# On Interface:
+- name: device
+  peer: DcimGenericDevice
+  identifier: "device__interface"    # Must match
+```
 
-Disable with environment variable if needed for development:
+### "Uniqueness constraint references unknown field"
+Use `__value` suffix for attributes in constraints:
+
+```yaml
+# BAD
+uniqueness_constraints:
+  - ["name", "rack"]
+
+# GOOD
+uniqueness_constraints:
+  - ["name__value", "rack"]    # __value for attributes, bare name for relationships
+```
+
+## Schema Migration Strategies
+
+### Adding a New Attribute
+
+Just add it to the schema. If `optional: false`, existing data will need a value:
+
+```yaml
+# Safe: add as optional first
+- name: new_field
+  kind: Text
+  optional: true
+
+# Later: make mandatory after data is populated
+- name: new_field
+  kind: Text
+  optional: false
+  default_value: "unknown"
+```
+
+### Removing an Attribute
+
+Use `state: absent`:
+
+```yaml
+- name: old_field
+  kind: Text
+  state: absent
+```
+
+### Renaming an Attribute
+
+Two-step migration:
+1. Add new attribute (optional), keep old one
+2. Migrate data from old to new
+3. Remove old attribute with `state: absent`
+
+### Adding a New Node
+
+Just add the node definition. No migration needed.
+
+### Adding a Relationship
+
+Add the relationship to the schema. For bidirectional relationships, add both sides with matching `identifier`.
+
+### Changing Attribute Type
+
+Some type changes require `validate_constraint` checks. The safest approach:
+1. Add new attribute with new type
+2. Migrate data
+3. Remove old attribute
+
+### Making an Optional Field Mandatory
+
+```yaml
+# Step 1: Ensure all data has values (via data migration or default)
+# Step 2: Update schema
+- name: field
+  kind: Text
+  optional: false
+  default_value: "default"    # Provides fallback for existing data
+```
+
+## Branch-Based Schema Changes
+
+Infrahub supports schema changes on branches:
 
 ```bash
-export INFRAHUB_SCHEMA_STRICT_MODE=false
+# Create a branch for schema work
+# (via Infrahub UI or API)
+
+# Check schema against the branch
+infrahubctl schema check schemas/ --branch schema-updates
+
+# Load schema to the branch
+infrahubctl schema load schemas/ --branch schema-updates
+
+# Test and validate on branch, then merge via Infrahub UI
 ```
 
-## Testing Schema Changes
+### Branch Support Types
 
-### GraphQL Mutation Test
+| Type | Behavior |
+|------|----------|
+| `aware` | Data is branch-aware (default). Changes on branches are isolated. |
+| `agnostic` | Same data across all branches. Changes are global. |
+| `local` | Data is local to the branch where created. |
 
-After loading a schema, test creating data:
+## Pre-Validation Checklist
 
-```graphql
-mutation {
-  NetworkDeviceCreate(data: {
-    hostname: {value: "test-device-01"}
-    model: {value: "Test Model"}
-  }) {
-    ok
-    object { id }
-  }
-}
+Before running `infrahubctl schema check`, verify:
+
+- [ ] Every schema file starts with `version: "1.0"`
+- [ ] All node/generic names are PascalCase
+- [ ] All namespaces start with uppercase, rest lowercase
+- [ ] All attribute/relationship names are snake_case, 3+ chars
+- [ ] All relationship `peer` values use full kind (namespace + name)
+- [ ] All bidirectional relationships have matching `identifier` on both sides
+- [ ] All Component relationships have a matching Parent on the other node
+- [ ] All hierarchical nodes inherit from a generic with `hierarchical: true`
+- [ ] Root hierarchical nodes have `parent: null`
+- [ ] All `Dropdown` attributes have `choices` defined
+- [ ] `human_friendly_id` is set on nodes that will be user-facing
+- [ ] `uniqueness_constraints` use `__value` suffix for attributes
+- [ ] No deprecated fields used (`display_labels`, `default_filter`, `String` kind)
+- [ ] The `$schema` comment is present for IDE validation
+
+## IDE Integration
+
+Add this comment to the top of every schema file for IDE autocompletion:
+
+```yaml
+# yaml-language-server: $schema=https://schema.infrahub.app/infrahub/schema/latest.json
 ```
 
-### Query Test
-
-Verify queries work correctly:
-
-```graphql
-query {
-  NetworkDevice {
-    edges {
-      node {
-        hostname { value }
-        interfaces {
-          edges {
-            node {
-              name { value }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
+This enables:
+- Property name autocompletion
+- Type validation
+- Inline error highlighting
+- Documentation tooltips

--- a/skills/transform-creator/SKILL.md
+++ b/skills/transform-creator/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: infrahub-transform-creator
+description: Create and manage Infrahub transforms. Use when building data transformations, config generation, or any workflow that converts Infrahub data into a different format (JSON, text, CSV, device configs) using Python or Jinja2 templates.
+license: MIT
+metadata:
+  author: infrahub
+  version: 1.0.0
+---
+
+## Overview
+
+Expert guidance for creating Infrahub transforms. Transforms convert Infrahub data into different formats -- JSON, text, CSV, device configs, or any text-based output -- using Python classes or Jinja2 templates.
+
+## When to Use
+
+- Building data transformations (Infrahub data -> another format)
+- Generating device configurations from infrastructure data
+- Creating CSV reports, cable matrices, or inventory exports
+- Rendering Jinja2 templates with query data
+- Combining Python logic with Jinja2 rendering
+- Connecting transforms to artifacts for automated output
+
+## Rule Categories
+
+| Priority | Category | Prefix | Description |
+|----------|----------|--------|-------------|
+| CRITICAL | Transform Types | `types-` | Python vs Jinja2, when to use which |
+| CRITICAL | Python Transform | `python-` | InfrahubTransform class, transform() method, return types |
+| CRITICAL | Jinja2 Transform | `jinja2-` | Template syntax, data variable, netutils filters |
+| HIGH | Hybrid | `hybrid-` | Python data prep + Jinja2 rendering pattern |
+| HIGH | Artifacts | `artifacts-` | Connecting transforms to output files, content types, targets |
+| HIGH | API Reference | `api-` | Class attributes, instance properties, methods |
+| MEDIUM | Patterns | `patterns-` | Data extraction utilities, CSV output, shared common.py |
+| LOW | Testing | `testing-` | infrahubctl transform/render commands |
+
+## Transform Basics
+
+Two types of transforms:
+
+| Type | Output | Entry Point |
+|------|--------|-------------|
+| **Python** | JSON/dict or text | `InfrahubTransform.transform()` |
+| **Jinja2** | Text | `.j2` template file |
+
+```python
+from infrahub_sdk.transforms import InfrahubTransform
+
+class MyTransform(InfrahubTransform):
+    query = "my_query"
+
+    async def transform(self, data: dict) -> dict:
+        device = data["DcimDevice"]["edges"][0]["node"]
+        return {"hostname": device["name"]["value"]}
+```
+
+## Supporting References
+
+- **[examples.md](./examples.md)** -- Complete transform patterns (Python, Jinja2, hybrid, CSV)
+- **[../common/graphql-queries.md](../common/graphql-queries.md)** -- GraphQL query writing reference
+- **[../common/infrahub-yml-reference.md](../common/infrahub-yml-reference.md)** -- .infrahub.yml project configuration
+- **[../common/rules/](../common/rules/)** -- Shared rules (git integration, caching gotchas) that apply across all skills
+- **[../schema-creator/SKILL.md](../schema-creator/SKILL.md)** -- Schema definitions transforms work with
+- **[rules/](./rules/)** -- Individual rules organized by category prefix

--- a/skills/transform-creator/examples.md
+++ b/skills/transform-creator/examples.md
@@ -1,0 +1,476 @@
+# Infrahub Transform Examples
+
+Real-world examples extracted from production Infrahub repositories.
+
+---
+
+## 1. Python Transform with Jinja2 Rendering (Spine Config)
+
+A Python transform that prepares data and renders a platform-specific Jinja2 template.
+
+### Query: `queries/config/spine.gql`
+
+```graphql
+query spine_config($device: String!) {
+  DcimDevice(name__value: $device) {
+    edges {
+      node {
+        id
+        name { value }
+        role { value }
+        device_type {
+          node {
+            name { value }
+            manufacturer { node { name { value } } }
+            platform {
+              node {
+                netmiko_device_type { value }
+                napalm_driver { value }
+              }
+            }
+          }
+        }
+        primary_address {
+          node {
+            address { value }
+          }
+        }
+        device_services {
+          edges {
+            node {
+              __typename
+              name { value }
+              status { value }
+              ... on ServiceBGP {
+                local_as { node { asn { value } } }
+                remote_as { node { asn { value } } }
+                router_id { node { address { value } } }
+                peer_group {
+                  node {
+                    name { value }
+                    peer_group_type { value }
+                  }
+                }
+              }
+              ... on ServiceOSPF {
+                process_id { value }
+                version { value }
+                router_id { node { address { value } } }
+                area { node { area { value } name { value } } }
+              }
+            }
+          }
+        }
+        interfaces {
+          edges {
+            node {
+              id
+              name { value }
+              description { value }
+              status { value }
+              role { value }
+              ... on InterfacePhysical {
+                mtu { value }
+                ip_addresses {
+                  edges {
+                    node {
+                      address { value }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Transform: `transforms/spine.py`
+
+```python
+from typing import Any
+from infrahub_sdk.transforms import InfrahubTransform
+from jinja2 import Environment, FileSystemLoader
+from netutils.utils import jinja2_convenience_function
+from .common import get_data, get_interfaces, get_bgp_profile, get_loopbacks, get_ospf
+
+
+class Spine(InfrahubTransform):
+    query = "spine_config"
+
+    async def transform(self, data: Any) -> str:
+        data = get_data(data)
+
+        # Get platform for template selection
+        platform = data["device_type"]["platform"]["netmiko_device_type"]
+
+        # Set up Jinja2 environment
+        template_path = f"{self.root_directory}/templates/configs/spines"
+        env = Environment(
+            loader=FileSystemLoader(template_path),
+            autoescape=False,
+        )
+        env.filters.update(jinja2_convenience_function())
+
+        # Select platform-specific template
+        template = env.get_template(f"{platform}.j2")
+
+        # Prepare template context
+        bgp_profiles = get_bgp_profile(data.get("device_services"))
+        ospf_configs = get_ospf(data.get("device_services"))
+
+        bgp = {}
+        if bgp_profiles:
+            first = bgp_profiles[0]
+            router_id = first.get("router_id", {}).get("address", "")
+            if router_id and "/" in router_id:
+                router_id = router_id.split("/")[0]
+            bgp = {
+                "local_as": first.get("local_as", {}).get("asn", ""),
+                "router_id": router_id,
+                "neighbors": [],
+            }
+            for profile in bgp_profiles:
+                for session in profile.get("sessions", []):
+                    bgp["neighbors"].append({
+                        "name": session.get("name", ""),
+                        "remote_ip": session.get("remote_ip", {}).get("address", ""),
+                        "remote_as": session.get("remote_as", {}).get("asn", ""),
+                    })
+
+        config = {
+            "hostname": data.get("name"),
+            "bgp": bgp,
+            "bgp_profiles": bgp_profiles,
+            "ospf": ospf_configs[0] if ospf_configs else {},
+            "interfaces": get_interfaces(data.get("interfaces")),
+            "loopbacks": get_loopbacks(data.get("interfaces")),
+        }
+
+        return template.render(**config)
+```
+
+### Config: `.infrahub.yml`
+
+```yaml
+queries:
+  - name: spine_config
+    file_path: queries/config/spine.gql
+
+python_transforms:
+  - name: spine
+    class_name: Spine
+    file_path: transforms/spine.py
+
+artifact_definitions:
+  - name: spine_config
+    artifact_name: spine
+    content_type: text/plain
+    targets: spines
+    transformation: spine
+    parameters:
+      device: name__value
+```
+
+---
+
+## 2. CSV Cable Matrix Transform
+
+A Python transform that generates a CSV cable documentation from topology data.
+
+### Transform: `transforms/topology_cabling.py`
+
+```python
+from infrahub_sdk.transforms import InfrahubTransform
+
+
+class TopologyCabling(InfrahubTransform):
+    query = "topology_cabling"
+
+    async def transform(self, data: dict) -> str:
+        csv_rows = []
+        header = "Source Device,Source Interface,Remote Device,Remote Interface,"
+        header += "Cable Type,Cable Status,Cable Color,Cable Label"
+        csv_rows.append(header)
+
+        seen_connections = set()
+
+        for device in data["TopologyDataCenter"]["edges"][0]["node"]["devices"]["edges"]:
+            source_device = device["node"]["name"]["value"]
+
+            for interface in device["node"]["interfaces"]["edges"]:
+                cable = interface["node"].get("connector", {}).get("node")
+                if not cable:
+                    continue
+
+                source_interface = interface["node"]["name"]["value"]
+                cable_type = cable.get("cable_type", {}).get("value", "")
+                cable_status = cable.get("status", {}).get("value", "")
+                cable_color = cable.get("color", {}).get("value", "")
+                cable_label = cable.get("label", {}).get("value", "")
+
+                # Find remote endpoint
+                endpoints = cable.get("connected_endpoints", {}).get("edges", [])
+                remote_endpoint = None
+                for ep in endpoints:
+                    ep_node = ep.get("node", {})
+                    ep_device = ep_node.get("device", {}).get("node", {}).get("name", {}).get("value")
+                    ep_intf = ep_node.get("name", {}).get("value")
+                    if ep_device != source_device or ep_intf != source_interface:
+                        remote_endpoint = ep_node
+                        break
+
+                if not remote_endpoint:
+                    continue
+
+                remote_device = remote_endpoint.get("device", {}).get("node", {}).get("name", {}).get("value")
+                remote_interface = remote_endpoint.get("name", {}).get("value")
+
+                # Deduplicate connections
+                key = tuple(sorted([
+                    (source_device, source_interface),
+                    (remote_device, remote_interface),
+                ]))
+                if key in seen_connections:
+                    continue
+                seen_connections.add(key)
+
+                row = [source_device, source_interface, remote_device, remote_interface,
+                       cable_type, cable_status, cable_color, cable_label]
+                escaped = [f'"{f}"' if "," in str(f) else str(f) for f in row]
+                csv_rows.append(",".join(escaped))
+
+        return "\n".join(csv_rows)
+```
+
+### Config: `.infrahub.yml`
+
+```yaml
+python_transforms:
+  - name: topology_cabling
+    class_name: TopologyCabling
+    file_path: transforms/topology_cabling.py
+
+artifact_definitions:
+  - name: Cable matrix for Topology
+    artifact_name: topology-cabling
+    content_type: text/csv
+    targets: topologies_dc
+    transformation: topology_cabling
+    parameters:
+      name: name__value
+```
+
+---
+
+## 3. Jinja2 Transform (ContainerLab Topology)
+
+A pure Jinja2 transform for generating ContainerLab topology files.
+
+### Config: `.infrahub.yml`
+
+```yaml
+queries:
+  - name: topology_simulator
+    file_path: queries/topology/clab.gql
+
+jinja2_transforms:
+  - name: topology_clab
+    description: Template to generate a containerlab topology
+    query: topology_simulator
+    template_path: templates/clab_topology.j2
+
+artifact_definitions:
+  - name: Containerlab Topology
+    artifact_name: containerlab-topology
+    content_type: text/plain
+    targets: topologies_clab
+    transformation: topology_clab
+    parameters:
+      name: name__value
+```
+
+### Template: `templates/clab_topology.j2`
+
+```jinja2
+name: {{ data.TopologyDataCenter.edges[0].node.name.value }}
+topology:
+  nodes:
+{% for device in data.TopologyDataCenter.edges[0].node.devices.edges %}
+    {{ device.node.name.value }}:
+      kind: linux
+      image: {{ device.node.device_type.node.platform.node.containerlab_image.value }}
+{% endfor %}
+  links:
+{% for device in data.TopologyDataCenter.edges[0].node.devices.edges %}
+{% for intf in device.node.interfaces.edges %}
+{% if intf.node.connector is defined and intf.node.connector.node %}
+    - endpoints:
+        - "{{ device.node.name.value }}:{{ intf.node.name.value }}"
+        - "{{ intf.node.connector.node.remote_device }}:{{ intf.node.connector.node.remote_interface }}"
+{% endif %}
+{% endfor %}
+{% endfor %}
+```
+
+---
+
+## 4. Minimal Python Transform Template
+
+The simplest possible Python transform:
+
+### Transform: `transforms/simple.py`
+
+```python
+from infrahub_sdk.transforms import InfrahubTransform
+
+
+class SimpleTransform(InfrahubTransform):
+    query = "my_query"
+
+    async def transform(self, data: dict) -> dict:
+        device = data["DcimDevice"]["edges"][0]["node"]
+        return {
+            "hostname": device["name"]["value"],
+            "status": device["status"]["value"],
+        }
+```
+
+### Config: `.infrahub.yml`
+
+```yaml
+queries:
+  - name: my_query
+    file_path: queries/my_query.gql
+
+python_transforms:
+  - name: simple_transform
+    class_name: SimpleTransform
+    file_path: transforms/simple.py
+```
+
+---
+
+## 5. Shared Transform Utilities
+
+### `transforms/common.py`
+
+```python
+from typing import Any
+
+
+def clean_data(data: Any) -> Any:
+    """Recursively normalize Infrahub API data."""
+    if isinstance(data, dict):
+        result = {}
+        for key, value in data.items():
+            if isinstance(value, dict):
+                keys = set(value.keys())
+                if keys == {"value"}:
+                    result[key] = value["value"]
+                elif keys == {"edges"} and not value["edges"]:
+                    result[key] = []
+                elif "node" in value:
+                    result[key] = clean_data(value["node"])
+                elif "edges" in value:
+                    result[key] = clean_data(value["edges"])
+                else:
+                    result[key] = clean_data(value)
+            elif "__" in key:
+                result[key.replace("__", "")] = value
+            else:
+                result[key] = clean_data(value)
+        return result
+    if isinstance(data, list):
+        return [clean_data(item.get("node", item)) for item in data]
+    return data
+
+
+def get_data(data: Any) -> Any:
+    """Extract the first object from cleaned data."""
+    cleaned = clean_data(data)
+    first_key = next(iter(cleaned))
+    first_value = cleaned[first_key]
+    if isinstance(first_value, list) and first_value:
+        return first_value[0]
+    return first_value if first_value is not None else {}
+
+
+def get_interfaces(interfaces: list | None) -> list:
+    """Return sorted interface list."""
+    if not interfaces:
+        return []
+    return sorted(interfaces, key=lambda x: x.get("name", ""))
+
+
+def get_loopbacks(interfaces: list | None) -> dict:
+    """Map loopback interfaces to their IPs."""
+    if not interfaces:
+        return {}
+    loopbacks = {}
+    for intf in interfaces:
+        if intf.get("role") == "loopback":
+            ips = intf.get("ip_addresses", [])
+            if ips:
+                loopbacks[intf["name"]] = ips[0].get("address", "")
+    return loopbacks
+
+
+def get_bgp_profile(services: list | None) -> list:
+    """Extract BGP service configurations."""
+    if not services:
+        return []
+    return [s for s in services if s.get("typename") == "ServiceBGP"]
+
+
+def get_ospf(services: list | None) -> list:
+    """Extract OSPF service configurations."""
+    if not services:
+        return []
+    return [s for s in services if s.get("typename") == "ServiceOSPF"]
+
+
+def get_interface_roles(interfaces: list | None) -> dict:
+    """Group interfaces by role."""
+    if not interfaces:
+        return {}
+    roles: dict[str, list] = {}
+    for intf in interfaces:
+        role = intf.get("role", "unknown")
+        roles.setdefault(role, []).append(intf)
+    return roles
+```
+
+---
+
+## Complete File Structure
+
+```
+project/
+  .infrahub.yml
+  transforms/
+    __init__.py
+    common.py                    # Shared utilities
+    spine.py                     # Spine config (Python + Jinja2)
+    leaf.py                      # Leaf config
+    topology_cabling.py          # Cable matrix CSV
+  templates/
+    configs/
+      spines/
+        arista_eos.j2
+        cisco_nxos.j2
+        juniper_junos.j2
+      leafs/
+        arista_eos.j2
+    clab_topology.j2
+  queries/
+    config/
+      spine.gql
+      leaf.gql
+    topology/
+      clab.gql
+      cabling.gql
+```

--- a/skills/transform-creator/rules/_sections.md
+++ b/skills/transform-creator/rules/_sections.md
@@ -1,0 +1,17 @@
+# Infrahub Transform Creator - Rule Sections
+
+1. **Transform Types (types-)** -- CRITICAL. Python vs Jinja2 transforms, when to use which, output formats. Choosing wrong type leads to unnecessary complexity.
+
+2. **Python Transform (python-)** -- CRITICAL. InfrahubTransform base class, transform() method, return types (dict=JSON, str=text), sync or async support.
+
+3. **Jinja2 Transform (jinja2-)** -- CRITICAL. Template syntax, data variable containing GraphQL response, netutils filters, template imports.
+
+4. **Hybrid (hybrid-)** -- HIGH. Combining Python data preparation with Jinja2 rendering. Platform-specific template selection, FileSystemLoader setup.
+
+5. **Artifacts (artifacts-)** -- HIGH. Connecting transforms to output files via artifact_definitions, content types, targets requirement (CoreArtifactTarget), parameter mapping.
+
+6. **API Reference (api-)** -- HIGH. Class attributes (query, timeout), instance properties (client, root_directory, server_url), methods, return type behavior.
+
+7. **Patterns (patterns-)** -- MEDIUM. Data extraction utilities (common.py), CSV output pattern, shared functions (get_data, get_interfaces, get_bgp_profile).
+
+8. **Testing (testing-)** -- LOW. infrahubctl transform and render commands, REST API endpoints.

--- a/skills/transform-creator/rules/_template.md
+++ b/skills/transform-creator/rules/_template.md
@@ -1,0 +1,25 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+tags: tag1, tag2
+---
+
+## Rule Title Here
+
+**Impact: MEDIUM**
+
+Brief explanation of the rule and why it matters for Infrahub transform creation.
+
+**Incorrect:**
+
+```python
+# Bad example
+```
+
+**Correct:**
+
+```python
+# Good example
+```
+
+Reference: [Infrahub Transform Docs](https://docs.infrahub.app)

--- a/skills/transform-creator/rules/api-reference.md
+++ b/skills/transform-creator/rules/api-reference.md
@@ -1,0 +1,37 @@
+---
+title: InfrahubTransform API Reference
+impact: HIGH
+tags: api, class-attributes, properties, methods
+---
+
+## InfrahubTransform API Reference
+
+**Impact: HIGH**
+
+### Class Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` | **Required.** GraphQL query name |
+| `timeout` | `int` | Timeout in seconds (default: 60) |
+
+### Instance Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `self.client` | `InfrahubClient` | SDK client (branch-aware clone) |
+| `self.nodes` | `list[InfrahubNode]` | SDK objects (when `convert_query_response=True`) |
+| `self.store` | `NodeStore` | Populated during data collection |
+| `self.branch_name` | `str` | Current branch name |
+| `self.root_directory` | `str` | Repository root path (for loading templates/files) |
+| `self.server_url` | `str` | Infrahub server URL |
+
+### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `transform(data: dict) -> Any` | **You must implement this.** Can be sync or async. Returns transformed data. |
+| `async collect_data()` | Executes the GraphQL query (called automatically) |
+| `async run(data=None)` | Orchestrates collection, processing, and calls `transform()` |
+
+Reference: [Infrahub SDK Docs](https://docs.infrahub.app)

--- a/skills/transform-creator/rules/artifacts-definitions.md
+++ b/skills/transform-creator/rules/artifacts-definitions.md
@@ -1,0 +1,55 @@
+---
+title: Artifact Definitions
+impact: HIGH
+tags: artifacts, content-type, targets, CoreArtifactTarget
+---
+
+## Artifact Definitions
+
+**Impact: HIGH**
+
+Artifacts connect transforms to output files attached to target objects.
+
+### Configuration
+
+```yaml
+artifact_definitions:
+  - name: spine_config                   # Unique identifier
+    artifact_name: spine                 # Display name
+    content_type: text/plain             # MIME type
+    targets: spines                      # Target group
+    transformation: spine                # Transform name (must match)
+    parameters:
+      device: name__value               # Maps target attribute to query variable
+```
+
+### Content Types
+
+| Content Type | Use Case |
+|-------------|----------|
+| `text/plain` | Device configs, scripts |
+| `application/json` | Structured data, API payloads |
+| `text/csv` | Cable matrices, inventory reports |
+| `text/yaml` | YAML config files |
+
+### Target Requirements
+
+Target nodes must inherit from `CoreArtifactTarget` in their schema:
+
+```yaml
+# In schema file
+generics:
+  - name: GenericDevice
+    namespace: Dcim
+    inherit_from:
+      - CoreArtifactTarget            # Required for artifact generation
+```
+
+### Key Rules
+
+- **`transformation` must match** the transform `name` in `python_transforms` or `jinja2_transforms`
+- **`targets`** references a group whose members get artifacts generated
+- **`parameters`** maps target object attributes to query variables
+- **`content_type`** must match what the transform actually outputs
+
+Reference: [../common/infrahub-yml-reference.md](../../common/infrahub-yml-reference.md)

--- a/skills/transform-creator/rules/hybrid-python-jinja2.md
+++ b/skills/transform-creator/rules/hybrid-python-jinja2.md
@@ -1,0 +1,59 @@
+---
+title: Hybrid Python + Jinja2 Pattern
+impact: HIGH
+tags: hybrid, python, jinja2, FileSystemLoader, platform-specific
+---
+
+## Hybrid Python + Jinja2 Pattern
+
+**Impact: HIGH**
+
+For complex scenarios, use Python to prepare data and Jinja2 to render it. This is the most common pattern for device configuration generation.
+
+### Example: Platform-Specific Config
+
+```python
+from infrahub_sdk.transforms import InfrahubTransform
+from jinja2 import Environment, FileSystemLoader
+from netutils.utils import jinja2_convenience_function
+from .common import get_data, get_interfaces, get_bgp_profile
+
+
+class Spine(InfrahubTransform):
+    query = "spine_config"
+
+    async def transform(self, data: dict) -> str:
+        data = get_data(data)
+
+        # Get platform for template selection
+        platform = data["device_type"]["platform"]["netmiko_device_type"]
+
+        # Set up Jinja2 with template directory
+        template_path = f"{self.root_directory}/templates/configs/spines"
+        env = Environment(
+            loader=FileSystemLoader(template_path),
+            autoescape=False,
+        )
+        env.filters.update(jinja2_convenience_function())
+
+        # Select platform-specific template
+        template = env.get_template(f"{platform}.j2")
+
+        # Prepare template context
+        config = {
+            "hostname": data.get("name"),
+            "bgp": get_bgp_profile(data.get("device_services")),
+            "interfaces": get_interfaces(data.get("interfaces")),
+        }
+
+        return template.render(**config)
+```
+
+### Key Points
+
+- **`self.root_directory`** provides the repo root path for template loading
+- **`jinja2_convenience_function()`** adds netutils filters to the Jinja2 environment
+- **Platform-specific templates** selected dynamically based on query data
+- **Registered as a `python_transform`** in `.infrahub.yml` (not `jinja2_transform`)
+
+Reference: [examples.md](../examples.md) for complete hybrid examples.

--- a/skills/transform-creator/rules/jinja2-template.md
+++ b/skills/transform-creator/rules/jinja2-template.md
@@ -1,0 +1,62 @@
+---
+title: Jinja2 Transform Templates
+impact: CRITICAL
+tags: jinja2, template, data-variable, netutils
+---
+
+## Jinja2 Transform Templates
+
+**Impact: CRITICAL**
+
+Jinja2 transforms render a template using GraphQL query data. No Python code needed.
+
+### Template Structure
+
+```jinja2
+{# templates/device_config.j2 #}
+{% for device in data["DcimDevice"]["edges"] %}
+{% set d = device.node %}
+hostname {{ d.name.value }}
+!
+{% for intf in d.interfaces.edges %}
+interface {{ intf.node.name.value }}
+  description {{ intf.node.description.value | default("") }}
+  {% if intf.node.ip_addresses is defined %}
+  {% for ip in intf.node.ip_addresses.edges %}
+  ip address {{ ip.node.address.value }}
+  {% endfor %}
+  {% endif %}
+{% endfor %}
+{% endfor %}
+```
+
+The `data` variable contains the full GraphQL query response.
+
+### Registration in .infrahub.yml
+
+```yaml
+queries:
+  - name: device_config_query
+    file_path: queries/config/device.gql
+
+jinja2_transforms:
+  - name: device_config
+    query: device_config_query
+    template_path: templates/device_config.j2
+    description: "Generate device startup config"
+```
+
+### Jinja2 Features
+
+- Standard Jinja2 filters and syntax
+- **Netutils** filters available (via `netutils.utils.jinja2_convenience_function()`)
+- Can import other templates from the repository
+- Both dot notation (`d.name.value`) and bracket notation (`d["name"]["value"]`) work
+
+### Key Rules
+
+- The `data` variable is automatically populated with the GraphQL response
+- Template path is relative to the repository root
+- No Python class needed -- just the `.j2` template and `.infrahub.yml` config
+
+Reference: [Infrahub Transform Docs](https://docs.infrahub.app)

--- a/skills/transform-creator/rules/patterns-common.md
+++ b/skills/transform-creator/rules/patterns-common.md
@@ -1,0 +1,71 @@
+---
+title: Common Transform Patterns
+impact: MEDIUM
+tags: patterns, data-extraction, csv, common-py
+---
+
+## Common Transform Patterns
+
+**Impact: MEDIUM**
+
+### Data Extraction Utilities
+
+```python
+# transforms/common.py
+def get_data(data):
+    """Extract first object from GraphQL response."""
+    cleaned = clean_data(data)
+    first_key = next(iter(cleaned))
+    return cleaned[first_key][0]
+
+def get_interfaces(interfaces):
+    """Return sorted interface list."""
+    if not interfaces:
+        return []
+    return sorted(interfaces, key=lambda x: x.get("name", ""))
+
+def get_bgp_profile(services):
+    """Group BGP sessions by peer group."""
+    if not services:
+        return []
+    return [s for s in services if s.get("typename") == "ServiceBGP"]
+```
+
+### CSV Output
+
+```python
+class CableMatrix(InfrahubTransform):
+    query = "topology_cabling"
+
+    async def transform(self, data: dict) -> str:
+        rows = ["Source Device,Source Interface,Remote Device,Remote Interface"]
+
+        for device in data["Topology"]["edges"][0]["node"]["devices"]["edges"]:
+            source = device["node"]["name"]["value"]
+            for intf in device["node"]["interfaces"]["edges"]:
+                cable = intf["node"].get("connector", {}).get("node")
+                if cable:
+                    # ... extract remote endpoint ...
+                    rows.append(f"{source},{src_intf},{remote_device},{remote_intf}")
+
+        return "\n".join(rows)
+```
+
+### Shared Utilities Pattern
+
+Extract common data extraction into `transforms/common.py` and import across transform files:
+
+```python
+# transforms/spine.py
+from .common import get_data, get_interfaces
+
+class Spine(InfrahubTransform):
+    query = "spine_config"
+
+    async def transform(self, data: dict) -> str:
+        data = get_data(data)
+        interfaces = get_interfaces(data.get("interfaces"))
+        # ... render config ...
+```
+
+Reference: [examples.md](../examples.md) for complete transform examples.

--- a/skills/transform-creator/rules/python-transform.md
+++ b/skills/transform-creator/rules/python-transform.md
@@ -1,0 +1,62 @@
+---
+title: Python Transform Class
+impact: CRITICAL
+tags: python, InfrahubTransform, transform, return-types
+---
+
+## Python Transform Class
+
+**Impact: CRITICAL**
+
+Python transforms inherit from `InfrahubTransform` and implement a `transform()` method that returns the transformed data.
+
+### Basic Structure
+
+```python
+from infrahub_sdk.transforms import InfrahubTransform
+
+
+class MyTransform(InfrahubTransform):
+    query = "my_query"                    # Must match query name in .infrahub.yml
+
+    async def transform(self, data: dict) -> dict:
+        device = data["DcimDevice"]["edges"][0]["node"]
+
+        return {
+            "hostname": device["name"]["value"],
+            "role": device["role"]["value"],
+            "interfaces": [
+                intf["node"]["name"]["value"]
+                for intf in device["interfaces"]["edges"]
+            ],
+        }
+```
+
+### Return Types
+
+| Return Type | Content Type | Use Case |
+|-------------|-------------|----------|
+| `dict` | `application/json` | Structured data, API payloads |
+| `str` | `text/plain` | Device configs, scripts, CSV |
+
+### Registration in .infrahub.yml
+
+```yaml
+queries:
+  - name: my_query
+    file_path: queries/config/my_query.gql
+
+python_transforms:
+  - name: my_transform
+    class_name: MyTransform
+    file_path: transforms/my_transform.py
+```
+
+### Key Rules
+
+- **`query` class attribute must match** the query `name` in `.infrahub.yml`
+- **`transform()` can be sync or async** -- the SDK handles both
+- **Return type determines format** -- `dict` for JSON, `str` for text
+- **Use `self.root_directory`** to access templates and other repo files
+
+Reference: [Infrahub Transform Docs](https://docs.infrahub.app)

--- a/skills/transform-creator/rules/testing-commands.md
+++ b/skills/transform-creator/rules/testing-commands.md
@@ -1,0 +1,35 @@
+---
+title: Testing Transforms
+impact: LOW
+tags: testing, infrahubctl, commands, rest-api
+---
+
+## Testing Transforms
+
+**Impact: LOW (reference)**
+
+### Commands
+
+```bash
+# List available transforms
+infrahubctl transform --list
+
+# Run a Python transform
+infrahubctl transform my_transform device=spine-01
+
+# Render a Jinja2 transform
+infrahubctl render my_jinja_transform device=spine-01
+
+# REST API (after deployment)
+# Python: GET /api/transform/python/my_transform?device=spine-01
+# Jinja2: GET /api/transform/jinja2/my_transform?device=spine-01&branch=main
+```
+
+### Debugging Tips
+
+- Test Python transforms with `infrahubctl transform` to see raw output
+- Test Jinja2 templates with `infrahubctl render` to see rendered text
+- Check that `query` class attribute matches the query `name` in `.infrahub.yml`
+- Use `print()` in `transform()` during development for data inspection
+
+Reference: [Infrahub CLI Docs](https://docs.infrahub.app)

--- a/skills/transform-creator/rules/types-overview.md
+++ b/skills/transform-creator/rules/types-overview.md
@@ -1,0 +1,63 @@
+---
+title: Transform Types Overview
+impact: CRITICAL
+tags: types, python, jinja2, choosing
+---
+
+## Transform Types Overview
+
+**Impact: CRITICAL**
+
+Choose the right transform type based on your output needs.
+
+### Comparison
+
+| Type | Output | Use Case | Entry Point | Registration |
+|------|--------|----------|-------------|-------------|
+| **Python** | JSON/dict or text | Complex logic, computations, API mashups | `InfrahubTransform.transform()` | `python_transforms` |
+| **Jinja2** | Text | Template-based rendering (device configs) | `.j2` template file | `jinja2_transforms` |
+
+### When to Use Python
+
+- Complex data transformations or computations
+- Multiple output formats from one query
+- Conditional logic that's hard in Jinja2
+- CSV output, JSON restructuring
+- When you need to combine data from multiple sources
+
+### When to Use Jinja2
+
+- Device configuration rendering
+- Text-based output with clear template structure
+- When the template closely mirrors the output format
+- Simple data-to-text mappings
+
+### When to Use Both (Hybrid)
+
+- Python prepares/cleans the data, Jinja2 renders it
+- Platform-specific template selection (e.g., `arista_eos.j2` vs `cisco_nxos.j2`)
+- Complex data extraction with template-based output
+
+### File Organization
+
+```
+transforms/
+  __init__.py
+  common.py                      # Shared utilities
+  spine.py                       # Python transforms
+  topology_cabling.py
+
+templates/
+  configs/
+    spines/
+      arista_eos.j2             # Platform-specific templates
+      cisco_nxos.j2
+  clab_topology.j2
+
+queries/
+  config/
+    spine.gql
+    leaf.gql
+```
+
+Reference: [Infrahub Transform Docs](https://docs.infrahub.app)


### PR DESCRIPTION
Expand plugin from schema-creator only to full Infrahub development lifecycle coverage. Add 5 new skills (object-creator, check-creator, generator-creator, transform-creator, menu-creator), shared common/ directory with cross-cutting rules, and update schema-creator with rules/ directory. Bump plugin version to 2.0.0.