### PR TITLE
feat(skills): add infrahub-reporting-issues skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "infrahub",
   "version": "1.2.5",
-  "description": "A Claude Code plugin to support developing on top of Infrahub. Includes skills for schemas, objects, checks, generators, transforms, menus, and data analysis.",
+  "description": "A Claude Code plugin to support developing on top of Infrahub. Includes skills for schemas, objects, checks, generators, transforms, menus, data analysis, repo auditing, and ecosystem issue reporting.",
   "author": {
     "name": "Solution Engineering and Architecture",
     "email": "sa@opsmill.com"
@@ -19,7 +19,8 @@
     "data-center",
     "analysis",
     "correlation",
-    "mcp"
+    "mcp",
+    "issue-reporting"
   ],
   "repository": "https://github.com/opsmill/infrahub-skills"
 }

--- a/.github/.release-manifest.json
+++ b/.github/.release-manifest.json
@@ -8,6 +8,7 @@
     "infrahub-managing-transforms",
     "infrahub-managing-menus",
     "infrahub-auditing-repo",
-    "infrahub-analyzing-data"
+    "infrahub-analyzing-data",
+    "infrahub-reporting-issues"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ The repository is a pure Markdown-based skills project (no Python code). Each sk
 | `infrahub-managing-menus` | `skills/infrahub-managing-menus/` | Custom navigation menus |
 | `infrahub-analyzing-data` | `skills/infrahub-analyzing-data/` | Live data analysis via MCP server |
 | `infrahub-auditing-repo` | `skills/infrahub-auditing-repo/` | Audit repository against best practices |
+| `infrahub-reporting-issues` | `skills/infrahub-reporting-issues/` | Route and prepare bug/feature reports for any opsmill/infrahub-* repo |
 
 ### Key Directories
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A team already running Infrahub who needs to continue extending it — adding sc
 | **managing-menus** | Define custom navigation menus for the Infrahub web UI |
 | **analyzing-data** | Query and correlate live Infrahub data via the MCP server (requires MCP connection) |
 | **auditing-repo** | Audit your repository against Infrahub best practices |
+| **reporting-issues** | Route a bug or feature request to the right Infrahub-ecosystem repo (SDK, Ansible, VS Code, MCP, etc.) and prepare a sanitized draft for review |
 
 Each skill lives in `skills/infrahub-<name>/` with a `SKILL.md` entry point, reference docs, examples, and modular rules. Shared references (GraphQL patterns, `.infrahub.yml` format, git integration) are in `skills/infrahub-common/`. Skills use gerund-form names following the [Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices).
 
@@ -208,7 +209,8 @@ See [Cursor Rules docs](https://cursor.com/docs/rules).
 │   ├── infrahub-managing-transforms/ # Data transforms
 │   ├── infrahub-managing-menus/    # Navigation menus
 │   ├── infrahub-analyzing-data/    # Live data analysis (MCP)
-│   └── infrahub-auditing-repo/     # Best-practice audits
+│   ├── infrahub-auditing-repo/     # Best-practice audits
+│   └── infrahub-reporting-issues/  # Ecosystem issue reporting
 ├── CLAUDE.md
 ├── README.md
 └── LICENSE                      # Apache 2.0

--- a/eval.yaml
+++ b/eval.yaml
@@ -666,3 +666,134 @@ tasks:
         check: >-
           Targeted check_definitions entry declares both targets and
           parameters
+
+  # --- Issue Reporter --- #
+  - name: bug-sanitization
+    instruction: |
+      Read the skill at .agents/skills/infrahub-reporting-issues/SKILL.md and follow its workflow and rules.
+
+      Task: A user is reporting a bug in the Infrahub Python SDK. Here is the raw context they shared:
+
+      "I'm running infrahub-sdk version 1.5.2 against an Infrahub server (version 1.4.0) on my Mac.
+      When I call InfrahubClient.create() with an empty list of payloads, it raises a TypeError
+      instead of returning an empty result.
+
+      My config is at /Users/alice/work/acme-corp/infrahub-config.yml, and I'm connecting to
+      https://infrahub.acme.corp at 10.50.12.7. Here's my GitHub token I was using for testing:
+      ghp_abcdefghijklmnopqrstuvwxyz1234567890ABC. Python is 3.12.1, macOS 14 arm64."
+
+      Render a complete, sanitized GitHub issue body in Markdown that this user could file
+      against opsmill/infrahub-sdk-python. The body MUST:
+      - Include a title line as the first non-blank line (as a `#` heading or `Title:` line).
+      - Include an Environment section with versions and OS.
+      - Redact all sensitive details (IPs, internal hostnames, user paths, tokens) using
+        placeholders like <internal-ip>, <internal-host>, <internal-url>, <path>, or by
+        omitting tokens entirely.
+
+      Do NOT submit this anywhere — just render it. Save ONLY the final Markdown to: output.md
+    graders:
+      - type: deterministic
+        run: python graders/reporting-issues/check_bug_sanitization.py
+        weight: 1.0
+    expected_output: >-
+      A Markdown issue body starting with a title line (e.g.,
+      `# SDK: InfrahubClient.create raises on empty list payload`),
+      containing an Environment section with versions (infrahub-sdk
+      1.5.2, infrahub-server 1.4.0, Python 3.12.1) and OS (macOS 14
+      arm64). All sensitive context — the internal hostname
+      `infrahub.acme.corp`, the IP `10.50.12.7`, the user path
+      `/Users/alice/work/acme-corp/...`, and the GitHub token —
+      must be redacted with placeholders or omitted entirely.
+    expectations:
+      - Output begins with a single title line as a Markdown heading
+      - >-
+        Title follows the form `<area>: <imperative summary>` and is
+        ≤72 characters
+      - >-
+        Environment section lists product versions (infrahub-sdk,
+        infrahub-server), OS, and Python version
+      - >-
+        No raw IPs from the user's environment appear (10.50.12.7
+        must be redacted or omitted)
+      - >-
+        No internal hostnames appear (infrahub.acme.corp must be
+        redacted)
+      - >-
+        No user filesystem paths appear (/Users/alice/... must be
+        redacted)
+      - >-
+        The GitHub token must be entirely removed or replaced with
+        an explicit placeholder, never partially redacted
+    assertions:
+      - name: has-title
+        check: First non-blank line is a Markdown heading or `Title:` line
+      - name: has-environment-section
+        check: An Environment / Versions section exists
+      - name: no-leaked-ips
+        check: No real IPv4 addresses outside documentation prefixes appear
+      - name: no-internal-hostnames
+        check: >-
+          No hostnames with internal TLDs (.corp, .local, .internal,
+          etc.) appear
+      - name: no-tokens
+        check: No GitHub/AWS/Slack/JWT-style token patterns appear
+      - name: no-user-paths
+        check: No /Users/<name> or /home/<name> paths appear
+
+  - name: route-to-main-on-doubt
+    instruction: |
+      Read the skill at .agents/skills/infrahub-reporting-issues/SKILL.md and follow its workflow and rules.
+
+      Task: A user reports: "Something weird is happening — my schema loads fine in the UI
+      but my Ansible playbook can't find one of the nodes. I'm not sure if it's a schema
+      problem, an Ansible problem, or something with my SDK. I'm not sure where to file this."
+
+      Decide which opsmill/* repository this issue should be filed against. Output a single
+      paragraph that names the target repo (as `opsmill/<repo>`) and explains the routing
+      decision in ≤3 sentences. Do NOT render the issue itself — just the routing decision.
+
+      Save ONLY the routing paragraph to: output.md
+    expected_output: >-
+      The routing decision should name `opsmill/infrahub` as the
+      target repo, citing the default-to-main rule because the user
+      explicitly expressed doubt about which component is at fault.
+      The explanation should mention that the main repo can re-route
+      to a sub-repo more easily than the reverse, and that ambiguous
+      symptoms across schema/SDK/Ansible suggest a platform-layer
+      issue.
+    expectations:
+      - >-
+        Routing target is `opsmill/infrahub` (the main repo), not a
+        sub-repo
+      - >-
+        Decision explicitly cites user uncertainty as the reason
+      - >-
+        Mentions the default-to-main / re-routing rationale
+
+  - name: template-fidelity
+    instruction: |
+      Read the skill at .agents/skills/infrahub-reporting-issues/SKILL.md and follow its workflow and rules.
+
+      Task: A user wants to file a bug against opsmill/infrahub. Before composing the issue
+      body, list the commands you would run to fetch the repo's bug_report.yml issue template
+      and explain which template you would use. Do NOT compose the issue itself — just the
+      template-fetch plan.
+
+      Save ONLY the plan to: output.md
+    expected_output: >-
+      A short plan listing a `gh api` command to fetch the
+      `.github/ISSUE_TEMPLATE/bug_report.yml` file from
+      `opsmill/infrahub`, with a note that the YAML form fields
+      will be followed when composing the issue. The plan should
+      acknowledge that opsmill/infrahub ships its own bug template
+      and so the skill's generic fallback should NOT be used.
+    expectations:
+      - >-
+        Plan uses `gh api repos/opsmill/infrahub/contents/.github/ISSUE_TEMPLATE/bug_report.yml`
+        or an equivalent
+      - >-
+        Plan acknowledges opsmill/infrahub has its own bug_report
+        template
+      - >-
+        Plan states the generic templates/bug.md fallback is NOT
+        used when the repo ships its own template

--- a/eval.yaml
+++ b/eval.yaml
@@ -753,6 +753,10 @@ tasks:
       decision in ≤3 sentences. Do NOT render the issue itself — just the routing decision.
 
       Save ONLY the routing paragraph to: output.md
+    graders:
+      - type: deterministic
+        run: python graders/reporting-issues/check_route_to_main.py
+        weight: 1.0
     expected_output: >-
       The routing decision should name `opsmill/infrahub` as the
       target repo, citing the default-to-main rule because the user
@@ -769,6 +773,13 @@ tasks:
         Decision explicitly cites user uncertainty as the reason
       - >-
         Mentions the default-to-main / re-routing rationale
+    assertions:
+      - name: routes-to-main
+        check: Names `opsmill/infrahub` as the routing target (not a sub-repo)
+      - name: cites-uncertainty
+        check: >-
+          Explanation cites user doubt/uncertainty/ambiguity as the
+          routing rationale
 
   - name: template-fidelity
     instruction: |
@@ -780,6 +791,10 @@ tasks:
       template-fetch plan.
 
       Save ONLY the plan to: output.md
+    graders:
+      - type: deterministic
+        run: python graders/reporting-issues/check_template_fidelity.py
+        weight: 1.0
     expected_output: >-
       A short plan listing a `gh api` command to fetch the
       `.github/ISSUE_TEMPLATE/bug_report.yml` file from
@@ -797,3 +812,10 @@ tasks:
       - >-
         Plan states the generic templates/bug.md fallback is NOT
         used when the repo ships its own template
+    assertions:
+      - name: uses-gh-api-for-template
+        check: >-
+          Plan invokes `gh api` for the bug_report.yml path under
+          `.github/ISSUE_TEMPLATE/`
+      - name: references-target-repo
+        check: Plan references opsmill/infrahub as the target repo

--- a/evaluations/infrahub-reporting-issues.json
+++ b/evaluations/infrahub-reporting-issues.json
@@ -1,0 +1,70 @@
+{
+  "skill_name": "infrahub-reporting-issues",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "A user is reporting a bug in the Infrahub Python SDK. Here is the raw context they shared:\n\n\"I'm running infrahub-sdk version 1.5.2 against an Infrahub server (version 1.4.0) on my Mac.\nWhen I call InfrahubClient.create() with an empty list of payloads, it raises a TypeError\ninstead of returning an empty result.\n\nMy config is at /Users/alice/work/acme-corp/infrahub-config.yml, and I'm connecting to\nhttps://infrahub.acme.corp at 10.50.12.7. Here's my GitHub token I was using for testing:\nghp_abcdefghijklmnopqrstuvwxyz1234567890ABC. Python is 3.12.1, macOS 14 arm64.\"\n\nRender a complete, sanitized GitHub issue body in Markdown that this user could file\nagainst opsmill/infrahub-sdk-python. The body MUST:\n- Include a title line as the first non-blank line (as a `#` heading or `Title:` line).\n- Include an Environment section with versions and OS.\n- Redact all sensitive details (IPs, internal hostnames, user paths, tokens) using\n  placeholders like <internal-ip>, <internal-host>, <internal-url>, <path>, or by\n  omitting tokens entirely.\n\nDo NOT submit this anywhere \u2014 just render it. Save ONLY the final Markdown to: output.md",
+      "expected_output": "A Markdown issue body starting with a title line (e.g., `# SDK: InfrahubClient.create raises on empty list payload`), containing an Environment section with versions (infrahub-sdk 1.5.2, infrahub-server 1.4.0, Python 3.12.1) and OS (macOS 14 arm64). All sensitive context \u2014 the internal hostname `infrahub.acme.corp`, the IP `10.50.12.7`, the user path `/Users/alice/work/acme-corp/...`, and the GitHub token \u2014 must be redacted with placeholders or omitted entirely.",
+      "files": [],
+      "expectations": [
+        "Output begins with a single title line as a Markdown heading",
+        "Title follows the form `<area>: <imperative summary>` and is \u226472 characters",
+        "Environment section lists product versions (infrahub-sdk, infrahub-server), OS, and Python version",
+        "No raw IPs from the user's environment appear (10.50.12.7 must be redacted or omitted)",
+        "No internal hostnames appear (infrahub.acme.corp must be redacted)",
+        "No user filesystem paths appear (/Users/alice/... must be redacted)",
+        "The GitHub token must be entirely removed or replaced with an explicit placeholder, never partially redacted"
+      ],
+      "assertions": [
+        {
+          "name": "has-title",
+          "check": "First non-blank line is a Markdown heading or `Title:` line"
+        },
+        {
+          "name": "has-environment-section",
+          "check": "An Environment / Versions section exists"
+        },
+        {
+          "name": "no-leaked-ips",
+          "check": "No real IPv4 addresses outside documentation prefixes appear"
+        },
+        {
+          "name": "no-internal-hostnames",
+          "check": "No hostnames with internal TLDs (.corp, .local, .internal, etc.) appear"
+        },
+        {
+          "name": "no-tokens",
+          "check": "No GitHub/AWS/Slack/JWT-style token patterns appear"
+        },
+        {
+          "name": "no-user-paths",
+          "check": "No /Users/<name> or /home/<name> paths appear"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "A user reports: \"Something weird is happening \u2014 my schema loads fine in the UI\nbut my Ansible playbook can't find one of the nodes. I'm not sure if it's a schema\nproblem, an Ansible problem, or something with my SDK. I'm not sure where to file this.\"\n\nDecide which opsmill/* repository this issue should be filed against. Output a single\nparagraph that names the target repo (as `opsmill/<repo>`) and explains the routing\ndecision in \u22643 sentences. Do NOT render the issue itself \u2014 just the routing decision.",
+      "expected_output": "The routing decision should name `opsmill/infrahub` as the target repo, citing the default-to-main rule because the user explicitly expressed doubt about which component is at fault. The explanation should mention that the main repo can re-route to a sub-repo more easily than the reverse, and that ambiguous symptoms across schema/SDK/Ansible suggest a platform-layer issue.",
+      "files": [],
+      "expectations": [
+        "Routing target is `opsmill/infrahub` (the main repo), not a sub-repo",
+        "Decision explicitly cites user uncertainty as the reason",
+        "Mentions the default-to-main / re-routing rationale"
+      ],
+      "assertions": []
+    },
+    {
+      "id": 3,
+      "prompt": "A user wants to file a bug against opsmill/infrahub. Before composing the issue\nbody, list the commands you would run to fetch the repo's bug_report.yml issue template\nand explain which template you would use. Do NOT compose the issue itself \u2014 just the\ntemplate-fetch plan.",
+      "expected_output": "A short plan listing a `gh api` command to fetch the `.github/ISSUE_TEMPLATE/bug_report.yml` file from `opsmill/infrahub`, with a note that the YAML form fields will be followed when composing the issue. The plan should acknowledge that opsmill/infrahub ships its own bug template and so the skill's generic fallback should NOT be used.",
+      "files": [],
+      "expectations": [
+        "Plan uses `gh api repos/opsmill/infrahub/contents/.github/ISSUE_TEMPLATE/bug_report.yml` or an equivalent",
+        "Plan acknowledges opsmill/infrahub has its own bug_report template",
+        "Plan states the generic templates/bug.md fallback is NOT used when the repo ships its own template"
+      ],
+      "assertions": []
+    }
+  ]
+}

--- a/evaluations/infrahub-reporting-issues.json
+++ b/evaluations/infrahub-reporting-issues.json
@@ -52,7 +52,16 @@
         "Decision explicitly cites user uncertainty as the reason",
         "Mentions the default-to-main / re-routing rationale"
       ],
-      "assertions": []
+      "assertions": [
+        {
+          "name": "routes-to-main",
+          "check": "Names `opsmill/infrahub` as the routing target (not a sub-repo)"
+        },
+        {
+          "name": "cites-uncertainty",
+          "check": "Explanation cites user doubt/uncertainty/ambiguity as the routing rationale"
+        }
+      ]
     },
     {
       "id": 3,
@@ -64,7 +73,16 @@
         "Plan acknowledges opsmill/infrahub has its own bug_report template",
         "Plan states the generic templates/bug.md fallback is NOT used when the repo ships its own template"
       ],
-      "assertions": []
+      "assertions": [
+        {
+          "name": "uses-gh-api-for-template",
+          "check": "Plan invokes `gh api` for the bug_report.yml path under `.github/ISSUE_TEMPLATE/`"
+        },
+        {
+          "name": "references-target-repo",
+          "check": "Plan references opsmill/infrahub as the target repo"
+        }
+      ]
     }
   ]
 }

--- a/graders/reporting-issues/check_bug_sanitization.py
+++ b/graders/reporting-issues/check_bug_sanitization.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Grader script for the bug-sanitization eval task.
+
+Checks that the rendered bug report does not leak IPs, internal
+hostnames, tokens, or user filesystem paths, and that it has the
+basic structural elements (title, environment section).
+
+Usage::
+
+    python check_bug_sanitization.py <output_file>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECK_NAMES = [
+    "has-title",
+    "has-environment-section",
+    "no-leaked-ips",
+    "no-internal-hostnames",
+    "no-tokens",
+    "no-user-paths",
+]
+
+
+def main() -> None:
+    output_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output.md")
+    print(json.dumps(run_checks(CHECK_NAMES, output_path)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/reporting-issues/check_route_to_main.py
+++ b/graders/reporting-issues/check_route_to_main.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Grader for the route-to-main-on-doubt eval task.
+
+Asserts that the routing decision names `opsmill/infrahub` as the target
+and cites user uncertainty as the reason.
+
+Usage::
+
+    python check_route_to_main.py <output_file>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECK_NAMES = [
+    "routes-to-main",
+    "cites-uncertainty",
+]
+
+
+def main() -> None:
+    output_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output.md")
+    print(json.dumps(run_checks(CHECK_NAMES, output_path)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/reporting-issues/check_template_fidelity.py
+++ b/graders/reporting-issues/check_template_fidelity.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Grader for the template-fidelity eval task.
+
+Asserts that the plan references fetching the repo's bug_report.yml
+template via `gh api` and names opsmill/infrahub as the target.
+
+Usage::
+
+    python check_template_fidelity.py <output_file>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECK_NAMES = [
+    "uses-gh-api-for-template",
+    "references-target-repo",
+]
+
+
+def main() -> None:
+    output_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output.md")
+    print(json.dumps(run_checks(CHECK_NAMES, output_path)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/reporting-issues/lib.py
+++ b/graders/reporting-issues/lib.py
@@ -1,0 +1,223 @@
+"""Shared grader library for infrahub-reporting-issues skill evaluations.
+
+The skill produces markdown issue bodies, not YAML. Checks here scan the
+raw text for prohibited patterns (sanitization) and required structural
+elements (title format, environment section).
+
+Usage (in a per-task grader script)::
+
+    from pathlib import Path
+    from lib import run_checks
+
+    result = run_checks(
+        ["no-leaked-ips", "no-internal-hostnames", "no-tokens"],
+        Path("output.md"),
+    )
+    print(result)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Output loading
+# ---------------------------------------------------------------------------
+
+
+def load_output(path: Path) -> str:
+    """Read the model's output file as text."""
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# Sanitization check functions
+# ---------------------------------------------------------------------------
+
+
+# Allow-list of public IPs that may legitimately appear in docs/examples.
+# Loopback and documentation-prefix ranges (RFC 5737) are not sensitive.
+_PUBLIC_IP_ALLOWLIST = {
+    "127.0.0.1",
+    "0.0.0.0",
+    "255.255.255.255",
+}
+
+# IPv4 regex — four octets 0-255. Loose; we filter false-positives below.
+_IPV4_RE = re.compile(
+    r"\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}"
+    r"(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b"
+)
+
+# Documentation-prefix ranges per RFC 5737 — fine to leave in examples.
+_DOC_IP_PREFIXES = ("192.0.2.", "198.51.100.", "203.0.113.")
+
+
+def _is_allowed_ip(ip: str) -> bool:
+    if ip in _PUBLIC_IP_ALLOWLIST:
+        return True
+    if ip.startswith(_DOC_IP_PREFIXES):
+        return True
+    # Placeholder check — sometimes models write <1.2.3.4>-style placeholders
+    return False
+
+
+def check_no_leaked_ips(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if the output contains real-looking IPv4 addresses."""
+    found: list[str] = []
+    for match in _IPV4_RE.finditer(text):
+        ip = match.group(0)
+        if _is_allowed_ip(ip):
+            continue
+        # Skip IPs inside placeholder markers like <internal-ip:10.0.0.1>
+        start = max(0, match.start() - 20)
+        end = min(len(text), match.end() + 20)
+        window = text[start:end]
+        if "<internal-ip>" in window or "<redacted>" in window:
+            # Already adjacent to a placeholder — probably commentary
+            continue
+        found.append(ip)
+    if found:
+        sample = ", ".join(found[:3])
+        return False, f"Leaked IPs detected: {sample}"
+    return True, "No leaked IPs"
+
+
+# Internal-looking TLDs and hostname suffixes. Models should redact these.
+_INTERNAL_TLD_RE = re.compile(
+    r"\b[a-z0-9][a-z0-9-]{0,62}"
+    r"(?:\.[a-z0-9][a-z0-9-]{0,62})+"
+    r"\.(?:local|internal|corp|lan|intranet|home|private)\b",
+    re.IGNORECASE,
+)
+
+
+def check_no_internal_hostnames(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if hostnames with internal-looking TLDs are present."""
+    matches = _INTERNAL_TLD_RE.findall(text)
+    if matches:
+        sample = ", ".join(matches[:3])
+        return False, f"Internal hostnames detected: {sample}"
+    return True, "No internal hostnames"
+
+
+# Token patterns. Conservative — better to flag false-positives than miss real
+# tokens. Models should redact and ask the user, not autocorrect.
+_TOKEN_RES = [
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"),  # GitHub tokens
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),  # OpenAI-style secret keys
+    re.compile(r"xox[bpoa]-[A-Za-z0-9-]{10,}"),  # Slack tokens
+    re.compile(r"AKIA[0-9A-Z]{16}"),  # AWS access key ID
+    re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}"),  # JWT
+]
+
+
+def check_no_tokens(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if any common secret-token pattern is present."""
+    for pattern in _TOKEN_RES:
+        match = pattern.search(text)
+        if match:
+            return False, f"Token-like string detected: pattern {pattern.pattern[:20]}..."
+    return True, "No tokens detected"
+
+
+# Filesystem paths containing user home directories.
+_USER_HOME_RE = re.compile(r"(?:/Users/|/home/|C:\\Users\\)[A-Za-z][\w.-]+")
+
+
+def check_no_user_paths(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if filesystem paths containing usernames are present."""
+    matches = _USER_HOME_RE.findall(text)
+    # Filter examples that the model preserved inside placeholders or code
+    # fences specifically demonstrating sanitization.
+    real = [m for m in matches if not m.endswith("<user>") and not m.endswith("<name>")]
+    if real:
+        sample = ", ".join(real[:3])
+        return False, f"User home paths detected: {sample}"
+    return True, "No user home paths"
+
+
+# ---------------------------------------------------------------------------
+# Structural checks (light-touch — content not exhaustively validated)
+# ---------------------------------------------------------------------------
+
+
+def check_has_environment_section(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if the output has no Environment / Versions section."""
+    if re.search(
+        r"^#{1,3}\s*(environment|versions?|system info)\b",
+        text,
+        re.IGNORECASE | re.MULTILINE,
+    ):
+        return True, "Environment section present"
+    return False, "No Environment/Versions section found"
+
+
+def check_has_title(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if no plausible title line is present.
+
+    A title is a first-level heading or a leading `Title:` line. Required
+    so the user-review step has something to evaluate.
+    """
+    first_nonblank = next((line for line in text.splitlines() if line.strip()), "")
+    if first_nonblank.startswith("#") or re.match(
+        r"^title:\s*\S", first_nonblank, re.IGNORECASE
+    ):
+        return True, "Title line present"
+    return False, "No title line found at top of output"
+
+
+# ---------------------------------------------------------------------------
+# CHECKS registry
+# ---------------------------------------------------------------------------
+
+
+CHECKS = {
+    "no-leaked-ips": check_no_leaked_ips,
+    "no-internal-hostnames": check_no_internal_hostnames,
+    "no-tokens": check_no_tokens,
+    "no-user-paths": check_no_user_paths,
+    "has-environment-section": check_has_environment_section,
+    "has-title": check_has_title,
+}
+
+
+def run_checks(check_names: list[str], output_path: Path) -> dict:
+    """Run named checks against the output file and return skillgrade JSON."""
+    text = load_output(output_path)
+
+    entries: list[dict] = []
+    passed_count = 0
+
+    for name in check_names:
+        fn = CHECKS[name]
+        try:
+            ok, msg = fn(text)
+        except Exception as exc:  # pragma: no cover — defensive
+            ok, msg = False, f"Error running check: {exc}"
+        if ok:
+            passed_count += 1
+        entries.append({"name": name, "passed": ok, "message": msg})
+
+    total = len(check_names)
+    score = round(passed_count / total, 4) if total > 0 else 0.0
+    failed = [e["name"] for e in entries if not e["passed"]]
+    if failed:
+        details = f"{passed_count}/{total} checks passed. Failed: {', '.join(failed)}"
+    else:
+        details = f"All {total} checks passed."
+
+    return {"score": score, "details": details, "checks": entries}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output.md")
+    print(json.dumps(run_checks(list(CHECKS.keys()), out), indent=2))

--- a/graders/reporting-issues/lib.py
+++ b/graders/reporting-issues/lib.py
@@ -174,6 +174,101 @@ def check_has_title(text: str, **_: Any) -> tuple[bool, str]:
 
 
 # ---------------------------------------------------------------------------
+# Routing decision checks
+# ---------------------------------------------------------------------------
+
+
+# Sub-repos that should NOT be named as the primary routing target when the
+# user has expressed doubt. Listed in the routing-default-to-main eval.
+_SUB_REPO_NAMES = (
+    "opsmill/infrahub-sdk-python",
+    "opsmill/infrahub-ansible",
+    "opsmill/infrahub-vscode",
+    "opsmill/nornir-infrahub",
+    "opsmill/infrahub-helm",
+    "opsmill/infrahub-mcp",
+    "opsmill/schema-library",
+    "opsmill/infrahub-backup",
+    "opsmill/infrahub-sync",
+    "opsmill/infrahub-skills",
+)
+
+
+def check_routes_to_main(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if the output does not name opsmill/infrahub as the target."""
+    if "opsmill/infrahub" not in text:
+        return False, "Output does not mention opsmill/infrahub"
+    # Reject if a sub-repo is named while opsmill/infrahub is not
+    # established as the primary target.
+    sub_mentioned = next((r for r in _SUB_REPO_NAMES if r in text), None)
+    # Heuristic: if the output mentions opsmill/infrahub on a line that
+    # uses "target", "file", "route", "open", "report" — accept it.
+    primary_pattern = re.compile(
+        r"opsmill/infrahub\b[^-]",
+    )
+    if not primary_pattern.search(text):
+        return False, "opsmill/infrahub appears only as a prefix of a sub-repo name"
+    if sub_mentioned:
+        # Acceptable only if the sub-repo is named as a non-target reference,
+        # e.g., "could be Ansible or SDK". Reject if it is named as the
+        # routing target.
+        target_for_sub = re.compile(
+            r"(?:file|route|target|open|report)\s+(?:it\s+)?(?:in|to|against)\s+"
+            + re.escape(sub_mentioned),
+            re.IGNORECASE,
+        )
+        if target_for_sub.search(text):
+            return False, f"Routes to sub-repo {sub_mentioned} instead of main"
+    return True, "Routes to opsmill/infrahub"
+
+
+def check_cites_uncertainty(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if the rationale does not cite user doubt/ambiguity."""
+    keywords = (
+        "doubt",
+        "uncertain",
+        "ambig",
+        "unclear",
+        "not sure",
+        "unsure",
+        "unknown",
+    )
+    lower = text.lower()
+    if any(kw in lower for kw in keywords):
+        return True, "Mentions user uncertainty"
+    return False, "Does not cite user doubt/ambiguity"
+
+
+# ---------------------------------------------------------------------------
+# Template-fidelity checks
+# ---------------------------------------------------------------------------
+
+
+def check_uses_gh_api_for_template(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if the plan does not reference fetching the template via gh."""
+    has_gh_api = re.search(r"gh\s+api\b", text)
+    has_template_path = re.search(
+        r"\.github/ISSUE_TEMPLATE/bug_report\.ya?ml",
+        text,
+    )
+    if has_gh_api and has_template_path:
+        return True, "Plan fetches bug_report.yml via gh api"
+    missing = []
+    if not has_gh_api:
+        missing.append("`gh api` invocation")
+    if not has_template_path:
+        missing.append("ISSUE_TEMPLATE/bug_report.yml path")
+    return False, f"Missing: {', '.join(missing)}"
+
+
+def check_references_target_repo(text: str, **_: Any) -> tuple[bool, str]:
+    """Fail if the plan does not reference opsmill/infrahub."""
+    if "opsmill/infrahub" in text:
+        return True, "References opsmill/infrahub"
+    return False, "Does not reference target repo opsmill/infrahub"
+
+
+# ---------------------------------------------------------------------------
 # CHECKS registry
 # ---------------------------------------------------------------------------
 
@@ -185,6 +280,10 @@ CHECKS = {
     "no-user-paths": check_no_user_paths,
     "has-environment-section": check_has_environment_section,
     "has-title": check_has_title,
+    "routes-to-main": check_routes_to_main,
+    "cites-uncertainty": check_cites_uncertainty,
+    "uses-gh-api-for-template": check_uses_gh_api_for_template,
+    "references-target-repo": check_references_target_repo,
 }
 
 

--- a/skills/infrahub-reporting-issues/SKILL.md
+++ b/skills/infrahub-reporting-issues/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: infrahub-reporting-issues
+description: >-
+  Reports bugs and feature requests against the right Infrahub-ecosystem GitHub repository.
+  Classifies the request, routes it (with the main `opsmill/infrahub` repo as the safe fallback when in doubt),
+  searches for existing duplicates, gathers conservative environment info for bugs, and prepares the issue
+  for the user to review before any submission.
+  TRIGGER when: user wants to report a bug, file an issue, request a feature, open a ticket, or escalate a problem
+  in any opsmill/infrahub-* project (SDK, Ansible, VS Code, MCP, Helm, schema-library, sync, backup, nornir, skills).
+  DO NOT TRIGGER when: the user wants to fix the bug themselves locally, write a test, or debug code without filing.
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+  - WebFetch
+metadata:
+  version: 1.2.5
+  author: OpsMill
+---
+
+# Infrahub Issue Reporter
+
+## Overview
+
+Help the user file a bug report or feature request
+against the correct Infrahub-ecosystem repository on
+GitHub. The skill does **not** auto-submit — it
+prepares a complete, sanitized issue and stops at the
+user's review gate. Submission only happens after the
+user explicitly approves both the content and the
+submission method.
+
+The ecosystem has 11 candidate repos. Most users will
+not know which one owns their problem. The skill's
+job is to make a confident guess from local-repo
+context, confirm it with the user, search for
+duplicates, and produce a draft that matches the
+target repo's intake form.
+
+## When to Use
+
+Trigger this skill when the user says things like:
+
+- "I think I found a bug in Infrahub"
+- "How do I report this issue?"
+- "I'd like to request a feature"
+- "Where should I file this?"
+- "This isn't working — I want to open a ticket"
+
+Do not trigger if the user is debugging locally and
+hasn't expressed an intent to file an issue. Filing
+is the action that distinguishes this skill from
+general troubleshooting.
+
+## Workflow
+
+Follow these steps in order. Stop at every user-gate
+step — never proceed past one without explicit
+confirmation.
+
+### 1. Capture the problem
+
+Ask the user to describe the problem in their own
+words if they haven't already. Don't probe yet —
+just listen. Take note of any product names, version
+numbers, error messages, or workflow context they
+mention; they feed every later step.
+
+### 2. Classify
+
+Decide whether this is a **bug**, **feature
+request**, or **question/usage help**. Use 1-2
+follow-ups only if classification is ambiguous:
+
+- "Did this work before and now doesn't, or is it
+  something that's never existed?"
+- "Do you have a reproduction case, or is this an
+  intermittent observation?"
+- "Is the desired behavior documented anywhere, or
+  is this new functionality you're asking for?"
+
+If the user describes a workaround they're already
+using, lean toward "feature request" (the bug has a
+workaround → real problem is the missing
+ergonomics). If the user describes a crash, wrong
+output, or 500-level error, lean toward "bug". If
+the user is asking how to do something, route them
+to Discord/discussions instead of filing an issue
+— don't open issues for support questions.
+
+### 3. Route to a repo
+
+Read `reference.md` for the full 11-repo registry,
+detection cues, and template availability. Apply this
+detection logic in order:
+
+1. Read the local working directory for filesystem
+   cues (`infrahub.toml`, `pyproject.toml` deps,
+   `galaxy.yml`, `.claude-plugin/plugin.json`, etc.)
+2. Cross-reference detected cues with what the user
+   said. A user complaining about Ansible playbooks
+   in a repo with no Ansible cues is still an
+   Ansible issue.
+3. Pick the most specific match.
+
+**The default-to-main rule**: if detection is
+ambiguous, if multiple repos match equally, if the
+user expresses any uncertainty about which component
+is at fault, or if the symptom plausibly lives at
+the platform layer — **default to `opsmill/infrahub`**.
+The main repo can re-route an incoming issue to a
+sub-repo more easily than a sub-repo can re-route
+back. Erring toward main is cheaper than erring
+toward a wrong specialized repo.
+
+Present your guess to the user with a one-sentence
+rationale and ask them to confirm or correct. Example:
+
+> "Based on `infrahub-sdk` in your `pyproject.toml`
+> and the error mentioning `InfrahubClient`, this
+> looks like an `opsmill/infrahub-sdk-python` issue.
+> Confirm?"
+
+### 4. Search for duplicates
+
+Always search both bugs and features. Use the first
+available method:
+
+1. **`gh` CLI** — `gh search issues --repo <owner/repo>
+   --state all "<keywords>"`. Pull keywords from the
+   user's description plus any error message strings.
+   Run a second pass with synonyms if the first
+   returns nothing.
+2. **MCP GitHub server** — if `gh` is not installed,
+   use whichever GitHub MCP tool is available in the
+   user's environment.
+3. **Manual** — if neither is available, give the
+   user the GitHub search URL and ask them to check.
+
+Show the user the top 3-5 matches with title, state
+(open/closed), and a one-line excerpt. Ask:
+
+> "Is your issue covered by any of these? If yes,
+> we'll add a comment instead of opening a new one."
+
+If a match exists, switch to **comment mode**:
+prepare a comment that adds the user's new
+information (their version, reproduction, etc.) to
+the existing issue. Otherwise, proceed.
+
+### 5. Gather environment info (bugs only)
+
+For features, skip this step. For bugs, collect
+**only**:
+
+- The relevant product version(s) — e.g., Infrahub
+  server version, SDK version, Ansible collection
+  version, plugin version.
+- Operating system + architecture (e.g., `macOS 14
+  arm64`, `Ubuntu 22.04 x86_64`).
+- Python or runtime version if relevant to the
+  component.
+
+That's it. **Do not** collect file paths, project
+structure, logs verbatim, env dumps, `docker
+compose ps` output, or anything that could leak
+internal state. The
+[environment-info-sanitization rule](rules/environment-info-sanitization.md)
+governs what is and is not allowed in the issue body
+— read it before composing the bug section.
+
+Where to find versions:
+
+| Component | Command |
+| --------- | ------- |
+| Infrahub server | `infrahubctl --version`, or check `image:` tag in compose file |
+| Python SDK | `pip show infrahub-sdk` |
+| Ansible collection | `ansible-galaxy collection list opsmill.infrahub` |
+| Nornir plugin | `pip show nornir-infrahub` |
+| Helm chart | `helm list -n <namespace>` |
+| infrahub-sync | `infrahub-sync --version` |
+| infrahub-backup | `infrahub-backup --version` |
+| MCP server | check MCP client config or `pip show infrahub-mcp` |
+| VS Code extension | Extensions panel in VS Code |
+| Skills plugin | `.claude-plugin/plugin.json` version field |
+
+If a version can't be determined cleanly, mark it
+`unknown` rather than guessing or running broader
+discovery commands.
+
+### 6. Render the issue
+
+If the target repo has a `.github/ISSUE_TEMPLATE/`
+directory, fetch the matching template (`bug_report.yml`
+for bugs, `feature_request.yml` for features) and
+follow its form fields. Use:
+
+```bash
+gh api repos/<owner>/<repo>/contents/.github/ISSUE_TEMPLATE/bug_report.yml --jq '.content' | base64 -d
+```
+
+Repos that ship issue templates:
+
+- `opsmill/infrahub`
+- `opsmill/infrahub-sdk-python`
+- `opsmill/infrahub-ansible`
+- `opsmill/nornir-infrahub`
+
+Repos without templates fall back to
+`templates/bug.md` or `templates/feature.md` in this
+skill.
+
+**Title conventions**: use the form
+`<area>: <imperative summary>`, keep it under 72
+characters, no trailing punctuation. Examples:
+
+- `SDK: InfrahubClient.create() raises on empty list payload`
+- `Schema: hierarchical generic loses parent on rename`
+- `Docs: clarify human_friendly_id behavior for inherited nodes`
+
+### 7. User review gate (mandatory)
+
+Present the rendered issue to the user. Show:
+
+- Target repo and URL
+- Final title
+- Full body (markdown)
+- Whether this is a new issue or a comment on an
+  existing one
+
+Ask: "Does the content look right? Anything to add
+or remove before we proceed?"
+
+**Do not skip this step.** Iterate with the user
+until they explicitly approve the content.
+
+### 8. Pick a submission method
+
+Once content is approved, ask the user how they want
+to submit:
+
+1. **`gh issue create`** — direct via the CLI. Use
+   `gh issue create --repo <owner/repo> --title
+   "..." --body "..."`. Show the resulting URL.
+2. **MCP GitHub server** — if the user has a GitHub
+   MCP server, use it. Confirm the tool name with
+   the user before invoking.
+3. **Manual** — print the title and body as
+   copy-paste-ready markdown, plus the "New issue"
+   URL for the target repo:
+   `https://github.com/<owner>/<repo>/issues/new`.
+
+Never assume a default — always ask. After the user
+picks a method, execute it.
+
+### 9. Confirm
+
+After submission, give the user:
+
+- The new issue URL (for gh/MCP submissions)
+- A one-line summary of what was filed
+- A reminder that they can subscribe to the issue
+  for updates
+
+## Rule Categories
+
+| Prefix | Category | Description |
+| ------ | -------- | ----------- |
+| env | Environment info | What can and cannot appear in issue bodies |
+
+See [rules/_sections.md](rules/_sections.md) for the
+index.
+
+## Supporting References
+
+- [reference.md](reference.md) — the 11-repo
+  registry with detection cues, descriptions, and
+  template availability. **Read this in step 3.**
+- [templates/bug.md](templates/bug.md) — generic
+  fallback bug template for repos without a
+  `.github/ISSUE_TEMPLATE/`.
+- [templates/feature.md](templates/feature.md) —
+  generic fallback feature template.
+- [rules/environment-info-sanitization.md](rules/environment-info-sanitization.md)
+  — what to redact before submitting. Security-critical;
+  read this for every bug report.
+
+## Anti-patterns
+
+- **Submitting without explicit user approval.**
+  The user gate in step 7 is not optional. A
+  surprise GitHub issue on a public repo is hard to
+  unwind.
+- **Filing in a sub-repo when the symptom is
+  ambiguous.** When in doubt, file in
+  `opsmill/infrahub` and let the maintainers
+  re-route. Wrong sub-repo issues create more work
+  for everyone.
+- **Filing a duplicate.** If a search match exists,
+  default to adding a comment with new info instead
+  of opening a new issue.
+- **Pasting full logs or `docker compose` output.**
+  These leak hostnames, IPs, container names, and
+  sometimes secrets. Stick to versions + OS for v1.
+- **Filing support questions as bugs.** "How do I
+  do X?" belongs in Discord or GitHub Discussions,
+  not Issues.

--- a/skills/infrahub-reporting-issues/reference.md
+++ b/skills/infrahub-reporting-issues/reference.md
@@ -1,0 +1,263 @@
+# Infrahub Ecosystem Repo Registry
+
+The 11 repositories where Infrahub-ecosystem issues
+live. Use this registry in step 3 of the workflow to
+route an incoming report to the right repo.
+
+When in doubt, default to `opsmill/infrahub`. The
+main repo can re-route an issue to a sub-repo more
+easily than the reverse.
+
+## Routing precedence
+
+1. Strong local cue + matching user description → use
+   the matched repo.
+2. Strong local cue, but user describes a different
+   product → use the product the user describes.
+3. Weak or no local cue → ask the user one
+   clarifying question, then default to
+   `opsmill/infrahub` if still ambiguous.
+
+## Registry
+
+### `opsmill/infrahub` — the platform (default fallback)
+
+Graph-based infrastructure data management platform
+with built-in version control, CI workflows, peer
+review, and API access. The core product that
+everything else integrates with.
+
+**Detection cues**:
+
+- `infrahub.toml` in repo root
+- `docker-compose*.yml` referencing `infrahub-server`,
+  `infrahub-task-worker`, or `infrahub-task-manager`
+- Schema YAML with `version: "1.0"` plus `nodes:` or
+  `generics:`
+- `.infrahub.yml` (this also matches several other
+  repos — not exclusive)
+
+**Issue templates**: `bug_report.yml`,
+`feature_request.yml`, `task.yml`
+
+**URL**: <https://github.com/opsmill/infrahub>
+
+---
+
+### `opsmill/infrahub-sdk-python` — the Python SDK
+
+Python SDK for interacting with Infrahub
+programmatically. Used by checks, generators,
+transforms, and any custom Python code talking to an
+Infrahub server.
+
+**Detection cues**:
+
+- `infrahub-sdk` in `pyproject.toml` dependencies or
+  `requirements*.txt`
+- `import infrahub_sdk` or `from infrahub_sdk import
+  ...` in Python files
+- Error messages mentioning `InfrahubClient`,
+  `InfrahubClientSync`, or `infrahub_sdk.*` modules
+
+**Issue templates**: `bug_report.yml`,
+`feature_request.yml`, `task.yml`
+
+**URL**: <https://github.com/opsmill/infrahub-sdk-python>
+
+---
+
+### `opsmill/infrahub-vscode` — the VS Code extension
+
+Visual Studio Code extension that enhances the
+Infrahub development experience (schema validation,
+syntax highlighting, etc.).
+
+**Detection cues**:
+
+- Filesystem cues are unreliable for this one. Rely
+  on the user describing VS Code, the extension UI,
+  or editor-specific behavior.
+
+**Issue templates**: none — use generic
+`templates/bug.md` / `templates/feature.md`.
+
+**URL**: <https://github.com/opsmill/infrahub-vscode>
+
+---
+
+### `opsmill/infrahub-ansible` — the Ansible Collection
+
+Ansible Collection for managing Infrahub resources
+from playbooks. Provides modules and inventory plugins
+for the `opsmill.infrahub` namespace.
+
+**Detection cues**:
+
+- `ansible_collections/opsmill/infrahub/` directory
+- `galaxy.yml` referencing `opsmill.infrahub`
+- Playbooks using `opsmill.infrahub.*` modules
+- Inventory files with `plugin: opsmill.infrahub.inventory`
+
+**Issue templates**: `bug_report.yml`,
+`feature_request.yml`, `documentation_change.yml`,
+`housekeeping.yml`
+
+**URL**: <https://github.com/opsmill/infrahub-ansible>
+
+---
+
+### `opsmill/nornir-infrahub` — the Nornir plugin
+
+Nornir inventory plugin for sourcing devices from
+Infrahub. Used in Python automation workflows that
+combine Infrahub with Nornir/NAPALM/Netmiko.
+
+**Detection cues**:
+
+- `nornir-infrahub` in `pyproject.toml` dependencies
+- `import nornir_infrahub` or
+  `from nornir_infrahub.plugins.inventory import
+  InfrahubInventory`
+- Nornir config files referencing the plugin
+
+**Issue templates**: `bug_report.yml`,
+`feature_request.yml`, `task.yml`
+
+**URL**: <https://github.com/opsmill/nornir-infrahub>
+
+---
+
+### `opsmill/infrahub-helm` — the Helm chart
+
+Helm charts for deploying Infrahub on Kubernetes.
+
+**Detection cues**:
+
+- `Chart.yaml` with `name: infrahub` or referencing
+  the opsmill chart repo
+- `values.yaml` with Infrahub-specific keys
+  (`infrahub.server.*`, `infrahub.cache.*`)
+- Kubernetes manifests generated from the chart
+
+**Issue templates**: none — use generic templates.
+
+**URL**: <https://github.com/opsmill/infrahub-helm>
+
+---
+
+### `opsmill/infrahub-mcp` — the MCP server
+
+MCP (Model Context Protocol) server exposing Infrahub
+to AI coding agents. Used by Claude Code and other
+MCP clients to query live Infrahub data.
+
+**Detection cues**:
+
+- MCP client config (`.mcp.json`, Claude Desktop
+  config, etc.) with an `infrahub-mcp` entry
+- `infrahub-mcp` pip-installed
+- User mentions querying Infrahub through their AI
+  agent or "the Infrahub MCP"
+
+**Issue templates**: none — use generic templates.
+
+**URL**: <https://github.com/opsmill/infrahub-mcp>
+
+---
+
+### `opsmill/schema-library` — the schema library
+
+Curated collection of reusable Infrahub schemas
+(DCIM, IPAM, etc.) that users can drop into their
+projects as a starting point.
+
+**Detection cues**:
+
+- The user is reporting a problem with a specific
+  schema they got from the library
+- Local layout mirrors the upstream `schemas/`
+  directory structure
+- Schema files that match published library schemas
+  (e.g., generic `DcimDevice` schemas)
+
+**Issue templates**: none — use generic templates.
+
+**URL**: <https://github.com/opsmill/schema-library>
+
+---
+
+### `opsmill/infrahub-backup` — the backup CLI
+
+CLI tool for backing up and restoring Infrahub data
+(database snapshots, etc.).
+
+**Detection cues**:
+
+- `infrahub-backup` invocations in shell scripts or
+  cron entries
+- `pip show infrahub-backup` succeeds
+- User mentions backup/restore workflows
+
+**Issue templates**: none — use generic templates.
+
+**URL**: <https://github.com/opsmill/infrahub-backup>
+
+---
+
+### `opsmill/infrahub-sync` — the sync tool
+
+Python package + Typer CLI for syncing data between
+Infrahub and other sources of truth (Netbox,
+Nautobot, etc.).
+
+**Detection cues**:
+
+- `infrahub-sync` in `pyproject.toml` dependencies
+- `sync.yml` configuration files
+- The user is reporting bidirectional sync issues
+  between Infrahub and Netbox/Nautobot
+
+**Issue templates**: none — use generic templates.
+
+**URL**: <https://github.com/opsmill/infrahub-sync>
+
+---
+
+### `opsmill/infrahub-skills` — this plugin
+
+The Claude Code plugin that contains these skills
+themselves (schema, objects, checks, etc.).
+
+**Detection cues**:
+
+- `.claude-plugin/plugin.json` with `"name":
+  "infrahub"`
+- `skills/infrahub-*/SKILL.md` files present
+- User reporting a problem with skill behavior
+  (e.g., "the managing-schemas skill generates wrong
+  output")
+
+**Issue templates**: none — use generic templates.
+
+**URL**: <https://github.com/opsmill/infrahub-skills>
+
+## Template availability summary
+
+| Repo | bug | feature | other |
+| ---- | --- | ------- | ----- |
+| `opsmill/infrahub` | yes | yes | task |
+| `opsmill/infrahub-sdk-python` | yes | yes | task |
+| `opsmill/infrahub-ansible` | yes | yes | doc, housekeeping |
+| `opsmill/nornir-infrahub` | yes | yes | task |
+| `opsmill/infrahub-vscode` | — | — | — |
+| `opsmill/infrahub-helm` | — | — | — |
+| `opsmill/infrahub-mcp` | — | — | — |
+| `opsmill/schema-library` | — | — | — |
+| `opsmill/infrahub-backup` | — | — | — |
+| `opsmill/infrahub-sync` | — | — | — |
+| `opsmill/infrahub-skills` | — | — | — |
+
+For repos with templates, fetch the YAML form via
+`gh api` and follow its field order. For the rest,
+fall back to the generic templates in this skill.

--- a/skills/infrahub-reporting-issues/rules/_sections.md
+++ b/skills/infrahub-reporting-issues/rules/_sections.md
@@ -1,0 +1,9 @@
+# Issue Reporter Rule Sections
+
+This skill keeps most of its guidance inline in
+`SKILL.md`. Only security-critical concerns get
+standalone rule files with eval coverage.
+
+| Prefix | Category | Description |
+| ------ | -------- | ----------- |
+| `env-` | Environment info | What can and cannot appear in issue bodies. Security-critical: bad redaction leaks internal infrastructure to public GitHub. |

--- a/skills/infrahub-reporting-issues/rules/environment-info-sanitization.md
+++ b/skills/infrahub-reporting-issues/rules/environment-info-sanitization.md
@@ -1,0 +1,129 @@
+# Rule: env-info-sanitization
+
+**Severity**: CRITICAL
+**Category**: Environment info
+
+## What It Checks
+
+Bug reports filed against public GitHub repos must
+not leak internal infrastructure details. The bug
+section of an issue body is rendered publicly, indexed
+by search engines, and cannot be reliably retracted
+once submitted. This rule defines what is and is not
+allowed to appear in the environment section of a
+generated bug report.
+
+## Why It Matters
+
+Once an issue is filed on a public repo:
+
+- It is indexed by GitHub search, Google, and AI
+  training scrapers within hours.
+- Editing or deleting the issue does not remove it
+  from those caches.
+- Internal hostnames, IP ranges, and container names
+  reveal network topology that can be cross-referenced
+  with the user's employer.
+- Tokens, even partial ones, are immediately scraped
+  by automated bots and used for credential stuffing.
+
+The cost of a single leaked production hostname can
+exceed the lifetime cost of every other skill in this
+plugin combined. The sanitization rule is the most
+load-bearing rule in this skill — get this one wrong
+and the rest of the workflow is irrelevant.
+
+## What Is Allowed
+
+The environment section may contain **only**:
+
+1. **Product versions** — e.g., `infrahub-sdk 1.5.2`,
+   `infrahub-server 1.4.0`. Public software versions
+   are not sensitive.
+2. **OS + architecture** — e.g., `macOS 14 arm64`,
+   `Ubuntu 22.04 x86_64`. Generic OS info is not
+   sensitive.
+3. **Runtime version** — e.g., `Python 3.12`,
+   `Node 20`. Not sensitive.
+
+Anything else requires explicit justification AND
+explicit user opt-in.
+
+## What Must Be Redacted
+
+The following patterns must never appear in the
+issue body. If detected, replace with the listed
+placeholder.
+
+| Pattern | Replace with |
+| ------- | ------------ |
+| IPv4 addresses (e.g., `10.20.30.40`) | `<internal-ip>` |
+| IPv6 addresses | `<internal-ipv6>` |
+| Hostnames containing internal/private TLDs (`.local`, `.internal`, `.corp`, `.lan`, or any custom org domain mentioned by the user) | `<internal-host>` |
+| URLs pointing to internal services (e.g., `https://infrahub.acme.corp`) | `<internal-url>` |
+| API tokens, JWTs, Bearer tokens, anything matching `gh[pousr]_[A-Za-z0-9]{36,}` or other obvious secret patterns | **abort and ask the user** |
+| Filesystem paths containing usernames (e.g., `/Users/alice/...`, `/home/bob/...`) | `<path>` |
+| Container names, pod names, k8s namespaces from the user's environment | `<container>` / `<namespace>` |
+| Database connection strings | **abort and ask the user** |
+| Email addresses (other than the user's GitHub-visible address) | `<email>` |
+
+## Abort-and-ask cases
+
+If the issue body would contain a token, secret, or
+database connection string after sanitization
+attempts, **stop**. Do not file the issue. Tell the
+user what was detected, where, and ask them to
+manually rewrite that section. Do not try to "fix"
+secrets by partial redaction — bots will still try
+the partial value.
+
+## Examples
+
+**Compliant environment section**:
+
+```markdown
+## Environment
+
+- infrahub-sdk: 1.5.2
+- infrahub-server: 1.4.0
+- OS: macOS 14 arm64
+- Python: 3.12.1
+```
+
+**Non-compliant** (leaks hostname, path, IP):
+
+```markdown
+## Environment
+
+- infrahub-sdk: 1.5.2
+- Connected to https://infrahub.acme.corp
+- Config at /Users/alice/work/acme-infra/config.yml
+- Server IP: 10.50.12.7
+```
+
+**After sanitization**:
+
+```markdown
+## Environment
+
+- infrahub-sdk: 1.5.2
+- Connected to <internal-url>
+- Config at <path>
+- Server IP: <internal-ip>
+```
+
+## Common Mistakes
+
+- Pasting `infrahubctl --version` output verbatim
+  when it includes a server URL.
+- Including stack traces without scrubbing file
+  paths (they typically contain `/Users/<name>/`).
+- Pasting `pip list` or `pip freeze` output — far
+  more than the required versions, and may reveal
+  private package indexes via implicit context.
+- Leaving the user's email in `git config user.email`
+  output when it's an internal-domain email.
+- Believing partial token redaction is safe.
+  `gh${actual_letters}_xxx...` is still scraped.
+- Forgetting that container names often encode
+  team/project names from internal conventions.

--- a/skills/infrahub-reporting-issues/templates/bug.md
+++ b/skills/infrahub-reporting-issues/templates/bug.md
@@ -1,0 +1,42 @@
+<!--
+Generic bug template for Infrahub-ecosystem repos
+that do not ship their own .github/ISSUE_TEMPLATE/.
+When a repo has its own template, use that instead.
+-->
+
+## What happened
+
+<!-- One or two sentences describing the symptom. What did
+you observe? -->
+
+## Expected behavior
+
+<!-- What did you expect to happen instead? -->
+
+## Steps to reproduce
+
+1. <!-- step one -->
+2. <!-- step two -->
+3. <!-- step three -->
+
+## Environment
+
+- **Component version**: <!-- e.g., infrahub-sdk 1.5.2 -->
+- **Infrahub server version**: <!-- e.g., 1.4.0 (or "unknown") -->
+- **OS / architecture**: <!-- e.g., macOS 14 arm64 -->
+- **Python version** (if applicable): <!-- e.g., 3.12 -->
+
+<!--
+Do not paste full logs, file paths, hostnames, IPs,
+container names, or environment dumps. If a stack
+trace is critical, redact anything that could
+identify your infrastructure (replace internal
+hostnames/IPs with placeholders like
+<internal-host> / <internal-ip>).
+-->
+
+## Additional context
+
+<!-- Anything else that helps maintainers reproduce or
+diagnose. Screenshots are fine if they don't show
+sensitive data. -->

--- a/skills/infrahub-reporting-issues/templates/feature.md
+++ b/skills/infrahub-reporting-issues/templates/feature.md
@@ -1,0 +1,32 @@
+<!--
+Generic feature-request template for
+Infrahub-ecosystem repos that do not ship their own
+.github/ISSUE_TEMPLATE/. When a repo has its own
+template, use that instead.
+-->
+
+## Problem
+
+<!-- What problem does this feature solve? Describe the
+underlying need, not the solution. -->
+
+## Proposed solution
+
+<!-- How would you like this to work? Describe the user
+experience or API shape you'd expect. -->
+
+## Alternatives considered
+
+<!-- What other approaches did you think about, and why
+didn't they fit? This helps maintainers understand
+the design space you've already explored. -->
+
+## Use case
+
+<!-- Concrete example of how you'd use this feature.
+Realistic scenarios help prioritize. -->
+
+## Additional context
+
+<!-- Links to related issues, documentation, or external
+projects that influence the design. -->


### PR DESCRIPTION
## Summary

- New skill `infrahub-reporting-issues` that routes bug reports and feature requests across the 11 repos in the Infrahub ecosystem (main, SDK, Ansible, VS Code, Nornir, Helm, MCP, schema library, backup, sync, skills) — defaults to `opsmill/infrahub` when routing is ambiguous, since the main repo re-routes downstream more easily than the reverse.
- The skill never auto-submits: it stops at a mandatory user-review gate, then asks the user to choose between `gh`, MCP, or manual submission.
- Security-critical `env-info-sanitization` rule with a deterministic grader covering IPs, internal hostnames, tokens (GitHub/AWS/Slack/JWT/OpenAI-style), and user filesystem paths. Environment info collection is scoped to versions + OS only.
- 3 eval tasks added (1 deterministic for sanitization, 2 advisory for routing default-to-main and template fidelity).
- No version bump on this branch — registration in `.release-manifest.json` is staged for whichever future release picks it up.

## Test plan

- [ ] Run `skillgrade --smoke` and confirm `bug-sanitization` reliably passes
- [ ] Manually trigger the skill with an ambiguous bug description and verify it asks before submitting
- [ ] Verify `gh api repos/<owner>/<repo>/contents/.github/ISSUE_TEMPLATE/bug_report.yml` returns templates for the 4 repos that ship them (`opsmill/infrahub`, `opsmill/infrahub-sdk-python`, `opsmill/infrahub-ansible`, `opsmill/nornir-infrahub`)
- [ ] Confirm the workflow correctly falls back to `templates/bug.md` for repos without a `.github/ISSUE_TEMPLATE/` (e.g., `opsmill/infrahub-mcp`)
- [ ] Hand-test sanitization: ask the skill to render a bug from raw context containing IPs/hostnames/tokens/user paths and confirm none leak through

🤖 Generated with [Claude Code](https://claude.com/claude-code)