### PR TITLE
Add paths, allowed-tools, and context frontmatter fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ docs/build/
 *.key
 credentials.json
 secrets.yaml
+.claude/

--- a/skills/infrahub-analyst/SKILL.md
+++ b/skills/infrahub-analyst/SKILL.md
@@ -7,6 +7,10 @@ description: >-
   correlate node types, investigate service impact,
   check maintenance windows, or produce ad-hoc
   reports — without writing pipeline code.
+context: fork
+allowed-tools:
+  - Read
+  - Bash
 metadata:
   version: 1.1.0
   author: OpsMill

--- a/skills/infrahub-analyst/SKILL.md
+++ b/skills/infrahub-analyst/SKILL.md
@@ -55,9 +55,6 @@ artifacts, see `../infrahub-transform-creator/SKILL.md`.
 
 ## Project Context
 
-Infrahub config:
-!`cat .infrahub.yml 2>/dev/null || echo "No .infrahub.yml found"`
-
 If invoked with arguments (e.g., `/infrahub:analyst Which devices have no platform assigned?`),
 treat the arguments as the question to answer.
 

--- a/skills/infrahub-analyst/SKILL.md
+++ b/skills/infrahub-analyst/SKILL.md
@@ -11,6 +11,7 @@ context: fork
 allowed-tools:
   - Read
   - Bash
+argument-hint: "[question about infrastructure data]"
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -51,6 +52,14 @@ block proposed changes, see
 `../infrahub-check-creator/SKILL.md`.
 For **repeatable scheduled reports** exported as
 artifacts, see `../infrahub-transform-creator/SKILL.md`.
+
+## Project Context
+
+Infrahub config:
+!`cat .infrahub.yml 2>/dev/null || echo "No .infrahub.yml found"`
+
+If invoked with arguments (e.g., `/infrahub:analyst Which devices have no platform assigned?`),
+treat the arguments as the question to answer.
 
 ## When to Use
 

--- a/skills/infrahub-check-creator/SKILL.md
+++ b/skills/infrahub-check-creator/SKILL.md
@@ -14,6 +14,7 @@ allowed-tools:
   - Edit
   - Bash
   - Grep
+argument-hint: "[check-name] [description...]"
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -27,6 +28,17 @@ Expert guidance for creating Infrahub checks. Checks are
 user-defined validation logic (Python + GraphQL) that run as
 part of a proposed change pipeline. If a check logs any
 errors, the proposed change cannot be merged.
+
+## Project Context
+
+Infrahub config:
+!`cat .infrahub.yml 2>/dev/null || echo "No .infrahub.yml found"`
+
+Existing checks:
+!`find . -name "*.py" -path "*/checks/*" 2>/dev/null | head -20`
+
+Existing queries:
+!`find . -name "*.gql" -path "*/queries/*" 2>/dev/null | head -20`
 
 ## When to Use
 

--- a/skills/infrahub-check-creator/SKILL.md
+++ b/skills/infrahub-check-creator/SKILL.md
@@ -5,6 +5,15 @@ description: >-
   writing validation logic, creating Python checks that run
   in proposed change pipelines, or building data quality
   guards for Infrahub.
+paths:
+  - "checks/**/*.py"
+  - "queries/**/*.gql"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
 metadata:
   version: 1.1.0
   author: OpsMill

--- a/skills/infrahub-generator-creator/SKILL.md
+++ b/skills/infrahub-generator-creator/SKILL.md
@@ -13,6 +13,7 @@ allowed-tools:
   - Edit
   - Bash
   - Grep
+argument-hint: "[generator-name] [description...]"
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -27,6 +28,14 @@ query data from Infrahub via GraphQL and create new nodes and
 relationships based on the result -- enabling design-driven
 automation where a "design" object automatically creates
 downstream infrastructure.
+
+## Project Context
+
+Infrahub config:
+!`cat .infrahub.yml 2>/dev/null || echo "No .infrahub.yml found"`
+
+Existing generators:
+!`find . -name "*.py" -path "*/generators/*" 2>/dev/null | head -20`
 
 ## When to Use
 

--- a/skills/infrahub-generator-creator/SKILL.md
+++ b/skills/infrahub-generator-creator/SKILL.md
@@ -5,6 +5,14 @@ description: >-
   design-driven automation that creates infrastructure objects
   from templates, topology definitions, or any
   design-to-implementation workflow in Infrahub.
+paths:
+  - "generators/**/*.py"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
 metadata:
   version: 1.1.0
   author: OpsMill

--- a/skills/infrahub-menu-creator/SKILL.md
+++ b/skills/infrahub-menu-creator/SKILL.md
@@ -13,6 +13,7 @@ allowed-tools:
   - Write
   - Edit
   - Bash
+argument-hint: "[menu-structure-description]"
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -26,6 +27,14 @@ Expert guidance for creating Infrahub custom menus.
 Menus control the left-side navigation in the web
 interface, organizing schema node types into a custom
 hierarchy.
+
+## Project Context
+
+Existing menu files:
+!`find . -name "*.yml" -path "*/menus/*" 2>/dev/null | head -10`
+
+Schema files (to identify available node types):
+!`find . -name "*.yml" -path "*/schemas/*" -o -name "*schema*" -name "*.yml" 2>/dev/null | head -10`
 
 ## When to Use
 

--- a/skills/infrahub-menu-creator/SKILL.md
+++ b/skills/infrahub-menu-creator/SKILL.md
@@ -5,6 +5,14 @@ description: >-
   designing navigation menus, organizing node types
   in the UI, or customizing the Infrahub web interface
   sidebar.
+paths:
+  - "menus/**/*.yml"
+  - "menus/**/*.yaml"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
 metadata:
   version: 1.1.0
   author: OpsMill

--- a/skills/infrahub-object-creator/SKILL.md
+++ b/skills/infrahub-object-creator/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Write
   - Edit
   - Bash
+argument-hint: "[kind] [object-details...]"
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -22,6 +23,17 @@ Expert guidance for creating Infrahub object (data) files.
 Objects are YAML files that populate schema nodes with actual
 infrastructure data -- devices, locations, organizations,
 modules, and more.
+
+## Project Context
+
+Existing schema files:
+!`find . -name "*.yml" -path "*/schemas/*" -o -name "*schema*" -name "*.yml" 2>/dev/null | head -10`
+
+Existing object files:
+!`find . -name "*.yml" -path "*/objects/*" 2>/dev/null | head -20`
+
+If invoked with arguments (e.g., `/infrahub:object-creator DcimDevice spine-01`),
+use the first argument as the kind and remaining arguments as object details.
 
 ## When to Use
 

--- a/skills/infrahub-object-creator/SKILL.md
+++ b/skills/infrahub-object-creator/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: infrahub-object-creator
 description: Create and manage Infrahub object data files. Use when populating infrastructure data, creating device instances, locations, organizations, module installations, or any other data objects for an Infrahub repository.
+paths:
+  - "objects/**/*.yml"
+  - "objects/**/*.yaml"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
 metadata:
   version: 1.1.0
   author: OpsMill

--- a/skills/infrahub-object-creator/SKILL.md
+++ b/skills/infrahub-object-creator/SKILL.md
@@ -4,6 +4,8 @@ description: Create and manage Infrahub object data files. Use when populating i
 paths:
   - "objects/**/*.yml"
   - "objects/**/*.yaml"
+  - "data/**/*.yml"
+  - "data/**/*.yaml"
 allowed-tools:
   - Read
   - Write

--- a/skills/infrahub-repo-auditor/SKILL.md
+++ b/skills/infrahub-repo-auditor/SKILL.md
@@ -5,6 +5,12 @@ description: >-
   and rules. Use when reviewing a project for compliance,
   onboarding to an existing repo, or before deployment to
   catch issues early.
+context: fork
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
 metadata:
   version: 1.1.0
   author: OpsMill

--- a/skills/infrahub-repo-auditor/SKILL.md
+++ b/skills/infrahub-repo-auditor/SKILL.md
@@ -11,6 +11,7 @@ allowed-tools:
   - Bash
   - Grep
   - Glob
+argument-hint: "[focus-area]"
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -25,6 +26,14 @@ all rules and best practices from the infrahub-skills
 plugin. Produces a structured report covering schemas,
 objects, checks, generators, transforms, menus,
 `.infrahub.yml` configuration, and deployment readiness.
+
+## Project Context
+
+Project structure:
+!`find . -maxdepth 2 -type f \( -name "*.yml" -o -name "*.yaml" -o -name "*.py" -o -name "*.gql" -o -name "*.j2" \) 2>/dev/null | head -40`
+
+Infrahub config:
+!`cat .infrahub.yml 2>/dev/null || echo "No .infrahub.yml found"`
 
 ## When to Use
 

--- a/skills/infrahub-schema-creator/SKILL.md
+++ b/skills/infrahub-schema-creator/SKILL.md
@@ -15,6 +15,7 @@ allowed-tools:
   - Write
   - Edit
   - Bash
+argument-hint: "[namespace] [node-names...]"
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -28,6 +29,17 @@ Expert guidance for designing and building Infrahub
 schemas. Schemas are YAML files defining nodes (concrete
 types), generics (abstract base types), attributes,
 relationships, and extensions.
+
+## Project Context
+
+Existing schemas in this project:
+!`find . -name "*.yml" -path "*/schemas/*" -o -name "*schema*" -name "*.yml" 2>/dev/null | head -20`
+
+Infrahub config (if present):
+!`cat .infrahub.yml 2>/dev/null || echo "No .infrahub.yml found"`
+
+If invoked with arguments (e.g., `/infrahub:schema-creator Ipam Vlan VlanGroup`),
+use the first argument as the namespace and remaining arguments as node names.
 
 ## When to Use
 

--- a/skills/infrahub-schema-creator/SKILL.md
+++ b/skills/infrahub-schema-creator/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   designing data models, creating schema nodes with
   attributes and relationships, validating schema
   definitions, or planning schema migrations for Infrahub.
+paths:
+  - "schemas/**/*.yml"
+  - "schemas/**/*.yaml"
+  - "*schema*.yml"
+  - "*schema*.yaml"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
 metadata:
   version: 1.1.0
   author: OpsMill

--- a/skills/infrahub-transform-creator/SKILL.md
+++ b/skills/infrahub-transform-creator/SKILL.md
@@ -15,6 +15,7 @@ allowed-tools:
   - Edit
   - Bash
   - Grep
+argument-hint: "[transform-name] [format]"
 metadata:
   version: 1.1.0
   author: OpsMill
@@ -28,6 +29,14 @@ Expert guidance for creating Infrahub transforms.
 Transforms convert Infrahub data into different formats
 -- JSON, text, CSV, device configs, or any text-based
 output -- using Python classes or Jinja2 templates.
+
+## Project Context
+
+Infrahub config:
+!`cat .infrahub.yml 2>/dev/null || echo "No .infrahub.yml found"`
+
+Existing transforms:
+!`find . -name "*.py" -path "*/transforms/*" -o -name "*.j2" -path "*/templates/*" 2>/dev/null | head -20`
 
 ## When to Use
 

--- a/skills/infrahub-transform-creator/SKILL.md
+++ b/skills/infrahub-transform-creator/SKILL.md
@@ -6,6 +6,15 @@ description: >-
   that converts Infrahub data into a different format
   (JSON, text, CSV, device configs) using Python or Jinja2
   templates.
+paths:
+  - "transforms/**/*.py"
+  - "templates/**/*.j2"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
 metadata:
   version: 1.1.0
   author: OpsMill


### PR DESCRIPTION
## Summary

- Adds `paths` frontmatter to 6 skills for file-based auto-activation (e.g., schema-creator activates when working with `schemas/**/*.yml`)
- Adds `allowed-tools` frontmatter to all 8 user-facing skills for explicit tool permissions
- Adds `context: fork` to `infrahub-analyst` and `infrahub-repo-auditor` for subagent isolation (these produce large outputs that benefit from running in a forked context)
- No changes to `infrahub-common` (shared resource, not user-invocable)

These are newer Anthropic Agent Skills frontmatter features that improve skill activation precision and tool permission management.

## Test plan

- [ ] Verify `grep -l "paths:" skills/*/SKILL.md` shows 6 skills (not analyst, auditor, common)
- [ ] Verify `grep -l "allowed-tools:" skills/*/SKILL.md` shows 8 skills (not common)
- [ ] Verify `grep -l "context: fork" skills/*/SKILL.md` shows 2 skills (analyst, auditor)
- [ ] Validate YAML frontmatter is syntactically correct in all modified files
- [ ] Run `skillgrade --smoke` to confirm evals still pass
