### PR TITLE
fix(skills): remove paths frontmatter from managing-* SKILL.md

### DIFF
--- a/skills/infrahub-managing-checks/SKILL.md
+++ b/skills/infrahub-managing-checks/SKILL.md
@@ -4,9 +4,6 @@ description: >-
   Creates Infrahub check definitions — Python validation logic and GraphQL queries for proposed change pipelines.
   TRIGGER when: writing validation checks, creating Python checks, building data quality guards for proposed changes.
   DO NOT TRIGGER when: designing schemas, querying live data, building transforms or generators.
-paths:
-  - "checks/**/*.py"
-  - "queries/**/*.gql"
 allowed-tools:
   - Read
   - Write

--- a/skills/infrahub-managing-generators/SKILL.md
+++ b/skills/infrahub-managing-generators/SKILL.md
@@ -4,8 +4,6 @@ description: >-
   Creates Infrahub Generators — design-driven automation that builds infrastructure objects from templates and topology definitions.
   TRIGGER when: building design-to-implementation workflows, auto-creating objects from templates, topology-driven generation.
   DO NOT TRIGGER when: designing schemas, writing data transforms, querying live data, populating static data files.
-paths:
-  - "generators/**/*.py"
 allowed-tools:
   - Read
   - Write

--- a/skills/infrahub-managing-menus/SKILL.md
+++ b/skills/infrahub-managing-menus/SKILL.md
@@ -4,9 +4,6 @@ description: >-
   Creates Infrahub custom navigation menus for the web UI sidebar, organizing node types into logical groups.
   TRIGGER when: designing sidebar menus, grouping node types in UI, customizing Infrahub web interface navigation.
   DO NOT TRIGGER when: designing schemas, writing checks or transforms, populating data objects.
-paths:
-  - "menus/**/*.yml"
-  - "menus/**/*.yaml"
 allowed-tools:
   - Read
   - Write

--- a/skills/infrahub-managing-objects/SKILL.md
+++ b/skills/infrahub-managing-objects/SKILL.md
@@ -4,11 +4,6 @@ description: >-
   Creates and manages Infrahub object data YAML files for populating infrastructure instances — devices, locations, organizations, and modules.
   TRIGGER when: creating device instances, populating data files, defining locations or organizations, adding infrastructure objects.
   DO NOT TRIGGER when: designing schemas, writing Python checks/generators, querying live data.
-paths:
-  - "objects/**/*.yml"
-  - "objects/**/*.yaml"
-  - "data/**/*.yml"
-  - "data/**/*.yaml"
 allowed-tools:
   - Read
   - Write

--- a/skills/infrahub-managing-schemas/SKILL.md
+++ b/skills/infrahub-managing-schemas/SKILL.md
@@ -4,11 +4,6 @@ description: >-
   Creates, validates, and modifies Infrahub schema YAML files — nodes, generics, attributes, relationships, and extensions.
   TRIGGER when: designing data models, adding schema nodes, validating schema definitions, planning schema migrations.
   DO NOT TRIGGER when: populating data objects, writing checks/generators/transforms, querying live data.
-paths:
-  - "schemas/**/*.yml"
-  - "schemas/**/*.yaml"
-  - "*schema*.yml"
-  - "*schema*.yaml"
 allowed-tools:
   - Read
   - Write

--- a/skills/infrahub-managing-transforms/SKILL.md
+++ b/skills/infrahub-managing-transforms/SKILL.md
@@ -4,9 +4,6 @@ description: >-
   Creates Infrahub transforms that convert data into JSON, text, CSV, or device configs using Python or Jinja2 templates.
   TRIGGER when: building config generation, data export, format conversion, Jinja2 templates, artifact pipelines.
   DO NOT TRIGGER when: designing schemas, writing validation checks, creating generators, querying live data.
-paths:
-  - "transforms/**/*.py"
-  - "templates/**/*.j2"
 allowed-tools:
   - Read
   - Write


### PR DESCRIPTION
## Summary

- Removes the `paths:` block from the six `managing-*` SKILL.md files. After `npx infrahub-skills install`, Claude Code's skills loader was hiding those skills from the user-invocable list — only `analyzing-data`, `auditing-repo`, and `common` (the three without `paths:`) showed up.
- Root cause: `paths:` is not a standard Claude Code skill frontmatter field. The loader appears to either treat it as an auto-trigger glob filter or fail strict validation, in either case suppressing the skill from `/skill` invocation.
- Caught live during prep for today's Skills × Infrahub webinar — a fresh demo repo went through the install and `/infrahub-managing-schemas` returned "Unknown skill."

## Test plan

- [x] Verified locally by stripping `paths:` from the same six files in `.agents/skills/` of a fresh `infrahub-skills-demo`; all six immediately appeared in the available skills list.
- [x] Invoked `/infrahub-managing-schemas` end-to-end and authored a network schema that loads cleanly.
- [ ] Merge + auto-bump to v1.2.3 + cut a release so a fresh `npx infrahub-skills install` picks up the fix before the webinar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)