### PR TITLE
Add Workflow sections to 5 skills

### DIFF
--- a/skills/infrahub-check-creator/SKILL.md
+++ b/skills/infrahub-check-creator/SKILL.md
@@ -71,6 +71,32 @@ class MyCheck(InfrahubCheck):
             )
 ```
 
+## Workflow
+
+Follow these steps when creating a check:
+
+1. **Understand the validation goal** — What data
+   condition should block a proposed change? Determine
+   whether this is a global check (all objects of a
+   type) or targeted (specific group). Read
+   [rules/architecture-types.md](./rules/architecture-types.md).
+2. **Write the GraphQL query** — Create a `.gql` file
+   that fetches the data to validate. Read
+   [../infrahub-common/graphql-queries.md](../infrahub-common/graphql-queries.md)
+   for query patterns.
+3. **Implement the Python class** — Inherit from
+   `InfrahubCheck`, implement `validate()`. Read
+   [rules/python-validate.md](./rules/python-validate.md)
+   for the class pattern and
+   [rules/api-reference.md](./rules/api-reference.md)
+   for available methods.
+4. **Register in .infrahub.yml** — Add the check under
+   `check_definitions`. The query name must match the
+   Python class `query` attribute. See
+   [rules/registration-config.md](./rules/registration-config.md).
+5. **Test** — Run `infrahubctl check` to validate. See
+   [rules/testing-commands.md](./rules/testing-commands.md).
+
 ## Supporting References
 
 - **[examples.md](./examples.md)** -- Complete check

--- a/skills/infrahub-generator-creator/SKILL.md
+++ b/skills/infrahub-generator-creator/SKILL.md
@@ -61,6 +61,34 @@ class MyGenerator(InfrahubGenerator):
         await obj.save(allow_upsert=True)
 ```
 
+## Workflow
+
+Follow these steps when creating a generator:
+
+1. **Identify the design pattern** — What "design"
+   object triggers generation? What objects should be
+   created from it? Read
+   [rules/architecture-components.md](./rules/architecture-components.md)
+   for the target group and generator components.
+2. **Write the GraphQL query** — Create a `.gql` file
+   that fetches the design data. Read
+   [../infrahub-common/graphql-queries.md](../infrahub-common/graphql-queries.md)
+   for query patterns.
+3. **Implement the Python class** — Inherit from
+   `InfrahubGenerator`, implement `generate()`. Read
+   [rules/python-generate.md](./rules/python-generate.md)
+   for the class pattern and
+   [rules/api-reference.md](./rules/api-reference.md)
+   for available methods.
+4. **Make it idempotent** — Use `allow_upsert=True` so
+   re-running creates or updates without duplicates.
+   See [rules/tracking-idempotent.md](./rules/tracking-idempotent.md).
+5. **Register in .infrahub.yml** — Add under
+   `generator_definitions` with the target group. See
+   [rules/registration-config.md](./rules/registration-config.md).
+6. **Test** — Run `infrahubctl generator` to validate.
+   See [rules/testing-commands.md](./rules/testing-commands.md).
+
 ## Supporting References
 
 - **[examples.md](./examples.md)** -- Complete Generator

--- a/skills/infrahub-object-creator/SKILL.md
+++ b/skills/infrahub-object-creator/SKILL.md
@@ -51,6 +51,32 @@ spec:
 are always required. Each `spec` block targets a single
 node kind.
 
+## Workflow
+
+Follow these steps when creating object data files:
+
+1. **Read the schema** — Identify the target node kind,
+   its attributes, relationships, and whether it has
+   component children or hierarchy parents.
+2. **Plan the file structure** — Read
+   [rules/format-structure.md](./rules/format-structure.md)
+   for the required YAML structure and
+   [rules/organization-load-order.md](./rules/organization-load-order.md)
+   for file naming and load order conventions.
+3. **Map attribute values** — Set each attribute using
+   the correct value format. Read
+   [rules/value-attributes.md](./rules/value-attributes.md)
+   for attribute mapping and
+   [rules/value-relationships.md](./rules/value-relationships.md)
+   for relationship references.
+4. **Handle children** — If the node has component
+   children or hierarchy nesting, read
+   [rules/children-components.md](./rules/children-components.md)
+   and [rules/children-hierarchy.md](./rules/children-hierarchy.md).
+5. **Validate** — Check YAML syntax and ensure
+   referenced objects exist or are defined in earlier
+   load-order files.
+
 ## Supporting References
 
 - **[reference.md](./reference.md)** -- Object file format

--- a/skills/infrahub-schema-creator/SKILL.md
+++ b/skills/infrahub-schema-creator/SKILL.md
@@ -61,6 +61,33 @@ extensions:    # Add attributes/relationships to existing nodes from other files
 Always include the `$schema` comment for IDE validation.
 Only `version` is required at the top level.
 
+## Workflow
+
+Follow these steps when creating or modifying a schema:
+
+1. **Gather requirements** — Identify the node types,
+   their attributes, and how they relate to each other.
+   Ask about hierarchies, dropdowns, and display needs.
+2. **Read relevant rules** — Read
+   [rules/naming-conventions.md](./rules/naming-conventions.md)
+   for naming constraints,
+   [rules/attribute-defaults-and-types.md](./rules/attribute-defaults-and-types.md)
+   for attribute kinds and defaults, and
+   [rules/relationship-identifiers.md](./rules/relationship-identifiers.md)
+   for bidirectional relationship setup.
+3. **Build the schema YAML** — Start with the `$schema`
+   comment and `version: "1.0"`. Define generics first
+   (if any), then nodes. Apply naming, display, and
+   relationship rules from step 2.
+4. **Configure display properties** — Set
+   `human_friendly_id`, `display_label`, and
+   `order_weight` per
+   [rules/display-human-friendly-id.md](./rules/display-human-friendly-id.md)
+   and [rules/display-order-weight.md](./rules/display-order-weight.md).
+5. **Validate** — Run `infrahubctl schema check` per
+   [validation.md](./validation.md). Fix any errors
+   using [rules/validation-common-errors.md](./rules/validation-common-errors.md).
+
 ## Supporting References
 
 - **[reference.md](./reference.md)** -- Complete property

--- a/skills/infrahub-transform-creator/SKILL.md
+++ b/skills/infrahub-transform-creator/SKILL.md
@@ -62,6 +62,36 @@ class MyTransform(InfrahubTransform):
         return {"hostname": device["name"]["value"]}
 ```
 
+## Workflow
+
+Follow these steps when creating a transform:
+
+1. **Choose the transform type** — Python for JSON/dict
+   or complex logic, Jinja2 for text templates, hybrid
+   for both. Read
+   [rules/types-overview.md](./rules/types-overview.md).
+2. **Write the GraphQL query** — Create a `.gql` file
+   that fetches the data to transform. Read
+   [../infrahub-common/graphql-queries.md](../infrahub-common/graphql-queries.md)
+   for query patterns.
+3. **Implement the transform** — For Python, inherit
+   from `InfrahubTransform` and implement `transform()`.
+   Read [rules/python-transform.md](./rules/python-transform.md).
+   For Jinja2, create a `.j2` template. Read
+   [rules/jinja2-template.md](./rules/jinja2-template.md).
+   For hybrid, read
+   [rules/hybrid-python-jinja2.md](./rules/hybrid-python-jinja2.md).
+4. **Connect to artifacts** — If the transform output
+   should be stored as a file, configure artifact
+   definitions. See
+   [rules/artifacts-definitions.md](./rules/artifacts-definitions.md).
+5. **Register in .infrahub.yml** — Add under
+   `python_transforms` or `jinja2_transforms`. See
+   [rules/api-reference.md](./rules/api-reference.md).
+6. **Test** — Run `infrahubctl transform` or
+   `infrahubctl render`. See
+   [rules/testing-commands.md](./rules/testing-commands.md).
+
 ## Supporting References
 
 - **[examples.md](./examples.md)** -- Complete transform


### PR DESCRIPTION
## Summary

- Add step-by-step `## Workflow` sections to 5 skills that were missing them: schema-creator, check-creator, generator-creator, object-creator, and transform-creator
- Follows the established pattern from menu-creator: numbered steps with bold names and contextual references to specific rule files at each step
- Gives Claude structured guidance for task execution while providing direct 1-level references to rules at the moment they're needed

The 3 other skills already have workflow-equivalent sections (menu-creator: `## Workflow`, analyst: `## Typical Analysis Workflow`, repo-auditor: `## How It Works`).

### Workflows added

| Skill | Steps | Key rule references |
|-------|-------|---------------------|
| schema-creator | 5 | naming-conventions, attribute-defaults, relationship-identifiers, display-*, validation |
| check-creator | 5 | architecture-types, graphql-queries, python-validate, registration-config, testing-commands |
| generator-creator | 6 | architecture-components, graphql-queries, python-generate, tracking-idempotent, registration-config |
| object-creator | 5 | format-structure, organization-load-order, value-attributes, value-relationships, children-* |
| transform-creator | 6 | types-overview, graphql-queries, python-transform/jinja2-template/hybrid, artifacts-definitions |

All files stay well under the 500-line SKILL.md budget (93-114 lines).

## Test plan

- [ ] Verify `grep "## Workflow" skills/*/SKILL.md` matches 6 files (5 new + menu-creator)
- [ ] Confirm each workflow references the correct rule files for that skill
- [ ] Check no existing content was modified (only insertions)
