### PR TITLE
fix(skills): relocate Information Priority to a shared rule

### DIFF
--- a/skills/infrahub-common/SKILL.md
+++ b/skills/infrahub-common/SKILL.md
@@ -14,19 +14,6 @@ metadata:
 This skill contains shared resources referenced by all other
 Infrahub skills. It is not meant to be invoked directly.
 
-## Information Priority
-
-When answering questions about any Infrahub topic covered
-by the loaded skills (schemas, objects, checks, generators,
-transforms, menus, data analysis, or repository audits):
-
-1. **First**: Consult the active skill's rules and reference docs
-2. **Second**: Check the infrahub-concepts knowledge base
-3. **Last resort only**: Fetch external documentation
-
-Do not skip to external docs or web searches when the
-answer is available in the skill's rules or reference files.
-
 ## Contents
 
 - **`graphql-queries.md`** — Infrahub GraphQL query syntax,
@@ -42,3 +29,5 @@ answer is available in the skill's rules or reference files.
   - Git integration and deployment patterns
   - Recovery from partial repository syncs
   - Generated file protocol conventions
+  - Information-source priority (skill content before
+    external docs)

--- a/skills/infrahub-common/rules/_sections.md
+++ b/skills/infrahub-common/rules/_sections.md
@@ -26,3 +26,9 @@ specific to any single workflow.
 4. **Caching (caching-)** -- MEDIUM. Display label caching
    with parent relationships, batch loading timing issues,
    no-op mutation workarounds.
+
+5. **Workflow (workflow-)** -- MEDIUM. How to navigate the
+   loaded skill content: information-source priority —
+   consult the active skill's rules and references, then the
+   shared `infrahub-common/` references, before reaching for
+   external docs or a web search.

--- a/skills/infrahub-common/rules/workflow-information-priority.md
+++ b/skills/infrahub-common/rules/workflow-information-priority.md
@@ -1,0 +1,64 @@
+---
+title: Information-Source Priority
+impact: MEDIUM
+tags: workflow, references, external-docs, web-search, source-priority
+---
+
+## Information-Source Priority
+
+Impact: MEDIUM
+
+When answering an Infrahub question that the loaded skills
+already cover (schemas, objects, checks, generators,
+transforms, menus, data analysis, repository audits), read
+the active skill's own rules and reference files before
+reaching for external documentation or a web search.
+
+### Why it matters
+
+The skill's `rules/`, `reference.md`, `examples.md`, and the
+shared `infrahub-common/` references are curated for the
+Infrahub version this plugin targets and encode gotchas that
+generic sources miss — `Text` over the deprecated `String`,
+singular `display_label`, matched relationship identifiers
+on both peers, full kind references. External docs and model
+training are often a version behind, or silent on these, so
+skipping straight to them produces answers that contradict
+the skill's tested guidance and reintroduce the exact
+mistakes the rules exist to prevent. It also burns turns
+fetching what is already in context.
+
+### Priority order
+
+1. **The active skill's own files** — its `rules/`,
+   `reference.md`, `examples.md`, and `validation.md`.
+2. **Shared `infrahub-common/` references** —
+   `graphql-queries.md`, `infrahub-yml-reference.md`,
+   `netbox-vs-infrahub.md`, and the cross-cutting `rules/`.
+3. **Last resort: external Infrahub documentation**
+   (`docs.infrahub.app`) or a web search — only when the
+   answer is genuinely absent above, and say so explicitly
+   so the gap in the skill can be filled later.
+
+### Examples
+
+Compliant — a question about which attribute type to use is
+answered from the schema skill's `reference.md` and the
+`attribute-defaults-and-types` rule, which specify `Text`
+rather than the deprecated `String`.
+
+Non-compliant — the same question is answered from a web
+search that suggests `String`, contradicting the rule and
+shipping a deprecated type.
+
+### Common mistakes
+
+- Treating a fetched doc page or training recall as
+  authoritative over a skill rule that addresses the same
+  point. The rule wins — it is version-matched to this plugin.
+- Searching the web for `.infrahub.yml` fields or GraphQL
+  syntax that `infrahub-common/` already lays out.
+- Reaching for external docs without first checking whether
+  the active skill's reference files answer the question.
+
+Reference: [Infrahub Docs](https://docs.infrahub.app)


### PR DESCRIPTION
## Summary

Follow-up to #31, which merged the **Information Priority** guidance into `skills/infrahub-common/SKILL.md`. That placement is ineffective:

- **No skill loads `infrahub-common/SKILL.md`.** Every skill references the sibling files (`graphql-queries.md`, `infrahub-yml-reference.md`, `netbox-vs-infrahub.md`, `rules/*.md`) — never the SKILL.md, which is `DO NOT TRIGGER directly`. So the guidance never reaches the model.
- **Dangling reference.** Step 2 pointed at the "infrahub-concepts knowledge base" = `dev/knowledges/infrahub-concepts.md`, a dev-only file that does not ship with the skills.

This relocates the guidance to where the other cross-cutting rules live and where skills already link.

## Changes

- **New rule** `skills/infrahub-common/rules/workflow-information-priority.md` — follows the established `title/impact/tags` rule format with *why it matters*, examples, and common mistakes. Corrected source-priority tiers: active-skill files → shared `infrahub-common/` references → external docs as a last resort (no more `dev/knowledges` reference).
- **Register** the new `workflow-` category in `rules/_sections.md`.
- **Drop** the dead inline `## Information Priority` section from `infrahub-common/SKILL.md` and list the rule in its Contents.

## Notes

- Advisory behavioral rule with no gradeable output, so no grader — consistent with its `infrahub-common/rules/` siblings and `dev/guides/adding-a-rule.md`'s carve-out for purely advisory rules.
- Reviewed with `/skill-creator` + `/writing-skills`. `markdownlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)