### PR TITLE
Remove extra frontmatter fields from SKILL.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,6 @@ Each skill directory contains:
    ---
    name: infrahub-my-skill
    description: Brief description of what this skill does
-   license: Apache-2.0
-   metadata:
-     author: infrahub
-     version: 1.0.0
    ---
    ```
 3. Include sections: Overview, When to Use, Rule Categories, Supporting References
@@ -86,7 +82,7 @@ Each skill directory contains:
 ## Conventions
 
 - Use semantic versioning for plugin versions
-- Skills require YAML frontmatter with `name`, `description`, `license`, and `metadata`
+- Skills require YAML frontmatter with `name` and `description`
 - Skill names: `infrahub-` prefix with lowercase hyphens (e.g., `infrahub-schema-creator`)
 - Directory names: drop the `infrahub-` prefix (e.g., `schema-creator/`)
 - Keep documentation current with Infrahub schema format changes

--- a/skills/check-creator/SKILL.md
+++ b/skills/check-creator/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: infrahub-check-creator
 description: Create and manage Infrahub check definitions. Use when writing validation logic, creating Python checks that run in proposed change pipelines, or building data quality guards for Infrahub.
-license: Apache-2.0
-metadata:
-  author: infrahub
-  version: 1.0.0
 ---
 
 ## Overview

--- a/skills/generator-creator/SKILL.md
+++ b/skills/generator-creator/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: infrahub-generator-creator
 description: Create and manage Infrahub generators. Use when building design-driven automation that creates infrastructure objects from templates, topology definitions, or any design-to-implementation workflow in Infrahub.
-license: Apache-2.0
-metadata:
-  author: infrahub
-  version: 1.0.0
 ---
 
 ## Overview

--- a/skills/menu-creator/SKILL.md
+++ b/skills/menu-creator/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: infrahub-menu-creator
 description: Create and manage Infrahub custom menus. Use when designing navigation menus, organizing node types in the UI, or customizing the Infrahub web interface sidebar.
-license: Apache-2.0
-metadata:
-  author: infrahub
-  version: 1.0.0
 ---
 
 ## Overview

--- a/skills/object-creator/SKILL.md
+++ b/skills/object-creator/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: infrahub-object-creator
 description: Create and manage Infrahub object data files. Use when populating infrastructure data, creating device instances, locations, organizations, module installations, or any other data objects for an Infrahub repository.
-license: Apache-2.0
-metadata:
-  author: infrahub
-  version: 1.0.0
 ---
 
 ## Overview

--- a/skills/schema-creator/SKILL.md
+++ b/skills/schema-creator/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: infrahub-schema-creator
 description: Create, validate, and modify Infrahub schemas. Use when designing data models, creating schema nodes with attributes and relationships, validating schema definitions, or planning schema migrations for Infrahub.
-license: Apache-2.0
-metadata:
-  author: infrahub
-  version: 1.0.0
 ---
 
 ## Overview

--- a/skills/transform-creator/SKILL.md
+++ b/skills/transform-creator/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: infrahub-transform-creator
 description: Create and manage Infrahub transforms. Use when building data transformations, config generation, or any workflow that converts Infrahub data into a different format (JSON, text, CSV, device configs) using Python or Jinja2 templates.
-license: Apache-2.0
-metadata:
-  author: infrahub
-  version: 1.0.0
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary
- Remove `license`, `metadata.author`, and `metadata.version` from all 6 SKILL.md frontmatters
- The official Claude Code Skills spec only requires `name` and `description` — extra fields consume tokens unnecessarily when skills are loaded
- Update CLAUDE.md to reflect the simplified frontmatter requirements

## Test plan
- [ ] Verify each SKILL.md still has valid `name` and `description` frontmatter
- [ ] Confirm skills are still discovered and triggered correctly by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)