### PR TITLE
Add CI/CD pipelines and fix linter errors

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,0 +1,32 @@
+---
+ci_config: &ci_config
+  - ".github/workflows/ci.yml"
+  - ".github/file-filters.yml"
+
+skill_files: &skill_files
+  - "skills/**"
+
+eval_files: &eval_files
+  - "evaluations/**"
+  - "scripts/**"
+
+plugin_files: &plugin_files
+  - ".claude-plugin/**"
+  - "hooks/**"
+  - "hooks-handlers/**"
+
+doc_files: &doc_files
+  - "dev/**"
+  - "docs/**"
+
+yaml_all: &yaml_all
+  - "**/*.{yml,yaml}"
+  - "!.github/**"
+
+markdown_all: &markdown_all
+  - "**/*.md"
+
+skills_all:
+  - *skill_files
+  - *eval_files
+  - *ci_config

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,31 @@
+---
+# yaml-disable-next-line rule:truthy
+"group/skills":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "skills/**"
+
+"group/ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "scripts/**"
+
+"group/docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "dev/**"
+          - "docs/**"
+          - "*.md"
+
+"group/evaluations":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "evaluations/**"
+
+"group/plugin":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".claude-plugin/**"
+          - "hooks/**"
+          - "hooks-handlers/**"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,80 @@
+---
+# -------------------------------------------------------------------
+# Group labels — categorize by area of the repository
+# -------------------------------------------------------------------
+- name: "group/skills"
+  color: "0075ca"
+  description: "Skill definitions and rules"
+- name: "group/ci"
+  color: "e4e669"
+  description: "CI/CD workflows and scripts"
+- name: "group/docs"
+  color: "0e8a16"
+  description: "Documentation and guides"
+- name: "group/evaluations"
+  color: "d876e3"
+  description: "Eval scenarios and grading scripts"
+- name: "group/common"
+  color: "006b75"
+  description: "Shared references and cross-cutting rules"
+- name: "group/plugin"
+  color: "1d76db"
+  description: "Plugin manifest and hooks"
+
+# -------------------------------------------------------------------
+# Type labels — categorize by nature of the change
+# -------------------------------------------------------------------
+- name: "type/feature"
+  color: "a2eeef"
+  description: "New feature or skill"
+- name: "type/bug"
+  color: "d73a4a"
+  description: "Something isn't working"
+- name: "type/housekeeping"
+  color: "fef2c0"
+  description: "Maintenance, cleanup, refactoring"
+- name: "type/documentation"
+  color: "0075ca"
+  description: "Documentation improvements"
+
+# -------------------------------------------------------------------
+# Effort labels
+# -------------------------------------------------------------------
+- name: "effort/small"
+  color: "c5def5"
+  description: "Small effort (< 1 hour)"
+- name: "effort/medium"
+  color: "bfd4f2"
+  description: "Medium effort (1-4 hours)"
+- name: "effort/large"
+  color: "b4c6e7"
+  description: "Large effort (> 4 hours)"
+
+# -------------------------------------------------------------------
+# Priority labels
+# -------------------------------------------------------------------
+- name: "priority/critical"
+  color: "b60205"
+  description: "Critical priority — release blocker"
+- name: "priority/high"
+  color: "d93f0b"
+  description: "High priority"
+- name: "priority/medium"
+  color: "fbca04"
+  description: "Medium priority"
+- name: "priority/low"
+  color: "0e8a16"
+  description: "Low priority"
+
+# -------------------------------------------------------------------
+# State labels
+# -------------------------------------------------------------------
+- name: "state/blocked"
+  color: "b60205"
+  description: "Blocked by external dependency"
+- name: "state/needs-review"
+  color: "fbca04"
+  description: "Ready for review"
+- name: "state/wip"
+  color: "ededed"
+  description: "Work in progress"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+---
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Detect which files changed to conditionally run downstream jobs
+  # ---------------------------------------------------------------------------
+  files-changed:
+    runs-on: ubuntu-latest
+    outputs:
+      markdown: ${{ steps.changes.outputs.markdown_all }}
+      yaml: ${{ steps.changes.outputs.yaml_all }}
+      skills: ${{ steps.changes.outputs.skills_all }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: opsmill/paths-filter@v3
+        id: changes
+        with:
+          filters: .github/file-filters.yml
+
+  # ---------------------------------------------------------------------------
+  # Lint Markdown files
+  # ---------------------------------------------------------------------------
+  markdown-lint:
+    needs: files-changed
+    if: needs.files-changed.outputs.markdown == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v22
+
+  # ---------------------------------------------------------------------------
+  # Lint YAML files
+  # ---------------------------------------------------------------------------
+  yaml-lint:
+    needs: files-changed
+    if: needs.files-changed.outputs.yaml == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: pip install yamllint
+      - run: yamllint -c .yamllint.yml .
+
+  # ---------------------------------------------------------------------------
+  # Run skill evaluations (reusable workflow)
+  # ---------------------------------------------------------------------------
+  skill-evals:
+    needs: files-changed
+    if: needs.files-changed.outputs.skills == 'true'
+    uses: ./.github/workflows/skill-evals.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       skills: ${{ steps.changes.outputs.skills_all }}
     steps:
       - uses: actions/checkout@v6
-      - uses: opsmill/paths-filter@v3
+      - uses: opsmill/paths-filter@v3.0.2
         id: changes
         with:
           filters: .github/file-filters.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+# yaml-disable-next-line rule:truthy
+name: Auto-label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v6.0.1
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,20 @@
+---
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/labels.yml"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crazy-max/ghaction-github-labeler@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+---
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  validate-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from tag
+        id: tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate plugin.json version matches tag
+        run: |
+          PLUGIN_VERSION=$(jq -r .version .claude-plugin/plugin.json)
+          TAG_VERSION="${{ steps.tag.outputs.version }}"
+          if [ "$PLUGIN_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Version mismatch: plugin.json=$PLUGIN_VERSION, tag=v$TAG_VERSION"
+            exit 1
+          fi
+
+      - name: Validate release-manifest version matches tag
+        run: |
+          MANIFEST_VERSION=$(jq -r .version .github/.release-manifest.json)
+          TAG_VERSION="${{ steps.tag.outputs.version }}"
+          if [ "$MANIFEST_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Version mismatch: release-manifest.json=$MANIFEST_VERSION, tag=v$TAG_VERSION"
+            exit 1
+          fi
+
+      - name: Validate SKILL.md versions match tag
+        run: |
+          TAG_VERSION="${{ steps.tag.outputs.version }}"
+          MISMATCHED=""
+          for f in skills/*/SKILL.md; do
+            SKILL_VERSION=$(sed -n '/^metadata:/,/^[^ ]/{ s/^  version: //p }' "$f")
+            if [ "$SKILL_VERSION" != "$TAG_VERSION" ]; then
+              MISMATCHED="$MISMATCHED\n  $f (has $SKILL_VERSION)"
+            fi
+          done
+          if [ -n "$MISMATCHED" ]; then
+            echo "::error::SKILL.md version mismatches:$MISMATCHED"
+            exit 1
+          fi
+
+      - name: Generate skills list
+        id: skills
+        run: |
+          {
+            echo "list<<EOF"
+            jq -r '.skills[]' .github/.release-manifest.json | sed 's/^/- /'
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update release with skills list
+        uses: softprops/action-gh-release@v2
+        with:
+          append_body: true
+          body: |
+            ### Skills included
+            ${{ steps.skills.outputs.list }}

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -1,12 +1,22 @@
+---
 name: Skill Evaluations
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - "skills/**"
-      - "evaluations/**"
-      - "scripts/**"
+  workflow_call:
+    inputs:
+      model:
+        description: "Model to use for evaluations"
+        required: false
+        type: string
+        default: "sonnet"
+      skip_baseline:
+        description: "Skip without-skill baseline runs"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       model:
@@ -95,13 +105,17 @@ jobs:
 
           if [ "$EVAL_CONFIG" = "with_skill" ]; then
             {
-              printf '%s\n' "Read the skill at skills/schema-creator/SKILL.md and follow its workflow and rules to accomplish this task."
+              MSG="Read the skill at skills/schema-creator/SKILL.md"
+              MSG="$MSG and follow its workflow and rules to accomplish this task."
+              printf '%s\n' "$MSG"
               printf '\n%s %s\n' "Task:" "$EVAL_PROMPT"
               printf '\n%s %s/schema.yml\n' "Save ONLY the final schema YAML file to:" "$OUTPUT_DIR"
             } > /tmp/eval_prompt.txt
           else
             {
-              printf '%s\n' "Do NOT read any files from the skills/ directory. Use only your general knowledge of Infrahub."
+              MSG="Do NOT read any files from the skills/ directory."
+              MSG="$MSG Use only your general knowledge of Infrahub."
+              printf '%s\n' "$MSG"
               printf '\n%s %s\n' "Task:" "$EVAL_PROMPT"
               printf '\n%s %s/schema.yml\n' "Save ONLY the final schema YAML file to:" "$OUTPUT_DIR"
             } > /tmp/eval_prompt.txt
@@ -122,12 +136,6 @@ jobs:
             --model ${{ inputs.model || 'sonnet' }}
             --max-turns 25
             --allowedTools "Read,Write,Edit,Glob,Grep,Bash"
-          # NOTE: For skills that need Infrahub access (check-creator,
-          # generator-creator, etc.), add infrahub-mcp via --mcp-config:
-          #
-          # claude_args: |
-          #   --mcp-config '{"mcpServers":{"infrahub":{"command":"uvx","args":["infrahub-mcp"],"env":{"INFRAHUB_ADDRESS":"${{ secrets.INFRAHUB_ADDRESS }}","INFRAHUB_API_TOKEN":"${{ secrets.INFRAHUB_API_TOKEN }}"}}}}'
-          #   --allowedTools "Read,Write,Edit,Glob,Grep,Bash,mcp__infrahub__*"
 
       - name: Upload eval output
         if: always()
@@ -179,7 +187,7 @@ jobs:
             --output-dir eval-report
 
       - name: Post evaluation summary as PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event.pull_request != null
         uses: actions/github-script@v7
         with:
           script: |
@@ -197,7 +205,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: context.payload.pull_request.number,
             });
             const existing = comments.find(c => c.body.includes(marker));
 
@@ -212,7 +220,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: context.payload.pull_request.number,
                 body,
               });
             }

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,48 @@
+---
+name: Sync documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "dev/guides/**"
+      - "README.md"
+  workflow_dispatch:
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: source
+
+      - uses: actions/checkout@v6
+        with:
+          repository: opsmill/infrahub-docs
+          token: ${{ secrets.PAT_TOKEN }}
+          path: docs-repo
+          ref: main
+
+      - name: Sync documentation
+        run: |
+          TARGET_DIR="docs-repo/docs/integrations/skills"
+          mkdir -p "$TARGET_DIR"
+          rsync -av --delete \
+            source/docs/ \
+            "$TARGET_DIR/"
+          cp source/README.md "$TARGET_DIR/index.md"
+
+      - name: Commit and push
+        working-directory: docs-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to sync"
+            exit 0
+          fi
+          git commit -m "docs: sync infrahub-skills documentation"
+          git push

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -1,0 +1,41 @@
+---
+name: Version sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".claude-plugin/plugin.json"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from plugin.json
+        id: version
+        run: |
+          VERSION=$(jq -r .version .claude-plugin/plugin.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Sync versions
+        run: bash scripts/sync-versions.sh "${{ steps.version.outputs.version }}"
+
+      - name: Commit changes if any
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add skills/*/SKILL.md .github/.release-manifest.json
+          if git diff --staged --quiet; then
+            echo "All versions already in sync"
+            exit 0
+          fi
+          git commit -m "chore: sync version to ${{ steps.version.outputs.version }}"
+          git push

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+  truthy:
+    check-keys: false

--- a/README.md
+++ b/README.md
@@ -229,10 +229,14 @@ SKILL.md, rules/
 
 **Name:** `infrahub-analyst`
 
-Analyze and correlate live Infrahub data using the MCP server to answer operational questions on demand.
+Analyze and correlate live Infrahub data using the
+MCP server to answer operational questions on demand.
 
 **Capabilities:**
-- Answer operational questions interactively ("which devices are in tonight's maintenance window?")
+
+- Answer operational questions interactively
+  ("which devices are in tonight's maintenance
+  window?")
 - Correlate data across multiple node types (services, BGP sessions, prefixes, devices)
 - Investigate service impact and blast radius before a change
 - Detect drift between design intent and realized objects

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:?Usage: sync-versions.sh <version>}"
+
+echo "Syncing version to: $VERSION"
+
+# Update all SKILL.md frontmatter metadata version fields.
+# The 2-space indent targets only the frontmatter "  version: X.Y.Z"
+# under the metadata: block, not schema examples like version: "1.0".
+for f in skills/*/SKILL.md; do
+  if [ -f "$f" ]; then
+    sed -i.bak "s/^  version: .*/  version: $VERSION/" "$f" && rm -f "${f}.bak"
+    echo "  Updated: $f"
+  fi
+done
+
+# Update .github/.release-manifest.json
+if [ -f ".github/.release-manifest.json" ]; then
+  jq --arg v "$VERSION" '.version = $v' .github/.release-manifest.json > /tmp/release-manifest.json \
+    && mv /tmp/release-manifest.json .github/.release-manifest.json
+  echo "  Updated: .github/.release-manifest.json"
+fi
+
+echo "Done."

--- a/skills/analyst/SKILL.md
+++ b/skills/analyst/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: infrahub-analyst
-description: Analyze and correlate Infrahub data using the MCP server. Use when querying live infrastructure data to answer operational questions, detect drift, correlate node types, investigate service impact, check maintenance windows, or produce ad-hoc reports — without writing pipeline code.
+description: >-
+  Analyze and correlate Infrahub data using the
+  MCP server. Use when querying live infrastructure
+  data to answer operational questions, detect drift,
+  correlate node types, investigate service impact,
+  check maintenance windows, or produce ad-hoc
+  reports — without writing pipeline code.
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -8,45 +14,73 @@ metadata:
 
 ## Overview
 
-Expert guidance for interactive data analysis against a live Infrahub instance. This skill uses the **Infrahub MCP server** to query, correlate, and reason over infrastructure data on demand — answering operational questions that span multiple node types and relationships.
+Expert guidance for interactive data analysis
+against a live Infrahub instance. This skill uses
+the **Infrahub MCP server** to query, correlate,
+and reason over infrastructure data on demand —
+answering operational questions that span multiple
+node types and relationships.
 
-Use this skill for any question of the form *"what does Infrahub currently know about X, and how does it relate to Y?"*
+Use this skill for any question of the form
+*"what does Infrahub currently know about X,
+and how does it relate to Y?"*
 
 Typical question patterns:
 
-- **Compliance** — "Are all devices following the naming convention?"
-- **Service impact** — "Which services are hosted on devices in this rack?"
-- **Maintenance windows** — "Which devices are currently in a maintenance window, and what depends on them?"
-- **Drift detection** — "Which realized devices differ from their topology design?"
+- **Compliance** — "Are all devices following
+  the naming convention?"
+- **Service impact** — "Which services are hosted
+  on devices in this rack?"
+- **Maintenance windows** — "Which devices are
+  currently in a maintenance window, and what
+  depends on them?"
+- **Drift detection** — "Which realized devices
+  differ from their topology design?"
 - **Capacity** — "Which racks are over 80% full?"
-- **Change impact** — "What BGP sessions, services, and IPs depend on this prefix?"
-- **Inventory gaps** — "Which devices have no platform or OS version recorded?"
+- **Change impact** — "What BGP sessions, services,
+  and IPs depend on this prefix?"
+- **Inventory gaps** — "Which devices have no
+  platform or OS version recorded?"
 
-For **automated, pipeline-enforced** checks that block proposed changes, see `../check-creator/SKILL.md`.
-For **repeatable scheduled reports** exported as artifacts, see `../transform-creator/SKILL.md`.
+For **automated, pipeline-enforced** checks that
+block proposed changes, see
+`../check-creator/SKILL.md`.
+For **repeatable scheduled reports** exported as
+artifacts, see `../transform-creator/SKILL.md`.
 
 ## When to Use
 
-- Answering operational questions interactively via natural language
-- Cross-referencing two or more node types to find relationships or gaps
-- Investigating the blast radius of a change before executing it
+- Answering operational questions interactively
+  via natural language
+- Cross-referencing two or more node types to find
+  relationships or gaps
+- Investigating the blast radius of a change before
+  executing it
 - Auditing data quality across the inventory
-- Producing one-time or on-demand reports for stakeholders
-- Exploring schema structure and data before writing a generator or check
+- Producing one-time or on-demand reports for
+  stakeholders
+- Exploring schema structure and data before writing
+  a generator or check
 
 ## How It Works
 
-The Infrahub MCP server exposes tools that let Claude query Infrahub data directly. The typical workflow:
+The Infrahub MCP server exposes tools that let
+Claude query Infrahub data directly.
+The typical workflow:
 
-1. **Query** — use MCP tools to fetch current state from Infrahub
-2. **Correlate** — join, diff, or filter the data against a policy or second dataset
-3. **Reason** — identify gaps, anomalies, or relationships
-4. **Report** — surface findings with context and remediation hints
+1. **Query** — use MCP tools to fetch current state
+   from Infrahub
+2. **Correlate** — join, diff, or filter the data
+   against a policy or second dataset
+3. **Reason** — identify gaps, anomalies, or
+   relationships
+4. **Report** — surface findings with context and
+   remediation hints
 
 ## Rule Categories
 
 | Priority | Category | Prefix | Description |
-|----------|----------|--------|-------------|
+| -------- | -------- | ------ | ----------- |
 | CRITICAL | MCP Tools | `mcp-` | Available Infrahub MCP tools, invocation patterns, response structure |
 | CRITICAL | Query Patterns | `query-` | GraphQL structures for fetching, filtering, and traversing relationships |
 | HIGH | Correlation | `correlation-` | Joining, diffing, and reasoning over data from multiple queries |
@@ -55,16 +89,23 @@ The Infrahub MCP server exposes tools that let Claude query Infrahub data direct
 
 ## MCP Server Basics
 
-When the Infrahub MCP server is connected, Claude can call tools such as:
+When the Infrahub MCP server is connected, Claude
+can call tools such as:
 
-- **`mcp__infrahub__infrahub_query`** — Execute a GraphQL query (primary tool)
-- **`mcp__infrahub__infrahub_list_schema`** — List available node kinds
-- **`mcp__infrahub__infrahub_get`** — Retrieve a specific object by ID or filters
-- **`mcp__infrahub__infrahub_create`** — Create an object (remediation, on a branch)
-- **`mcp__infrahub__infrahub_update`** — Update an object (remediation, on a branch)
+- **`mcp__infrahub__infrahub_query`** — Execute a
+  GraphQL query (primary tool)
+- **`mcp__infrahub__infrahub_list_schema`** — List
+  available node kinds
+- **`mcp__infrahub__infrahub_get`** — Retrieve a
+  specific object by ID or filters
+- **`mcp__infrahub__infrahub_create`** — Create an
+  object (remediation, on a branch)
+- **`mcp__infrahub__infrahub_update`** — Update an
+  object (remediation, on a branch)
 
 ```graphql
-# Example: find all devices in an active maintenance window
+# Example: find all devices in an active
+# maintenance window
 query MaintenanceDevices {
   MaintenanceWindow(status__value: "active") {
     edges {
@@ -91,28 +132,39 @@ query MaintenanceDevices {
 
 ## Typical Analysis Workflow
 
-```
+```text
 1. Understand the question
-   → "Which services depend on devices currently in a maintenance window?"
+   → "Which services depend on devices currently
+      in a maintenance window?"
 
 2. Identify the node types involved
-   → MaintenanceWindow, DcimDevice, Service (or equivalent in your schema)
+   → MaintenanceWindow, DcimDevice, Service
+     (or equivalent in your schema)
 
 3. Query current state
-   → mcp__infrahub__infrahub_query — one query per node type, or combined
+   → mcp__infrahub__infrahub_query — one query
+     per node type, or combined
 
 4. Correlate the data
    → Join across node types, filter, count, diff
 
 5. Report findings
-   → Summarize with counts, list affected objects, suggest next steps
+   → Summarize with counts, list affected objects,
+     suggest next steps
 ```
 
 ## Supporting References
 
-- **[examples.md](./examples.md)** — Analysis patterns (naming, VLAN, BGP, maintenance, service impact)
-- **[../common/graphql-queries.md](../common/graphql-queries.md)** — GraphQL query writing reference
-- **[../common/infrahub-yml-reference.md](../common/infrahub-yml-reference.md)** — .infrahub.yml project configuration
-- **[../check-creator/SKILL.md](../check-creator/SKILL.md)** — Automated pipeline checks (for enforcement)
-- **[../transform-creator/SKILL.md](../transform-creator/SKILL.md)** — Transforms for scheduled report artifacts
-- **[rules/](./rules/)** — Individual rules organized by category prefix
+- **[examples.md](./examples.md)** — Analysis
+  patterns (naming, VLAN, BGP, maintenance,
+  service impact)
+- **[../common/graphql-queries.md](../common/graphql-queries.md)**
+  — GraphQL query writing reference
+- **[../common/infrahub-yml-reference.md](../common/infrahub-yml-reference.md)**
+  — .infrahub.yml project configuration
+- **[../check-creator/SKILL.md](../check-creator/SKILL.md)**
+  — Automated pipeline checks (for enforcement)
+- **[../transform-creator/SKILL.md](../transform-creator/SKILL.md)**
+  — Transforms for scheduled report artifacts
+- **[rules/](./rules/)** — Individual rules organized
+  by category prefix

--- a/skills/analyst/examples.md
+++ b/skills/analyst/examples.md
@@ -1,12 +1,15 @@
 # Infrahub Analyst Examples
 
-Real-world analysis and correlation patterns using the Infrahub MCP server.
+Real-world analysis and correlation patterns using
+the Infrahub MCP server.
 
 ---
 
 ## 1. Device Naming Convention Compliance
 
-Verify all devices follow the naming standard `<site>-<role>-<number>` (e.g., `par01-spine-01`).
+Verify all devices follow the naming standard
+`<site>-<role>-<number>`
+(e.g., `par01-spine-01`).
 
 ### Step 1 — Query all devices
 
@@ -30,41 +33,51 @@ query DeviceNamingCompliance {
 }
 ```
 
-Use `mcp__infrahub__infrahub_query` with the above query.
+Use `mcp__infrahub__infrahub_query` with the
+above query.
 
 ### Step 2 — Correlate against policy
 
-Claude evaluates each device name against the pattern `^[a-z]{3}[0-9]{2}-[a-z]+-[0-9]{2}$`:
+Claude evaluates each device name against the
+pattern `^[a-z]{3}[0-9]{2}-[a-z]+-[0-9]{2}$`:
 
-```
+```text
 COMPLIANT:   par01-spine-01, lon02-leaf-03
-VIOLATION:   SPINE-01 (uppercase), spine-01 (missing site prefix)
+VIOLATION:   SPINE-01 (uppercase),
+             spine-01 (missing site prefix)
 ```
 
 ### Step 3 — Report findings
 
-```
+```text
 Naming Convention Compliance Report
 ────────────────────────────────────
-Policy:      <site><nn>-<role>-<nn> (e.g., par01-spine-01)
+Policy:      <site><nn>-<role>-<nn>
+             (e.g., par01-spine-01)
 Checked:     47 devices
 Compliant:   43
 Violations:  4
 
 Non-compliant devices:
-  ✗ SPINE-01  [id: abc123]  — uppercase, missing site prefix
-  ✗ spine-01  [id: def456]  — missing site prefix
-  ✗ Leaf_03   [id: ghi789]  — underscore not allowed
-  ✗ par01-leaf  [id: jkl012]  — missing sequence number
+  ✗ SPINE-01  [id: abc123]
+    — uppercase, missing site prefix
+  ✗ spine-01  [id: def456]
+    — missing site prefix
+  ✗ Leaf_03   [id: ghi789]
+    — underscore not allowed
+  ✗ par01-leaf  [id: jkl012]
+    — missing sequence number
 
-Remediation: Rename via Infrahub UI or use mcp__infrahub__infrahub_update
+Remediation: Rename via Infrahub UI or use
+mcp__infrahub__infrahub_update
 ```
 
 ---
 
 ## 2. VLAN Assignment Compliance
 
-Verify all VLANs in use on devices are from the approved VLAN list stored in Infrahub.
+Verify all VLANs in use on devices are from the
+approved VLAN list stored in Infrahub.
 
 ### Step 1 — Query approved VLANs
 
@@ -129,9 +142,10 @@ query InterfaceVlans {
 
 ### Step 3 — Cross-reference
 
-Build the approved VLAN set per site, then check each interface's VLANs against that set:
+Build the approved VLAN set per site, then check
+each interface's VLANs against that set:
 
-```
+```text
 VLAN Compliance Report
 ──────────────────────
 Site: PAR01
@@ -141,8 +155,10 @@ Site: PAR01
   Violations: 4
 
   Non-compliant interfaces:
-    ✗ par01-leaf-01 / Eth1/10 — VLAN 999 not in approved list
-    ✗ par01-leaf-02 / Eth1/5  — VLAN 50 not in approved list
+    ✗ par01-leaf-01 / Eth1/10
+      — VLAN 999 not in approved list
+    ✗ par01-leaf-02 / Eth1/5
+      — VLAN 50 not in approved list
     ...
 ```
 
@@ -150,7 +166,10 @@ Site: PAR01
 
 ## 3. BGP Peer Correlation
 
-Verify each BGP session has a matching IP prefix-list for route filtering, and that the peer AS matches the expected ASN from the neighbor's device record.
+Verify each BGP session has a matching IP
+prefix-list for route filtering, and that the
+peer AS matches the expected ASN from the
+neighbor's device record.
 
 ### Step 1 — Query BGP sessions
 
@@ -207,14 +226,14 @@ query BgpSessions {
 Claude evaluates each session:
 
 | Check | Policy |
-|-------|--------|
+| ----- | ------ |
 | Prefix lists present | Each active session must have ≥1 import and ≥1 export prefix-list |
 | Session symmetry | For every session on device A to device B, a reverse session must exist |
 | Status | All sessions with `status: active` must have both sides configured |
 
 ### Step 3 — Report
 
-```
+```text
 BGP Session Compliance Report
 ──────────────────────────────
 Sessions checked: 24
@@ -222,20 +241,29 @@ Fully compliant: 19
 Violations: 5
 
 Missing prefix-lists (3):
-  ✗ par01-spine-01 → lon02-spine-01 — no import prefix-list
-  ✗ par01-spine-02 → lon02-spine-01 — no export prefix-list
-  ✗ par01-leaf-03 → par01-spine-01  — no prefix-lists at all
+  ✗ par01-spine-01 → lon02-spine-01
+    — no import prefix-list
+  ✗ par01-spine-02 → lon02-spine-01
+    — no export prefix-list
+  ✗ par01-leaf-03 → par01-spine-01
+    — no prefix-lists at all
 
 Asymmetric sessions (2):
-  ✗ par01-leaf-05 → par01-spine-02 — no reverse session found on par01-spine-02
-  ✗ lon02-leaf-01 → lon02-spine-03 — reverse session exists but status: disabled
+  ✗ par01-leaf-05 → par01-spine-02
+    — no reverse session found
+      on par01-spine-02
+  ✗ lon02-leaf-01 → lon02-spine-03
+    — reverse session exists but
+      status: disabled
 ```
 
 ---
 
 ## 4. IP Address Space Compliance
 
-Verify all device loopback IPs are allocated from the approved loopback prefix, and identify any rogue IPs.
+Verify all device loopback IPs are allocated from
+the approved loopback prefix, and identify any
+rogue IPs.
 
 ### Step 1 — Query approved prefix
 
@@ -291,28 +319,36 @@ query LoopbackIPs {
 
 ### Step 3 — Validate containment
 
-Claude checks each loopback IP is contained within the approved prefix for its site:
+Claude checks each loopback IP is contained within
+the approved prefix for its site:
 
-```
+```text
 IP Space Compliance Report
 ───────────────────────────
-Approved loopback prefix: 10.0.0.0/24 (site: PAR01)
+Approved loopback prefix:
+  10.0.0.0/24 (site: PAR01)
 Loopback IPs checked: 22
 Compliant: 20
 Violations: 2
 
 Rogue IPs (not in approved prefix):
-  ✗ par01-leaf-07 / Loopback0 — 192.168.100.5/32 (not in 10.0.0.0/24)
+  ✗ par01-leaf-07 / Loopback0
+    — 192.168.100.5/32
+      (not in 10.0.0.0/24)
 
-Missing loopbacks (devices with no Loopback0):
-  ✗ par01-leaf-09 — no Loopback0 interface found
+Missing loopbacks
+(devices with no Loopback0):
+  ✗ par01-leaf-09
+    — no Loopback0 interface found
 ```
 
 ---
 
 ## 5. Design-to-Reality Correlation
 
-Verify that generator-created objects match their design intent by comparing design nodes to realized objects.
+Verify that generator-created objects match their
+design intent by comparing design nodes to
+realized objects.
 
 ### Step 1 — Query topology designs
 
@@ -366,27 +402,34 @@ query RealizedDevices($topology: String!) {
 
 ### Step 3 — Diff design vs reality
 
-```
-Design Compliance Report: topology-par01-core
-──────────────────────────────────────────────
+```text
+Design Compliance Report:
+  topology-par01-core
+──────────────────────────────────────────
 Expected devices: 6 (2 spines, 4 leafs)
 Realized devices: 5
 
 Missing from reality:
-  ✗ par01-leaf-04 (role: leaf, type: Arista7050CX3)
+  ✗ par01-leaf-04
+    (role: leaf, type: Arista7050CX3)
 
 Extra in reality (not in design):
-  ✗ par01-mgmt-01 (role: management) — not defined in topology design
+  ✗ par01-mgmt-01 (role: management)
+    — not defined in topology design
 
 Device type mismatches:
-  ✗ par01-leaf-02 — expected: Arista7050CX3, actual: Arista7280CR3
+  ✗ par01-leaf-02
+    — expected: Arista7050CX3,
+      actual: Arista7280CR3
 ```
 
 ---
 
 ## 6. Maintenance Window Impact Analysis
 
-Find all devices currently in an active maintenance window and surface which services and BGP sessions are affected.
+Find all devices currently in an active maintenance
+window and surface which services and BGP sessions
+are affected.
 
 ### Step 1 — Query active maintenance windows
 
@@ -421,7 +464,9 @@ query ActiveMaintenanceWindows {
 
 ```graphql
 query DeviceServices($device: String!) {
-  ServiceInstance(device__name__value: $device) {
+  ServiceInstance(
+    device__name__value: $device
+  ) {
     edges {
       node {
         id
@@ -445,9 +490,10 @@ Run this query for each device found in Step 1.
 
 ### Step 3 — Report
 
-```
-Maintenance Window Impact Report — 2026-03-13 14:00 UTC
-═══════════════════════════════════════════════════════
+```text
+Maintenance Window Impact Report
+  — 2026-03-13 14:00 UTC
+══════════════════════════════════
 Active windows: 1
 
   Window: MW-2026-03-13-PAR01-CORE
@@ -455,28 +501,37 @@ Active windows: 1
   Devices in scope: 2
 
   par01-spine-01 (spine, PAR01)
-    BGP sessions:    4 active (will be impacted)
+    BGP sessions:    4 active
+                     (will be impacted)
     Services:        3
-      • SVC-MPLS-CustA  [status: active]  — Customer: Acme Corp
-      • SVC-MPLS-CustB  [status: active]  — Customer: Globex
-      • SVC-INTERNET-01 [status: active]  — Customer: Initech
+      • SVC-MPLS-CustA  [active]
+        — Customer: Acme Corp
+      • SVC-MPLS-CustB  [active]
+        — Customer: Globex
+      • SVC-INTERNET-01 [active]
+        — Customer: Initech
 
   par01-spine-02 (spine, PAR01)
-    BGP sessions:    4 active (will be impacted)
+    BGP sessions:    4 active
+                     (will be impacted)
     Services:        1
-      • SVC-INTERNET-02 [status: active]  — Customer: Initech
+      • SVC-INTERNET-02 [active]
+        — Customer: Initech
 
-  ─────────────────────────────────────────
+  ─────────────────────────────────
   Total affected services: 4
-  Total affected customers: 3 (Acme Corp, Globex, Initech)
-  Recommendation: Notify affected customers before window starts.
+  Total affected customers: 3
+    (Acme Corp, Globex, Initech)
+  Recommendation: Notify affected
+    customers before window starts.
 ```
 
 ---
 
 ## 7. Service Impact Analysis for a Planned Change
 
-Before changing a prefix or interface, identify everything that depends on it.
+Before changing a prefix or interface, identify
+everything that depends on it.
 
 ### Step 1 — Query the prefix and its consumers
 
@@ -515,60 +570,72 @@ query PrefixImpact($prefix: String!) {
 
 ### Step 2 — Report blast radius
 
-```
-Change Impact Analysis — Prefix 10.0.1.0/24
-════════════════════════════════════════════
+```text
+Change Impact Analysis
+  — Prefix 10.0.1.0/24
+════════════════════════════════════
 Role:    transit
 Status:  active
 
 IP addresses allocated: 6
-  10.0.1.1/30  →  par01-spine-01 / Eth1/1
-  10.0.1.2/30  →  lon02-spine-01 / Eth1/1   (peer)
-  10.0.1.5/30  →  par01-spine-01 / Eth1/2
-  10.0.1.6/30  →  lon02-spine-02 / Eth1/1   (peer)
+  10.0.1.1/30
+    → par01-spine-01 / Eth1/1
+  10.0.1.2/30
+    → lon02-spine-01 / Eth1/1 (peer)
+  10.0.1.5/30
+    → par01-spine-01 / Eth1/2
+  10.0.1.6/30
+    → lon02-spine-02 / Eth1/1 (peer)
   ...
 
 BGP sessions using IPs from this prefix: 4
 Services riding these BGP sessions: 7
 
-⚠ Changing or withdrawing this prefix will affect 4 BGP sessions
-  and potentially 7 services. Create a maintenance window and
-  notify affected customers before proceeding.
+⚠ Changing or withdrawing this prefix
+  will affect 4 BGP sessions and
+  potentially 7 services. Create a
+  maintenance window and notify affected
+  customers before proceeding.
 ```
 
 ---
 
 ## 8. Multi-Check Analysis Run
 
-Run several analysis checks in sequence and produce a consolidated report.
+Run several analysis checks in sequence and
+produce a consolidated report.
 
 ### Prompt pattern
 
-```
+```text
 Run a full analysis for site PAR01. Check:
-1. Device naming convention (<site><nn>-<role>-<nn>)
+1. Device naming convention
+   (<site><nn>-<role>-<nn>)
 2. All active interfaces have a description
 3. All devices have a platform assigned
-4. All loopback IPs are from the approved 10.0.0.0/24 prefix
+4. All loopback IPs are from the approved
+   10.0.0.0/24 prefix
 ```
 
 Claude will:
-1. Run `mcp__infrahub__infrahub_query` once per area (or combine into fewer queries)
+
+1. Run `mcp__infrahub__infrahub_query` once per
+   area (or combine into fewer queries)
 2. Evaluate each check independently
 3. Produce a consolidated summary
 
 ### Consolidated report format
 
-```
+```text
 Analysis Summary — PAR01 — 2026-03-13
 ──────────────────────────────────────
-                              Checked  Pass  Fail  Status
-─────────────────────────────────────────────────────────
-Naming Convention              47       43    4     ⚠ WARN
-Interface Descriptions         312     298   14     ⚠ WARN
-Platform Assignment             47       47    0     ✓ PASS
-Loopback IP Space               22       20    2     ⚠ WARN
-─────────────────────────────────────────────────────────
+                          Checked Pass Fail Status
+──────────────────────────────────────────────────
+Naming Convention          47      43   4   ⚠ WARN
+Interface Descriptions    312     298  14   ⚠ WARN
+Platform Assignment        47      47   0   ✓ PASS
+Loopback IP Space          22      20   2   ⚠ WARN
+──────────────────────────────────────────────────
 Overall: 408/428 (95.3%)
 
 See detailed findings above for remediation steps.
@@ -579,7 +646,7 @@ See detailed findings above for remediation steps.
 ## Complete MCP Tool Invocation Reference
 
 | Scenario | MCP Tool | Key Arguments |
-|----------|----------|--------------|
+| -------- | -------- | ------------- |
 | Query objects | `mcp__infrahub__infrahub_query` | `query` (GraphQL string) |
 | List schema kinds | `mcp__infrahub__infrahub_list_schema` | none |
 | Get one object | `mcp__infrahub__infrahub_get` | `kind`, `id` or filters |

--- a/skills/analyst/rules/_sections.md
+++ b/skills/analyst/rules/_sections.md
@@ -1,11 +1,37 @@
 # Infrahub Analyst - Rule Sections
 
-1. **MCP Tools (mcp-)** — CRITICAL. Available Infrahub MCP server tools, invocation patterns, how to pass GraphQL queries, and interpreting responses. Required before running any analysis query.
+1. **MCP Tools (mcp-)** — CRITICAL. Available
+   Infrahub MCP server tools, invocation patterns,
+   how to pass GraphQL queries, and interpreting
+   responses. Required before running any analysis
+   query.
 
-2. **Query Patterns (query-)** — CRITICAL. GraphQL structures for analysis use cases: fetching all objects of a kind, filtering by attribute, traversing relationships across node types. Getting queries right determines what data is available for correlation.
+2. **Query Patterns (query-)** — CRITICAL. GraphQL
+   structures for analysis use cases: fetching all
+   objects of a kind, filtering by attribute,
+   traversing relationships across node types.
+   Getting queries right determines what data is
+   available for correlation.
 
-3. **Correlation (correlation-)** — HIGH. Techniques for matching, diffing, and joining data returned from multiple MCP queries: set operations, ID-based joins, attribute lookups, design-to-reality comparison, and service impact tracing. Correlation logic is where findings are identified.
+3. **Correlation (correlation-)** — HIGH. Techniques
+   for matching, diffing, and joining data returned
+   from multiple MCP queries: set operations,
+   ID-based joins, attribute lookups,
+   design-to-reality comparison, and service impact
+   tracing. Correlation logic is where findings are
+   identified.
 
-4. **Reporting Output (reporting-)** — HIGH. Presenting findings clearly: summary tables with counts, per-object detail, remediation hints, and structured output for stakeholders. Good reporting makes analysis findings actionable.
+4. **Reporting Output (reporting-)** — HIGH.
+   Presenting findings clearly: summary tables with
+   counts, per-object detail, remediation hints,
+   and structured output for stakeholders. Good
+   reporting makes analysis findings actionable.
 
-5. **Approach Selection (approach-)** — MEDIUM. Decision guide for choosing between interactive MCP analysis (this skill), automated InfrahubCheck (check-creator), or artifact-producing Transform (transform-creator). Each has different trade-offs around automation, enforcement, and repeatability.
+5. **Approach Selection (approach-)** — MEDIUM.
+   Decision guide for choosing between interactive
+   MCP analysis (this skill), automated
+   InfrahubCheck (check-creator), or
+   artifact-producing Transform
+   (transform-creator). Each has different
+   trade-offs around automation, enforcement, and
+   repeatability.

--- a/skills/analyst/rules/_template.md
+++ b/skills/analyst/rules/_template.md
@@ -6,9 +6,10 @@ tags: tag1, tag2
 
 ## Rule Title Here
 
-**Impact: MEDIUM**
+Impact: MEDIUM
 
-Brief explanation of the rule and why it matters for Infrahub compliance analysis.
+Brief explanation of the rule and why it matters
+for Infrahub compliance analysis.
 
 **Incorrect:**
 
@@ -22,4 +23,5 @@ Brief explanation of the rule and why it matters for Infrahub compliance analysi
 # Good example
 ```
 
-Reference: [Infrahub Docs](https://docs.infrahub.app)
+Reference:
+[Infrahub Docs](https://docs.infrahub.app)

--- a/skills/analyst/rules/approach-selection.md
+++ b/skills/analyst/rules/approach-selection.md
@@ -6,16 +6,19 @@ tags: approach, mcp, check, transform, decision
 
 ## Choosing the Right Approach
 
-**Impact: MEDIUM**
+Impact: MEDIUM
 
-Infrahub offers three distinct ways to analyze data and surface findings. Picking the right one avoids over-engineering simple tasks and under-engineering recurring ones.
+Infrahub offers three distinct ways to analyze data
+and surface findings. Picking the right one avoids
+over-engineering simple tasks and under-engineering
+recurring ones.
 
 ---
 
 ### Decision Table
 
 | Criterion | MCP Analysis (this skill) | InfrahubCheck | Transform + Artifact |
-|-----------|--------------------------|---------------|----------------------|
+| --------- | ------------------------- | ------------- | -------------------- |
 | **Trigger** | On demand, conversational | Every proposed change | Scheduled or on demand |
 | **Enforcement** | None (informational) | Blocks merge on failure | None (output only) |
 | **Automation** | Manual (Claude + human) | Fully automated | Fully automated |
@@ -25,49 +28,69 @@ Infrahub offers three distinct ways to analyze data and surface findings. Pickin
 
 ---
 
-### Use MCP Analysis (this skill) when:
+### Use MCP Analysis (this skill) when
 
-- You need to answer a one-off question ("what's broken right now?")
-- You're exploring the data model before writing a check or generator
+- You need to answer a one-off question
+  ("what's broken right now?")
+- You're exploring the data model before writing
+  a check or generator
 - The policy is informal or still being defined
 - You want immediate results without writing code
-- The analysis involves reasoning that's hard to express as a pure pass/fail rule
-- You need to investigate a specific incident or change impact
+- The analysis involves reasoning that's hard to
+  express as a pure pass/fail rule
+- You need to investigate a specific incident or
+  change impact
 
 **Example prompts:**
-- "Which devices are in the PAR01 maintenance window starting tonight?"
-- "Show me all BGP sessions missing a prefix-list"
-- "What services depend on devices in rack PAR01-A01?"
+
+- "Which devices are in the PAR01 maintenance
+  window starting tonight?"
+- "Show me all BGP sessions missing a
+  prefix-list"
+- "What services depend on devices in rack
+  PAR01-A01?"
 
 ---
 
-### Use InfrahubCheck when:
+### Use InfrahubCheck when
 
-- The policy is stable and should be enforced automatically
-- You want to **block** non-compliant proposed changes from merging
-- The check needs to run on every change without human involvement
-- The validation logic can be expressed as Python + GraphQL
+- The policy is stable and should be enforced
+  automatically
+- You want to **block** non-compliant proposed
+  changes from merging
+- The check needs to run on every change without
+  human involvement
+- The validation logic can be expressed as
+  Python + GraphQL
 
 **Example policies suited to checks:**
+
 - Rack unit collision detection
-- Required interface description on all active interfaces
+- Required interface description on all active
+  interfaces
 - Loopback IP must be from the approved prefix
 
 See `../check-creator/SKILL.md` to implement.
 
 ---
 
-### Use Transform + Artifact when:
+### Use Transform + Artifact when
 
-- You need a recurring report (daily, weekly, per proposed change)
-- Stakeholders need the output as a file (CSV, HTML, JSON)
-- The report is identical every time it runs, just with fresh data
-- You want to attach the compliance snapshot to a proposed change for review
+- You need a recurring report (daily, weekly,
+  per proposed change)
+- Stakeholders need the output as a file
+  (CSV, HTML, JSON)
+- The report is identical every time it runs,
+  just with fresh data
+- You want to attach the compliance snapshot to
+  a proposed change for review
 
 **Example use cases:**
+
 - Weekly IP address utilization report
 - Pre-change device inventory export
-- Nightly audit of naming convention violations as CSV
+- Nightly audit of naming convention violations
+  as CSV
 
 See `../transform-creator/SKILL.md` to implement.
 
@@ -75,16 +98,25 @@ See `../transform-creator/SKILL.md` to implement.
 
 ### Common Escalation Path
 
-Start with MCP analysis to understand the problem, then escalate:
+Start with MCP analysis to understand the problem,
+then escalate:
 
-```
-1. MCP Analysis     — explore and define the policy interactively
+```text
+1. MCP Analysis
+   — explore and define the policy interactively
        ↓
-2. InfrahubCheck    — enforce it automatically on proposed changes
+2. InfrahubCheck
+   — enforce it automatically on proposed changes
        ↓
-3. Transform        — export a recurring report for stakeholders
+3. Transform
+   — export a recurring report for stakeholders
 ```
 
-You don't have to go through all three steps — stop at whichever level of automation is appropriate.
+You don't have to go through all three steps —
+stop at whichever level of automation is
+appropriate.
 
-Reference: [Infrahub Check Docs](https://docs.infrahub.app/topics/check) · [Infrahub Artifact Docs](https://docs.infrahub.app/topics/artifact)
+Reference:
+[Infrahub Check Docs](https://docs.infrahub.app/topics/check)
+·
+[Infrahub Artifact Docs](https://docs.infrahub.app/topics/artifact)

--- a/skills/analyst/rules/correlation-patterns.md
+++ b/skills/analyst/rules/correlation-patterns.md
@@ -6,17 +6,23 @@ tags: correlation, diffing, joining, policy
 
 ## Data Correlation Patterns
 
-**Impact: HIGH**
+Impact: HIGH
 
-Correlation is the core step of compliance analysis: taking data returned from one or more MCP queries and comparing it against a policy to find violations. These patterns cover the most common correlation techniques.
+Correlation is the core step of compliance analysis:
+taking data returned from one or more MCP queries
+and comparing it against a policy to find violations.
+These patterns cover the most common correlation
+techniques.
 
 ---
 
 ### Pattern 1: Membership Check (Allow-list)
 
-Verify each item in "current state" is present in an approved set.
+Verify each item in "current state" is present in
+an approved set.
 
-**Use case:** VLANs on interfaces must be from the approved VLAN list.
+**Use case:** VLANs on interfaces must be from the
+approved VLAN list.
 
 ```python
 # Build approved set from policy query
@@ -45,9 +51,11 @@ for edge in state_response["DcimInterface"]["edges"]:
 
 ### Pattern 2: Attribute Pattern Match (Regex)
 
-Verify object names or attributes conform to a naming convention.
+Verify object names or attributes conform to a
+naming convention.
 
-**Use case:** Device names must match `^[a-z]{3}[0-9]{2}-[a-z]+-[0-9]{2}$`.
+**Use case:** Device names must match
+`^[a-z]{3}[0-9]{2}-[a-z]+-[0-9]{2}$`.
 
 ```python
 import re
@@ -70,9 +78,11 @@ for edge in response["DcimDevice"]["edges"]:
 
 ### Pattern 3: Relationship Count Threshold
 
-Verify objects have the required number of related objects.
+Verify objects have the required number of related
+objects.
 
-**Use case:** Spine devices must have at least 2 active BGP sessions.
+**Use case:** Spine devices must have at least 2
+active BGP sessions.
 
 ```python
 violations = []
@@ -95,9 +105,11 @@ for edge in response["DcimDevice"]["edges"]:
 
 ### Pattern 4: Presence Check (Required Relationship)
 
-Verify a required relationship is present (not null/empty).
+Verify a required relationship is present
+(not null/empty).
 
-**Use case:** All devices must have a platform assigned.
+**Use case:** All devices must have a platform
+assigned.
 
 ```python
 violations = []
@@ -116,9 +128,11 @@ for edge in response["DcimDevice"]["edges"]:
 
 ### Pattern 5: Cross-Node ID Join
 
-Correlate two node types using a shared identifier (e.g., IP address, ASN, name).
+Correlate two node types using a shared identifier
+(e.g., IP address, ASN, name).
 
-**Use case:** Every BGP session must have a matching IP address in IPAM.
+**Use case:** Every BGP session must have a matching
+IP address in IPAM.
 
 ```python
 # Build IP set from IPAM
@@ -146,9 +160,11 @@ for edge in bgp_response["NetworkBgpSession"]["edges"]:
 
 ### Pattern 6: Symmetric Relationship Check
 
-Verify bidirectional relationships exist (e.g., BGP sessions must have a reverse).
+Verify bidirectional relationships exist
+(e.g., BGP sessions must have a reverse).
 
-**Use case:** For every session A→B there must be a session B→A.
+**Use case:** For every session A->B there must be
+a session B->A.
 
 ```python
 # Build set of (local_device, remote_device) tuples
@@ -174,7 +190,8 @@ for (local, remote) in sessions:
 
 ### Pattern 7: Design-to-Reality Diff
 
-Compare expected objects (from a design/template) against realized objects.
+Compare expected objects (from a design/template)
+against realized objects.
 
 ```python
 # Expected from design
@@ -197,7 +214,8 @@ extra   = realized_names - expected_names      # realized, not in design
 
 ### Grouping Violations by Site or Device
 
-When reporting, group violations to make findings actionable:
+When reporting, group violations to make findings
+actionable:
 
 ```python
 from collections import defaultdict
@@ -212,4 +230,5 @@ for site, items in sorted(by_site.items()):
         print(f"  ✗ {item['name']} — {item['reason']}")
 ```
 
-Reference: [Infrahub Check Examples](../../check-creator/examples.md)
+Reference:
+[Infrahub Check Examples](../../check-creator/examples.md)

--- a/skills/analyst/rules/mcp-tools.md
+++ b/skills/analyst/rules/mcp-tools.md
@@ -6,9 +6,13 @@ tags: mcp, tools, query, infrahub
 
 ## Infrahub MCP Server Tool Reference
 
-**Impact: CRITICAL**
+Impact: CRITICAL
 
-The Infrahub MCP server exposes a set of tools that allow Claude to interact with a live Infrahub instance directly. Compliance workflows depend on calling these tools correctly to fetch, evaluate, and optionally update data.
+The Infrahub MCP server exposes a set of tools that
+allow Claude to interact with a live Infrahub
+instance directly. Compliance workflows depend on
+calling these tools correctly to fetch, evaluate,
+and optionally update data.
 
 ---
 
@@ -16,26 +20,41 @@ The Infrahub MCP server exposes a set of tools that allow Claude to interact wit
 
 #### `mcp__infrahub__infrahub_query`
 
-Execute a raw GraphQL query against Infrahub. This is the primary tool for compliance data retrieval.
+Execute a raw GraphQL query against Infrahub. This
+is the primary tool for compliance data retrieval.
 
-```
+```text
 Arguments:
-  query  (string, required)  — GraphQL query string
-  branch (string, optional)  — Branch name (default: main)
-  variables (object, optional) — GraphQL variables for parameterized queries
+  query  (string, required)
+    — GraphQL query string
+  branch (string, optional)
+    — Branch name (default: main)
+  variables (object, optional)
+    — GraphQL variables for
+      parameterized queries
 ```
 
 **Correct usage:**
-```
+
+```text
 mcp__infrahub__infrahub_query({
-  "query": "query { DcimDevice { edges { node { id name { value } } } } }"
+  "query": "query { DcimDevice {
+    edges { node { id name { value } } }
+  } }"
 })
 ```
 
 **With variables:**
-```
+
+```text
 mcp__infrahub__infrahub_query({
-  "query": "query DevicesBySite($site: String!) { DcimDevice(site__name__value: $site) { edges { node { id name { value } } } } }",
+  "query": "query DevicesBySite(
+    $site: String!
+  ) { DcimDevice(
+    site__name__value: $site
+  ) { edges { node {
+    id name { value }
+  } } } }",
   "variables": { "site": "PAR01" }
 })
 ```
@@ -44,81 +63,110 @@ mcp__infrahub__infrahub_query({
 
 #### `mcp__infrahub__infrahub_list_schema`
 
-List all available schema node kinds in the Infrahub instance. Use this when you don't know the exact kind name for a node type.
+List all available schema node kinds in the
+Infrahub instance. Use this when you don't know
+the exact kind name for a node type.
 
-```
+```text
 Arguments: none
 ```
 
-Returns a list of kind names (e.g., `DcimDevice`, `IpamPrefix`, `NetworkBgpSession`).
+Returns a list of kind names (e.g., `DcimDevice`,
+`IpamPrefix`, `NetworkBgpSession`).
 
 ---
 
 #### `mcp__infrahub__infrahub_get`
 
-Retrieve a single object by ID or human_friendly_id. Useful for fetching the full detail of a specific violation.
+Retrieve a single object by ID or
+human_friendly_id. Useful for fetching the full
+detail of a specific violation.
 
-```
+```text
 Arguments:
-  kind  (string, required)  — Node kind (e.g., "DcimDevice")
-  id    (string, optional)  — Infrahub object ID
-  filters (object, optional) — Attribute filters
+  kind  (string, required)
+    — Node kind (e.g., "DcimDevice")
+  id    (string, optional)
+    — Infrahub object ID
+  filters (object, optional)
+    — Attribute filters
 ```
 
 ---
 
 #### `mcp__infrahub__infrahub_create`
 
-Create a new object in Infrahub. Use for remediation workflows (e.g., creating a missing loopback interface).
+Create a new object in Infrahub. Use for
+remediation workflows (e.g., creating a missing
+loopback interface).
 
-```
+```text
 Arguments:
-  kind   (string, required)  — Node kind
-  data   (object, required)  — Attribute values
-  branch (string, optional)  — Branch (default: main)
+  kind   (string, required)
+    — Node kind
+  data   (object, required)
+    — Attribute values
+  branch (string, optional)
+    — Branch (default: main)
 ```
 
-Always create on a **branch** (not main) so changes can be reviewed in a proposed change.
+Always create on a **branch** (not main) so
+changes can be reviewed in a proposed change.
 
 ---
 
 #### `mcp__infrahub__infrahub_update`
 
-Update an existing object in Infrahub. Use for remediation (e.g., correcting a wrong VLAN assignment).
+Update an existing object in Infrahub. Use for
+remediation (e.g., correcting a wrong VLAN
+assignment).
 
-```
+```text
 Arguments:
-  kind   (string, required)  — Node kind
-  id     (string, required)  — Object ID
-  data   (object, required)  — Fields to update
-  branch (string, optional)  — Branch (default: main)
+  kind   (string, required)
+    — Node kind
+  id     (string, required)
+    — Object ID
+  data   (object, required)
+    — Fields to update
+  branch (string, optional)
+    — Branch (default: main)
 ```
 
 ---
 
 ### Tool Invocation Patterns
 
-**Pattern 1: Single query compliance**
-```
-1. Call mcp__infrahub__infrahub_query with your GraphQL
-2. Parse response: data.<NodeKind>.edges[].node
+#### Pattern 1 — Single query compliance
+
+```text
+1. Call mcp__infrahub__infrahub_query
+   with your GraphQL
+2. Parse response:
+   data.<NodeKind>.edges[].node
 3. Evaluate each node against the policy
 4. Report violations
 ```
 
-**Pattern 2: Multi-query correlation**
-```
-1. Call mcp__infrahub__infrahub_query for node type A (policy source)
-2. Call mcp__infrahub__infrahub_query for node type B (current state)
+#### Pattern 2 — Multi-query correlation
+
+```text
+1. Call mcp__infrahub__infrahub_query
+   for node type A (policy source)
+2. Call mcp__infrahub__infrahub_query
+   for node type B (current state)
 3. Build lookup set from A
 4. Check each item in B against the set
 5. Report gaps
 ```
 
-**Pattern 3: Schema discovery first**
-```
-1. Call mcp__infrahub__infrahub_list_schema to find the right kind name
-2. Construct GraphQL query using the correct kind
+#### Pattern 3 — Schema discovery first
+
+```text
+1. Call mcp__infrahub__infrahub_list_schema
+   to find the right kind name
+2. Construct GraphQL query using the
+   correct kind
 3. Proceed with compliance query
 ```
 
@@ -126,7 +174,8 @@ Arguments:
 
 ### Response Structure
 
-All query responses follow the Infrahub GraphQL convention:
+All query responses follow the Infrahub GraphQL
+convention:
 
 ```json
 {
@@ -136,7 +185,9 @@ All query responses follow the Infrahub GraphQL convention:
         "node": {
           "id": "17f3a...",
           "display_label": "par01-spine-01",
-          "name": { "value": "par01-spine-01" },
+          "name": {
+            "value": "par01-spine-01"
+          },
           "role": { "value": "spine" }
         }
       }
@@ -145,21 +196,25 @@ All query responses follow the Infrahub GraphQL convention:
 }
 ```
 
-Always navigate: `response.<Kind>.edges[].node` to get individual objects.
+Always navigate: `response.<Kind>.edges[].node`
+to get individual objects.
 
 ---
 
 ### Branch Considerations
 
-By default all MCP queries run against the `main` branch. To audit a proposed change branch:
+By default all MCP queries run against the `main`
+branch. To audit a proposed change branch:
 
-```
+```text
 mcp__infrahub__infrahub_query({
   "query": "...",
   "branch": "cr-2026-03-change"
 })
 ```
 
-For remediation creates/updates, **always use a named branch** — never write directly to `main`.
+For remediation creates/updates, **always use a
+named branch** — never write directly to `main`.
 
-Reference: [Infrahub MCP Server Docs](https://docs.infrahub.app/integrations/mcp)
+Reference:
+[Infrahub MCP Server Docs](https://docs.infrahub.app/integrations/mcp)

--- a/skills/analyst/rules/query-patterns.md
+++ b/skills/analyst/rules/query-patterns.md
@@ -6,17 +6,25 @@ tags: graphql, query, filters, pagination
 
 ## GraphQL Query Patterns for Compliance
 
-**Impact: CRITICAL**
+Impact: CRITICAL
 
-Compliance queries have different requirements from generator or transform queries: they often need all objects of a type (no filtering), must traverse multiple relationship levels, and sometimes need to combine data that doesn't naturally live together. These patterns cover the most common compliance query shapes.
+Compliance queries have different requirements from
+generator or transform queries: they often need all
+objects of a type (no filtering), must traverse
+multiple relationship levels, and sometimes need to
+combine data that doesn't naturally live together.
+These patterns cover the most common compliance
+query shapes.
 
 ---
 
 ### Pattern 1: Fetch All Objects of a Kind
 
-The baseline compliance query — get every object with the attributes needed to evaluate the policy.
+The baseline compliance query — get every object
+with the attributes needed to evaluate the policy.
 
 **Correct:**
+
 ```graphql
 query AllDevices {
   DcimDevice {
@@ -42,18 +50,24 @@ query AllDevices {
 }
 ```
 
-Do not add filters unless you intentionally want to scope the compliance check to a subset.
+Do not add filters unless you intentionally want
+to scope the compliance check to a subset.
 
 ---
 
 ### Pattern 2: Filter by Attribute Value
 
-Scope a compliance check to objects matching a criterion.
+Scope a compliance check to objects matching a
+criterion.
 
 **Correct:**
+
 ```graphql
 query ActiveLeafDevices {
-  DcimDevice(role__value: "leaf", status__value: "active") {
+  DcimDevice(
+    role__value: "leaf",
+    status__value: "active"
+  ) {
     edges {
       node {
         id
@@ -73,15 +87,21 @@ query ActiveLeafDevices {
 }
 ```
 
-Infrahub GraphQL filter format: `<attribute>__value: "<value>"` for scalar attributes, `<relationship>__<attribute>__value: "<value>"` for relationship traversal.
+Infrahub GraphQL filter format:
+`<attribute>__value: "<value>"` for scalar
+attributes,
+`<relationship>__<attribute>__value: "<value>"`
+for relationship traversal.
 
 ---
 
 ### Pattern 3: Multi-Level Relationship Traversal
 
-Fetch data across multiple hops for correlation (e.g., device → interface → IP → prefix).
+Fetch data across multiple hops for correlation
+(e.g., device -> interface -> IP -> prefix).
 
 **Correct:**
+
 ```graphql
 query DeviceIpCompliance {
   DcimDevice {
@@ -122,15 +142,19 @@ query DeviceIpCompliance {
 }
 ```
 
-Each relationship level adds one `edges { node { ... } }` wrapper.
+Each relationship level adds one
+`edges { node { ... } }` wrapper.
 
 ---
 
 ### Pattern 4: Inline Fragments for Generic Types
 
-When querying a generic node kind that has concrete subtypes, use inline fragments to fetch subtype-specific fields.
+When querying a generic node kind that has concrete
+subtypes, use inline fragments to fetch
+subtype-specific fields.
 
 **Correct:**
+
 ```graphql
 query GenericDeviceCompliance {
   DcimGenericDevice {
@@ -156,15 +180,19 @@ query GenericDeviceCompliance {
 }
 ```
 
-Always include `__typename` when using inline fragments so you can identify the concrete type in your correlation logic.
+Always include `__typename` when using inline
+fragments so you can identify the concrete type
+in your correlation logic.
 
 ---
 
 ### Pattern 5: Counting Relationships for Threshold Checks
 
-Fetch relationship lists to count them (e.g., "device must have ≥2 BGP peers").
+Fetch relationship lists to count them (e.g.,
+"device must have >=2 BGP peers").
 
 **Correct:**
+
 ```graphql
 query BgpPeerCounts {
   DcimDevice(role__value: "spine") {
@@ -191,18 +219,26 @@ query BgpPeerCounts {
 }
 ```
 
-Then in correlation: `len(device["bgp_sessions"]["edges"]) >= 2`.
+Then in correlation:
+`len(device["bgp_sessions"]["edges"]) >= 2`.
 
 ---
 
 ### Pattern 6: Fetching Policy Source Objects
 
-When the policy itself is stored in Infrahub (e.g., approved VLANs, authorized prefixes), fetch it as a separate query before the compliance query.
+When the policy itself is stored in Infrahub
+(e.g., approved VLANs, authorized prefixes),
+fetch it as a separate query before the compliance
+query.
 
 **Policy source query:**
+
 ```graphql
 query ApprovedVlans {
-  IpamVlan(status__value: "active", role__value: "approved") {
+  IpamVlan(
+    status__value: "active",
+    role__value: "approved"
+  ) {
     edges {
       node {
         vlan_id { value }
@@ -218,6 +254,7 @@ query ApprovedVlans {
 ```
 
 **Current state query:**
+
 ```graphql
 query InterfaceVlanAssignments {
   DcimInterface(mode__value: "access") {
@@ -244,16 +281,23 @@ query InterfaceVlanAssignments {
 }
 ```
 
-Run both queries, build a lookup from the first, check each item in the second.
+Run both queries, build a lookup from the first,
+check each item in the second.
 
 ---
 
 ### Pagination Note
 
-Infrahub returns all objects in a single response by default (no cursor pagination needed for typical dataset sizes). If a query returns an unexpectedly empty `edges` list:
+Infrahub returns all objects in a single response
+by default (no cursor pagination needed for typical
+dataset sizes). If a query returns an unexpectedly
+empty `edges` list:
 
-1. Verify the kind name is correct using `mcp__infrahub__infrahub_list_schema`
-2. Check that the filter values match exactly (case-sensitive for `value` fields)
+1. Verify the kind name is correct using
+   `mcp__infrahub__infrahub_list_schema`
+2. Check that the filter values match exactly
+   (case-sensitive for `value` fields)
 3. Try without filters to confirm data exists
 
-Reference: [Infrahub GraphQL Query Reference](../graphql-queries.md)
+Reference:
+[Infrahub GraphQL Query Reference](../graphql-queries.md)

--- a/skills/analyst/rules/reporting-output.md
+++ b/skills/analyst/rules/reporting-output.md
@@ -6,17 +6,22 @@ tags: reporting, output, findings, remediation
 
 ## Compliance Reporting Output
 
-**Impact: HIGH**
+Impact: HIGH
 
-Clear, actionable output is what makes compliance analysis useful. Raw violation lists aren't enough — findings need context, counts, severity, and remediation hints. These patterns define how to present compliance results.
+Clear, actionable output is what makes compliance
+analysis useful. Raw violation lists aren't enough —
+findings need context, counts, severity, and
+remediation hints. These patterns define how to
+present compliance results.
 
 ---
 
 ### Standard Report Structure
 
-Every compliance report should follow this structure:
+Every compliance report should follow this
+structure:
 
-```
+```text
 <Title> — <Scope> — <Date>
 ═══════════════════════════════════
 Policy:     <Description of what was checked>
@@ -38,26 +43,42 @@ Remediation
 
 For a focused check on one policy:
 
-```
-Device Naming Convention — All Sites — 2026-03-13
-══════════════════════════════════════════════════
-Policy:     Names must match <site><nn>-<role>-<nn> (e.g., par01-spine-01)
+```text
+Device Naming Convention
+  — All Sites — 2026-03-13
+══════════════════════════════════════
+Policy:     Names must match
+            <site><nn>-<role>-<nn>
+            (e.g., par01-spine-01)
 Checked:    47 devices
 Compliant:  43  (91.5%)
 Violations: 4
 
 Non-compliant devices:
-  ✗ SPINE-01        [id: abc123]  — uppercase letters, missing site prefix
-  ✗ spine-01        [id: def456]  — missing site prefix
-  ✗ Leaf_03         [id: ghi789]  — underscore not allowed, mixed case
-  ✗ par01-leaf      [id: jkl012]  — missing sequence number
+  ✗ SPINE-01    [id: abc123]
+    — uppercase letters,
+      missing site prefix
+  ✗ spine-01    [id: def456]
+    — missing site prefix
+  ✗ Leaf_03     [id: ghi789]
+    — underscore not allowed,
+      mixed case
+  ✗ par01-leaf  [id: jkl012]
+    — missing sequence number
 
 Remediation
 ───────────
-• Rename affected devices via Infrahub UI or:
-    mcp__infrahub__infrahub_update(kind="DcimDevice", id="<id>", data={"name": "<correct-name>"})
+• Rename affected devices via
+  Infrahub UI or:
+    mcp__infrahub__infrahub_update(
+      kind="DcimDevice",
+      id="<id>",
+      data={"name": "<correct-name>"}
+    )
   Note: always use a branch, not main.
-• Consider adding an InfrahubCheck to enforce naming on future proposed changes.
+• Consider adding an InfrahubCheck to
+  enforce naming on future proposed
+  changes.
   See: skills/check-creator/SKILL.md
 ```
 
@@ -67,17 +88,18 @@ Remediation
 
 For a compliance run covering several policies:
 
-```
-Compliance Summary — PAR01 — 2026-03-13
-════════════════════════════════════════
-                              Checked  Pass  Fail  Status
-─────────────────────────────────────────────────────────
-Naming Convention              47       43    4     ⚠ WARN
-Interface Descriptions         312     298   14     ⚠ WARN
-Platform Assignment             47       47    0     ✓ PASS
-Loopback IP Space               22       20    2     ⚠ WARN
-BGP Peer Count (min 2)           8        8    0     ✓ PASS
-─────────────────────────────────────────────────────────
+```text
+Compliance Summary
+  — PAR01 — 2026-03-13
+════════════════════════════════════
+                      Checked Pass Fail Status
+────────────────────────────────────────────────
+Naming Convention      47      43   4   ⚠ WARN
+Interface Desc.       312     298  14   ⚠ WARN
+Platform Assignment    47      47   0   ✓ PASS
+Loopback IP Space      22      20   2   ⚠ WARN
+BGP Peer Count (≥2)     8       8   0   ✓ PASS
+────────────────────────────────────────────────
 Overall compliance: 416/436 (95.4%)
 
 Details for each ⚠ check are expanded below.
@@ -87,46 +109,57 @@ Details for each ⚠ check are expanded below.
 
 ### Per-Violation Detail Block
 
-Include enough context per violation to act on it without re-running the analysis:
+Include enough context per violation to act on it
+without re-running the analysis:
 
-```
+```text
   ✗ par01-leaf-07 / Loopback0
     Object ID:   17f3a2c4-...
     Kind:        DcimInterface
-    Violation:   IP 192.168.100.5/32 not in approved loopback prefix 10.0.0.0/24
+    Violation:   IP 192.168.100.5/32
+                 not in approved loopback
+                 prefix 10.0.0.0/24
     Site:        PAR01
-    Fix:         Update IP address to a /32 from 10.0.0.0/24
+    Fix:         Update IP address to a
+                 /32 from 10.0.0.0/24
 ```
 
 Fields to include per violation:
-- **Object name** and **ID** (for direct lookup or update)
-- **Kind** (so the user knows which Infrahub node type to navigate to)
-- **Violation description** (what policy was violated)
+
+- **Object name** and **ID** (for direct lookup
+  or update)
+- **Kind** (so the user knows which Infrahub node
+  type to navigate to)
+- **Violation description** (what policy was
+  violated)
 - **Suggested fix** (concrete remediation action)
 
 ---
 
 ### Severity Levels
 
-Not all violations are equal. Use severity markers to prioritize:
+Not all violations are equal. Use severity markers
+to prioritize:
 
 | Symbol | Severity | Meaning |
-|--------|----------|---------|
+| ------ | -------- | ------- |
 | `✗ CRITICAL` | Critical | Immediate action required (security risk, data loss risk) |
 | `✗ ERROR` | Error | Policy violation that must be fixed |
 | `⚠ WARN` | Warning | Deviation that should be addressed |
 | `ℹ INFO` | Info | Observation, no action required |
 
-Default: use `✗` for all violations unless severity levels are explicitly requested.
+Default: use `✗` for all violations unless severity
+levels are explicitly requested.
 
 ---
 
 ### Remediation Hints
 
-Always include a remediation section. Match the remediation to the violation type:
+Always include a remediation section. Match the
+remediation to the violation type:
 
 | Violation Type | Remediation Hint |
-|----------------|-----------------|
+| -------------- | ---------------- |
 | Missing required attribute | Set value via UI or `mcp__infrahub__infrahub_update` |
 | Wrong attribute value | Correct value via UI or `mcp__infrahub__infrahub_update` |
 | Missing related object | Create via `mcp__infrahub__infrahub_create` on a branch |
@@ -138,33 +171,44 @@ Always include a remediation section. Match the remediation to the violation typ
 
 ### Compact Format for Large Result Sets
 
-When there are many violations, use a compact table format:
+When there are many violations, use a compact table
+format:
 
-```
+```text
 Non-compliant interfaces (14):
-Device              Interface    Violation
-─────────────────────────────────────────────────────
-par01-leaf-01      Eth1/1       Missing description
-par01-leaf-01      Eth1/2       Missing description
-par01-leaf-03      Eth1/7       Missing description
-par01-leaf-05      Eth2/1       Missing description
-...and 10 more. Use filter 'site=PAR01, missing_description=true' to see all.
+Device           Interface  Violation
+──────────────────────────────────────────
+par01-leaf-01   Eth1/1     Missing desc.
+par01-leaf-01   Eth1/2     Missing desc.
+par01-leaf-03   Eth1/7     Missing desc.
+par01-leaf-05   Eth2/1     Missing desc.
+...and 10 more. Use filter
+  'site=PAR01, missing_description=true'
+  to see all.
 ```
 
-Limit inline output to 10–15 items; offer to filter or expand on request.
+Limit inline output to 10-15 items; offer to
+filter or expand on request.
 
 ---
 
 ### Exporting Compliance Reports as Artifacts
 
-For repeatable, stakeholder-facing reports, convert the compliance workflow into a Transform + Artifact:
+For repeatable, stakeholder-facing reports, convert
+the compliance workflow into a
+Transform + Artifact:
 
+```text
+Interactive MCP compliance
+  → good for ad-hoc, exploratory analysis
+InfrahubCheck
+  → good for pipeline enforcement (pass/fail)
+Transform + Artifact
+  → good for scheduled reports, CSV/HTML export
 ```
-Interactive MCP compliance   →   good for ad-hoc, exploratory analysis
-InfrahubCheck                →   good for pipeline enforcement (pass/fail)
-Transform + Artifact         →   good for scheduled reports, CSV/HTML export
-```
 
-See `../transform-creator/SKILL.md` for how to turn a compliance query into a recurring artifact.
+See `../transform-creator/SKILL.md` for how to
+turn a compliance query into a recurring artifact.
 
-Reference: [Infrahub Artifact Definitions](https://docs.infrahub.app/topics/artifact)
+Reference:
+[Infrahub Artifact Definitions](https://docs.infrahub.app/topics/artifact)


### PR DESCRIPTION
## Summary
- Add CI workflow with markdownlint and yamllint jobs, gated by path filters
- Add supporting workflows: release validation, version sync, label sync, auto-labeler, docs sync
- Fix all markdownlint errors (MD013, MD040, MD060, MD036, MD032, MD056) across `skills/analyst/`, `skills/generator-creator/`, `skills/object-creator/`, and `README.md`
- Fix all yamllint errors: missing `---` document starts, indentation in `labeler.yml`, long lines in `skill-evals.yml`
- Add `.yamllint.yml` config, `.github/file-filters.yml`, labels, and labeler config

## Test plan
- [x] `markdownlint-cli2 "**/*.md"` reports 0 errors
- [x] `yamllint -c .yamllint.yml .` reports 0 errors (only warnings for gitignored workspace files)
- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)