### PR TITLE
fix(skills): require args for infrahub-analyzing-data

### DIFF
--- a/skills/infrahub-analyzing-data/SKILL.md
+++ b/skills/infrahub-analyzing-data/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Analyzes and correlates live Infrahub data via the MCP server — answers operational questions, detects drift, and investigates impact.
   TRIGGER when: querying infrastructure data, checking compliance, investigating change impact, producing ad-hoc reports.
   DO NOT TRIGGER when: writing automated checks, building transforms, designing schemas, populating data files.
+  ALWAYS pass the user's question verbatim as args — this skill runs in a forked context and cannot see the parent conversation. Invoking without args will fail.
 context: fork
 allowed-tools:
   - Read
@@ -52,8 +53,18 @@ artifacts, see `../infrahub-managing-transforms/SKILL.md`.
 
 ## Project Context
 
-If invoked with arguments (e.g., `/infrahub:analyzing-data Which devices have no platform assigned?`),
-treat the arguments as the question to answer.
+This skill runs in a forked subagent context and has no visibility into the
+parent conversation. The user's question MUST be passed via arguments.
+
+- If invoked with arguments (e.g., `/infrahub:analyzing-data Which devices have no platform assigned?`),
+  treat the arguments as the question to answer.
+- If invoked with **no arguments**, do **not** guess, do **not** use any example
+  question from this file, and do **not** proceed. Return immediately with:
+
+  > **Error:** No question was passed to `infrahub-analyzing-data`. This skill
+  > runs in a forked context and requires the user's question as args. Re-invoke
+  > with the question, e.g.
+  > `Skill(skill="infrahub-analyzing-data", args="<the user's question>")`.
 
 ## When to Use
 


### PR DESCRIPTION
## Summary

- `infrahub-analyzing-data` runs in a forked subagent context (`context: fork`) and has no visibility into the parent conversation.
- When invoked without args, the fork was latching onto the example question baked into `SKILL.md` (`Which devices have no platform assigned?`) and answering that instead of the user's real question.
- This PR makes the requirement explicit in two reinforcing places so the failure mode cannot recur:
  1. **Frontmatter `description:`** — appends *"ALWAYS pass the user's question verbatim as args — this skill runs in a forked context and cannot see the parent conversation. Invoking without args will fail."* This is the only text the calling agent sees in its skill listing, so the instruction lands before the call is made.
  2. **Body "Project Context" section** — when invoked with no args, the fork now refuses to guess and returns an error telling the caller to re-invoke with the question, rather than silently answering an example.

## Why

Hit during a demo: the skill was called without args and answered an unrelated question instead of the one the user asked. Root cause is that `args` is marked optional on the `Skill` tool, and the prior SKILL.md only used permissive *"if invoked with arguments"* language, with no defined fallback behaviour for the no-args case — so the fork happily used the example question as the prompt.

## Test plan

- [ ] Invoke `infrahub-analyzing-data` with no args — confirm it returns the error message and does not answer the example question.
- [ ] Invoke with a real question via `args=...` — confirm it answers that question.
- [ ] Confirm parent agents see the `ALWAYS pass ... as args` instruction in the skill listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)