### PR TITLE
feat(skills): from_graphql hydration rule for managing-generators

### DIFF
--- a/eval.yaml
+++ b/eval.yaml
@@ -1643,3 +1643,110 @@ tasks:
         check: flags.yml is a list whose entries all have id/severity/evidence/hint
       - name: oom-in-logs-fires
         check: flags.yml contains an entry with id `oom-in-logs`
+
+  # --- Generator Creator --- #
+  - name: from-graphql-hydration-refactor
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-managing-generators/SKILL.md and follow its workflow and rules.
+
+      Task: Refactor an existing generator that performs an N+1 fetch
+      pattern into one that uses response-driven hydration. The
+      generator flips the `drained` attribute on every BGP neighbor of
+      a target interface when a maintenance event fires. Today it
+      iterates the cascade query's `bgp_neighbors.edges` and re-fetches
+      each peer via `self.client.get(...)`. That's `1 + N` round trips
+      per run; for a maintenance event touching 30 neighbors it's 31
+      mutations worth of latency.
+
+      Current GraphQL query (queries/drain.gql), shown indented:
+
+          query drain($name: String!) {
+            NetworkMaintenanceEvent(name__value: $name) {
+              edges {
+                node {
+                  target_interface {
+                    node {
+                      bgp_neighbors {
+                        edges {
+                          node {
+                            id
+                            hfid
+                            drained { value }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+      Current generator (generators/drain.py), shown indented:
+
+          from infrahub_sdk.generator import InfrahubGenerator
+
+
+          class DrainBgpNeighborsGenerator(InfrahubGenerator):
+              async def generate(self, data: dict) -> None:
+                  event = data["NetworkMaintenanceEvent"]["edges"][0]["node"]
+                  target = event["target_interface"]["node"]
+                  for edge in target["bgp_neighbors"]["edges"]:
+                      peer = await self.client.get(
+                          kind="NetworkBgpNeighbor",
+                          hfid=edge["node"]["hfid"],
+                      )
+                      peer.drained.value = True
+                      await peer.save(allow_upsert=True)
+
+      Refactor the generator so the loop body does zero re-fetches via
+      response-driven hydration, and update the query so the refactor
+      works.
+
+      Save ONLY the refactored generator and the updated query to a
+      single Markdown file, as two triple-backtick code-fenced blocks
+      — one tagged `python` and one tagged `graphql` — to: output.md
+    graders:
+      - type: deterministic
+        run: python graders/managing-generators/check_from_graphql_refactor.py
+        weight: 1.0
+    expected_output: >-
+      A refactored generator that uses InfrahubNode.from_graphql to
+      hydrate each iterated peer (no self.client.get inside the loop
+      body), plus an updated GraphQL query with __typename added under
+      the iterated peer's node selection.
+    expectations:
+      - InfrahubNode is imported from infrahub_sdk.node
+      - >-
+        The for-loop body calls InfrahubNode.from_graphql with
+        client=, branch=, and data= kwargs
+      - >-
+        self.client.get(...) is NOT called inside any for-loop in the
+        refactored generator
+      - >-
+        The updated GraphQL query includes __typename inside the
+        bgp_neighbors edge's node selection
+      - >-
+        Output is a single Markdown file with one ```python block and
+        one ```graphql block
+    assertions:
+      - name: python-block-present
+        check: Output contains a ```python fenced code block
+      - name: graphql-block-present
+        check: Output contains a ```graphql fenced code block
+      - name: imports-infrahub-node
+        check: >-
+          Refactored Python imports InfrahubNode from infrahub_sdk
+      - name: uses-from-graphql
+        check: >-
+          InfrahubNode.from_graphql(...) is called inside the peer
+          iteration for-loop with client= and data= kwargs
+      - name: no-client-get-in-loop
+        check: >-
+          self.client.get(...) is not called inside any for-loop in
+          the refactored generator
+      - name: query-has-typename
+        check: >-
+          __typename appears inside the bgp_neighbors selection in
+          the updated GraphQL query

--- a/evaluations/infrahub-managing-generators.json
+++ b/evaluations/infrahub-managing-generators.json
@@ -107,6 +107,45 @@
         "The guidance notes that unit tests on the input dict do not cover SDK call shape"
       ],
       "assertions": []
+    },
+    {
+      "id": 6,
+      "prompt": "Refactor an existing generator that performs an N+1 fetch\npattern into one that uses response-driven hydration. The\ngenerator flips the `drained` attribute on every BGP neighbor of\na target interface when a maintenance event fires. Today it\niterates the cascade query's `bgp_neighbors.edges` and re-fetches\neach peer via `self.client.get(...)`. That's `1 + N` round trips\nper run; for a maintenance event touching 30 neighbors it's 31\nmutations worth of latency.\n\nCurrent GraphQL query (queries/drain.gql), shown indented:\n\n    query drain($name: String!) {\n      NetworkMaintenanceEvent(name__value: $name) {\n        edges {\n          node {\n            target_interface {\n              node {\n                bgp_neighbors {\n                  edges {\n                    node {\n                      id\n                      hfid\n                      drained { value }\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n\nCurrent generator (generators/drain.py), shown indented:\n\n    from infrahub_sdk.generator import InfrahubGenerator\n\n\n    class DrainBgpNeighborsGenerator(InfrahubGenerator):\n        async def generate(self, data: dict) -> None:\n            event = data[\"NetworkMaintenanceEvent\"][\"edges\"][0][\"node\"]\n            target = event[\"target_interface\"][\"node\"]\n            for edge in target[\"bgp_neighbors\"][\"edges\"]:\n                peer = await self.client.get(\n                    kind=\"NetworkBgpNeighbor\",\n                    hfid=edge[\"node\"][\"hfid\"],\n                )\n                peer.drained.value = True\n                await peer.save(allow_upsert=True)\n\nRefactor the generator so the loop body does zero re-fetches via\nresponse-driven hydration, and update the query so the refactor\nworks.",
+      "expected_output": "A refactored generator that uses InfrahubNode.from_graphql to hydrate each iterated peer (no self.client.get inside the loop body), plus an updated GraphQL query with __typename added under the iterated peer's node selection.",
+      "files": [],
+      "expectations": [
+        "InfrahubNode is imported from infrahub_sdk.node",
+        "The for-loop body calls InfrahubNode.from_graphql with client=, branch=, and data= kwargs",
+        "self.client.get(...) is NOT called inside any for-loop in the refactored generator",
+        "The updated GraphQL query includes __typename inside the bgp_neighbors edge's node selection",
+        "Output is a single Markdown file with one ```python block and one ```graphql block"
+      ],
+      "assertions": [
+        {
+          "name": "python-block-present",
+          "check": "Output contains a ```python fenced code block"
+        },
+        {
+          "name": "graphql-block-present",
+          "check": "Output contains a ```graphql fenced code block"
+        },
+        {
+          "name": "imports-infrahub-node",
+          "check": "Refactored Python imports InfrahubNode from infrahub_sdk"
+        },
+        {
+          "name": "uses-from-graphql",
+          "check": "InfrahubNode.from_graphql(...) is called inside the peer iteration for-loop with client= and data= kwargs"
+        },
+        {
+          "name": "no-client-get-in-loop",
+          "check": "self.client.get(...) is not called inside any for-loop in the refactored generator"
+        },
+        {
+          "name": "query-has-typename",
+          "check": "__typename appears inside the bgp_neighbors selection in the updated GraphQL query"
+        }
+      ]
     }
   ]
 }

--- a/graders/managing-generators/check_from_graphql_refactor.py
+++ b/graders/managing-generators/check_from_graphql_refactor.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Grader for the from-graphql-hydration-refactor eval task.
+
+Reads ``output.md`` from CWD, extracts the ```python and ```graphql
+fenced blocks, and asserts the generator was refactored to use
+``InfrahubNode.from_graphql`` with matching query coverage.
+
+Prints skillgrade JSON to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = [
+    "python-block-present",
+    "graphql-block-present",
+    "imports-infrahub-node",
+    "uses-from-graphql",
+    "no-client-get-in-loop",
+    "query-has-typename",
+]
+
+
+if __name__ == "__main__":
+    output_path = Path("output.md")
+    result = run_checks(CHECKS, output_path)
+    print(json.dumps(result))

--- a/graders/managing-generators/lib.py
+++ b/graders/managing-generators/lib.py
@@ -1,33 +1,47 @@
 """Shared grader library for infrahub-managing-generators evaluations.
 
-Provides Python AST parsing helpers, individual assertion check
-functions, a CHECKS registry, and the top-level ``run_checks``
-function that returns skillgrade JSON format.
+This library backs two grader families that share one ``run_checks`` entry
+point, dispatched by the output file's suffix:
 
-Graders for this skill parse Python source (the generator class
-the model produced as ``output.py``) rather than YAML. Some
-expressions cannot be resolved from AST alone — variable
-references, function-call results — and the check functions
-treat those as "indeterminate" (passing) rather than failing.
-The checks fail only on shapes that are demonstrably wrong:
-bare string literals where a dict reference is required,
-over-packed list literals, list literals passed to ``.add()``.
+* **AST / relationship checks** (relationship references, multi-peer add,
+  natural-key preflight) parse a Python source file the model produced as
+  ``output.py``. Some expressions cannot be resolved from AST alone —
+  variable references, function-call results — and the check functions treat
+  those as "indeterminate" (passing) rather than failing. The checks fail
+  only on shapes that are demonstrably wrong: bare string literals where a
+  dict reference is required, over-packed list literals, list literals passed
+  to ``.add()``. These checks take ``(tree, raw_text=...)``.
+
+* **from_graphql hydration checks** parse a Markdown file (``output.md``)
+  that carries the refactored generator and the updated cascade query as
+  fenced ``python`` / ``graphql`` blocks. They verify the loop body does zero
+  re-fetches (``InfrahubNode.from_graphql`` instead of ``self.client.get``)
+  and that the query was extended with ``__typename``. These checks take a
+  single ``output`` dict.
 
 Usage (in a per-task grader script)::
 
     from pathlib import Path
     from lib import run_checks
 
+    # AST family — output.py
     result = run_checks(
         ["relationship-hfid-form-correct", "no-bare-string-relationship"],
         Path("output.py"),
     )
-    print(result)
+
+    # from_graphql family — output.md
+    result = run_checks(
+        ["imports-infrahub-node", "uses-from-graphql"],
+        Path("output.md"),
+    )
+    print(result)  # {"score": 0.67, "details": "...", "checks": [...]}
 """
 
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -54,8 +68,39 @@ def load_output_py(path: Path) -> tuple[ast.Module | None, str]:
     return tree, raw
 
 
+_PY_FENCE = re.compile(
+    r"^```(?:python|py)\s*\n(.*?)^```",
+    re.MULTILINE | re.DOTALL,
+)
+_GQL_FENCE = re.compile(
+    r"^```(?:graphql|gql)\s*\n(.*?)^```",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def load_output(path: Path) -> dict[str, str]:
+    """Load the model's output.md and return its fenced blocks.
+
+    Returns a dict with keys ``python``, ``graphql``, ``raw``. Missing
+    blocks resolve to empty strings; ``raw`` is always the full file
+    content (or "" if unreadable).
+    """
+    try:
+        raw = Path(path).read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return {"python": "", "graphql": "", "raw": ""}
+
+    py = _PY_FENCE.search(raw)
+    gql = _GQL_FENCE.search(raw)
+    return {
+        "python": py.group(1) if py else "",
+        "graphql": gql.group(1) if gql else "",
+        "raw": raw,
+    }
+
+
 # ---------------------------------------------------------------------------
-# AST helpers
+# AST helpers (relationship / multi-peer / preflight family)
 # ---------------------------------------------------------------------------
 
 
@@ -164,6 +209,87 @@ def is_bare_string(node: ast.AST) -> bool:
 def is_name_or_attribute(node: ast.AST) -> bool:
     """True if ``node`` is a Name or Attribute reference (likely an SDK obj)."""
     return isinstance(node, (ast.Name, ast.Attribute))
+
+
+# ---------------------------------------------------------------------------
+# AST helpers (from_graphql hydration family)
+# ---------------------------------------------------------------------------
+
+
+def _parse_python(source: str) -> ast.Module | None:
+    if not source.strip():
+        return None
+    try:
+        return ast.parse(source)
+    except SyntaxError:
+        return None
+
+
+def _imports_infrahub_node(tree: ast.Module) -> bool:
+    """True if `InfrahubNode` is imported (any infrahub_sdk path)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module and node.module.startswith("infrahub_sdk"):
+                if any(alias.name == "InfrahubNode" for alias in node.names):
+                    return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name and "InfrahubNode" in alias.name:
+                    return True
+    return False
+
+
+def _from_graphql_calls(tree: ast.Module) -> list[ast.Call]:
+    """Return every `InfrahubNode.from_graphql(...)` call in the tree."""
+    out: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr != "from_graphql":
+            continue
+        # Match `InfrahubNode.from_graphql` (Name) or `<x>.InfrahubNode.from_graphql`
+        if isinstance(func.value, ast.Name) and func.value.id == "InfrahubNode":
+            out.append(node)
+        elif isinstance(func.value, ast.Attribute) and func.value.attr == "InfrahubNode":
+            out.append(node)
+    return out
+
+
+def _client_get_calls(tree: ast.Module) -> list[ast.Call]:
+    """Return every `self.client.get(...)` call in the tree."""
+    out: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "get"):
+            continue
+        val = func.value
+        if not (isinstance(val, ast.Attribute) and val.attr == "client"):
+            continue
+        inner = val.value
+        if isinstance(inner, ast.Name) and inner.id == "self":
+            out.append(node)
+    return out
+
+
+def _node_within(child: ast.AST, parent: ast.AST) -> bool:
+    """True if ``child`` is a descendant of ``parent`` in the AST."""
+    for node in ast.walk(parent):
+        if node is child:
+            return True
+    return False
+
+
+def _for_loops(tree: ast.Module) -> list[ast.AST]:
+    """Return every for / async-for loop in the tree."""
+    return [
+        n for n in ast.walk(tree)
+        if isinstance(n, (ast.For, ast.AsyncFor))
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -509,10 +635,116 @@ def check_no_raw_create_without_handler(
 
 
 # ---------------------------------------------------------------------------
+# from_graphql hydration checks
+#
+# Each check has the signature:
+#     check_*(output: dict[str, str], **kwargs) -> tuple[bool, str]
+# where output is the dict returned by ``load_output``.
+# ---------------------------------------------------------------------------
+
+
+def check_imports_infrahub_node(output: dict, **_: Any) -> tuple[bool, str]:
+    """Refactored Python imports InfrahubNode from infrahub_sdk."""
+    tree = _parse_python(output["python"])
+    if tree is None:
+        return False, "No parseable Python block found"
+    if _imports_infrahub_node(tree):
+        return True, "InfrahubNode imported from infrahub_sdk"
+    return False, "InfrahubNode is not imported from infrahub_sdk"
+
+
+def check_uses_from_graphql(output: dict, **_: Any) -> tuple[bool, str]:
+    """At least one InfrahubNode.from_graphql(...) call exists inside a for-loop."""
+    tree = _parse_python(output["python"])
+    if tree is None:
+        return False, "No parseable Python block found"
+    calls = _from_graphql_calls(tree)
+    if not calls:
+        return False, "No InfrahubNode.from_graphql(...) call found"
+    loops = _for_loops(tree)
+    in_loop = [c for c in calls if any(_node_within(c, loop) for loop in loops)]
+    if not in_loop:
+        return False, (
+            f"InfrahubNode.from_graphql called {len(calls)}x but never "
+            "inside a for-loop (expected inside the peer iteration)"
+        )
+    # Verify at least one call uses the expected kwargs.
+    for call in in_loop:
+        kwargs = {kw.arg for kw in call.keywords if kw.arg}
+        if {"client", "data"}.issubset(kwargs):
+            return True, (
+                f"InfrahubNode.from_graphql called inside a for-loop "
+                f"with client= and data= kwargs ({len(in_loop)} total)"
+            )
+    return False, (
+        f"InfrahubNode.from_graphql called inside a for-loop but missing "
+        "client= or data= kwargs"
+    )
+
+
+def check_no_client_get_in_loop(output: dict, **_: Any) -> tuple[bool, str]:
+    """self.client.get(...) does not appear inside any for-loop body."""
+    tree = _parse_python(output["python"])
+    if tree is None:
+        return False, "No parseable Python block found"
+    get_calls = _client_get_calls(tree)
+    loops = _for_loops(tree)
+    leaked = [
+        c for c in get_calls
+        if any(_node_within(c, loop) for loop in loops)
+    ]
+    if leaked:
+        return False, (
+            f"self.client.get(...) still called inside a for-loop "
+            f"({len(leaked)} occurrence(s)) — refactor incomplete"
+        )
+    return True, "No self.client.get(...) calls inside any for-loop"
+
+
+def check_query_has_typename(output: dict, **_: Any) -> tuple[bool, str]:
+    """The GraphQL query includes __typename inside the bgp_neighbors selection."""
+    gql = output["graphql"]
+    if not gql.strip():
+        return False, "No GraphQL block found"
+    # Locate bgp_neighbors { ... } block (allow nesting).
+    match = re.search(r"bgp_neighbors\s*{", gql)
+    if not match:
+        return False, "bgp_neighbors selection not found in query"
+    start = match.end()
+    depth = 1
+    end = start
+    while end < len(gql) and depth > 0:
+        if gql[end] == "{":
+            depth += 1
+        elif gql[end] == "}":
+            depth -= 1
+        end += 1
+    block = gql[start:end]
+    if "__typename" in block:
+        return True, "__typename present inside bgp_neighbors selection"
+    return False, "__typename missing from bgp_neighbors selection"
+
+
+def check_python_block_present(output: dict, **_: Any) -> tuple[bool, str]:
+    """A ```python fenced block exists in output.md."""
+    if output["python"].strip():
+        return True, "Python code block present"
+    return False, "No ```python fenced block found in output.md"
+
+
+def check_graphql_block_present(output: dict, **_: Any) -> tuple[bool, str]:
+    """A ```graphql fenced block exists in output.md."""
+    if output["graphql"].strip():
+        return True, "GraphQL code block present"
+    return False, "No ```graphql fenced block found in output.md"
+
+
+# ---------------------------------------------------------------------------
 # CHECKS registry
 # ---------------------------------------------------------------------------
 
 CHECKS: dict[str, Any] = {
+    # AST / relationship family (output.py)
     "relationship-hfid-form-correct": check_relationship_hfid_form_correct,
     "no-bare-string-relationship": check_no_bare_string_relationship,
     "no-overpacked-hfid-list": check_no_overpacked_hfid_list,
@@ -523,6 +755,13 @@ CHECKS: dict[str, Any] = {
     "members-add-iterates": check_members_add_iterates,
     "preflight-or-upsert": check_preflight_or_upsert,
     "no-raw-create-without-handler": check_no_raw_create_without_handler,
+    # from_graphql hydration family (output.md)
+    "imports-infrahub-node": check_imports_infrahub_node,
+    "uses-from-graphql": check_uses_from_graphql,
+    "no-client-get-in-loop": check_no_client_get_in_loop,
+    "query-has-typename": check_query_has_typename,
+    "python-block-present": check_python_block_present,
+    "graphql-block-present": check_graphql_block_present,
 }
 
 
@@ -531,19 +770,26 @@ CHECKS: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 
-def run_checks(
-    check_names: list[str],
-    output_path: Path,
-) -> dict:
-    """Run named checks against a Python source file.
+def run_checks(check_names: list[str], output_path: Path) -> dict:
+    """Run named checks against a generator-task output file.
+
+    Dispatch is by the output file's suffix: ``.md`` routes to the
+    Markdown/dict family (from_graphql hydration checks, which receive the
+    ``load_output`` dict), anything else to the Python/AST family (which
+    receive ``(tree, raw_text=...)`` from ``load_output_py``). A grader
+    script requests only checks from its own family and passes the matching
+    path, so the two never mix within one call.
 
     Returns skillgrade JSON: ``{"score": float, "details": str,
     "checks": [...]}``.
 
-    Raises ``KeyError`` if any name in ``check_names`` is not in
-    ``CHECKS``.
+    Raises ``KeyError`` if any name in ``check_names`` is not in ``CHECKS``.
     """
-    tree, raw = load_output_py(output_path)
+    markdown_mode = Path(output_path).suffix.lower() == ".md"
+    if markdown_mode:
+        output = load_output(output_path)
+    else:
+        tree, raw = load_output_py(output_path)
 
     entries: list[dict] = []
     passed_count = 0
@@ -551,7 +797,10 @@ def run_checks(
     for name in check_names:
         fn = CHECKS[name]  # raises KeyError for unknown names
         try:
-            ok, msg = fn(tree, raw_text=raw)
+            if markdown_mode:
+                ok, msg = fn(output)
+            else:
+                ok, msg = fn(tree, raw_text=raw)
         except Exception as exc:  # defensive — never let one check crash all
             ok, msg = False, f"Error running check: {exc}"
 

--- a/skills/infrahub-managing-generators/SKILL.md
+++ b/skills/infrahub-managing-generators/SKILL.md
@@ -112,10 +112,18 @@ Follow these steps when creating a generator:
 4. **Make it idempotent** — Use `allow_upsert=True` so
    re-running creates or updates without duplicates.
    See [rules/tracking-idempotent.md](./rules/tracking-idempotent.md).
-5. **Register in .infrahub.yml** — Add under
+5. **Check for `from_graphql` adoption opportunity** — if
+   `generate()` iterates response edges and calls
+   `self.client.get()` to re-fetch typed peers, consider
+   refactoring to `InfrahubNode.from_graphql()` to collapse
+   `O(N + 1)` round trips to `O(1)`. Read
+   [rules/patterns-hydration.md](./rules/patterns-hydration.md)
+   for the decision tree, detection heuristic, and refactor
+   recipe.
+6. **Register in .infrahub.yml** — Add under
    `generator_definitions` with the target group. See
    [rules/registration-config.md](./rules/registration-config.md).
-6. **Test** — Run `infrahubctl generator` to validate.
+7. **Test** — Run `infrahubctl generator` to validate.
    See [rules/testing-commands.md](./rules/testing-commands.md).
 
 ## Supporting References

--- a/skills/infrahub-managing-generators/examples.md
+++ b/skills/infrahub-managing-generators/examples.md
@@ -9,6 +9,7 @@ repositories.
 - [2. Network Segment Generator](#2-network-segment-generator)
 - [3. Minimal Generator Template](#3-minimal-generator-template)
 - [4. Generator with convert_query_response](#4-generator-with-convert_query_response)
+- [5. Refactor: `client.get()` → `from_graphql` for peer iteration](#5-refactor-clientget--from_graphql-for-peer-iteration)
 - [Complete File Structure](#complete-file-structure)
 
 ---
@@ -390,6 +391,95 @@ generator_definitions:
     parameters:
       name: name__value
 ```
+
+---
+
+## 5. Refactor: `client.get()` → `from_graphql` for peer iteration
+
+A real-shape example showing round-trip elimination when the
+generator iterates a relationship from the cascade query and
+flips an attribute on each peer.
+
+See [rules/patterns-hydration.md](./rules/patterns-hydration.md)
+for the decision tree and detection heuristic.
+
+### Original (one round trip per peer)
+
+```python
+from infrahub_sdk.generator import InfrahubGenerator
+
+
+class DrainBgpNeighborsGenerator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        event = data["NetworkMaintenanceEvent"]["edges"][0]["node"]
+        target = event["target_interface"]["node"]
+        for edge in target["bgp_neighbors"]["edges"]:
+            peer_hfid = edge["node"]["hfid"]
+            peer = await self.client.get(
+                kind="NetworkBgpNeighbor",
+                hfid=peer_hfid,
+            )
+            peer.drained.value = True
+            await peer.save(allow_upsert=True)
+```
+
+For `N` peers: `1` cascade query + `N` re-fetches =
+`N + 1` round trips.
+
+### Refactored (one round trip total)
+
+Query change — add `__typename` to the iterated peer's node
+selection:
+
+```diff
+ bgp_neighbors {
+   edges { node {
+     id
+     hfid
++    __typename
+     drained { value }
+   }}
+ }
+```
+
+Generator change:
+
+```python
+from infrahub_sdk.generator import InfrahubGenerator
+from infrahub_sdk.node import InfrahubNode
+
+
+class DrainBgpNeighborsGenerator(InfrahubGenerator):
+    async def generate(self, data: dict) -> None:
+        event = data["NetworkMaintenanceEvent"]["edges"][0]["node"]
+        target = event["target_interface"]["node"]
+        for edge in target["bgp_neighbors"]["edges"]:
+            peer = await InfrahubNode.from_graphql(
+                client=self.client,
+                branch=self.branch,
+                data=edge,
+            )
+            peer.drained.value = True
+            await peer.save(allow_upsert=True)
+```
+
+For `N` peers: `1` cascade query + `0` re-fetches =
+`1` round trip.
+
+### Verification
+
+After the refactor, confirm:
+
+1. The branch state matches pre-refactor — every peer's
+   mutated attribute landed correctly (spot-check via
+   `infrahubctl` or a follow-up GraphQL query).
+2. A re-fire of the generator on an unchanged design produces
+   no updates — `save(allow_upsert=True)` with identical
+   values elides the mutation, so idempotency is preserved.
+3. Unfetched optional one-cardinality relationships on the
+   peers are still set — confirm by querying the same peers
+   for those relationships post-refactor (partial-hydration
+   handling preserves them on save).
 
 ---
 

--- a/skills/infrahub-managing-generators/rules/_sections.md
+++ b/skills/infrahub-managing-generators/rules/_sections.md
@@ -28,7 +28,9 @@
 6. **Patterns (patterns-)** -- MEDIUM. Data cleaning helper,
    batch object creation, using the local store for
    inter-object references, and natural-key preflight for
-   form-driven mutations.
+   form-driven mutations. **HIGH** for hydration —
+   `InfrahubNode.from_graphql` for peer iteration to collapse
+   `O(N + 1)` round trips.
 
 7. **Testing (testing-)** -- LOW. infrahubctl generator
    commands, listing and running Generators locally, and the

--- a/skills/infrahub-managing-generators/rules/patterns-hydration.md
+++ b/skills/infrahub-managing-generators/rules/patterns-hydration.md
@@ -1,0 +1,212 @@
+---
+title: Response-Driven Hydration via InfrahubNode.from_graphql
+impact: HIGH
+tags: from_graphql, hydration, refactor, detection, round-trips
+---
+
+## Response-Driven Hydration via `InfrahubNode.from_graphql`
+
+Impact: HIGH
+
+`InfrahubNode.from_graphql(client, branch, data)` hydrates a
+typed `InfrahubNode` directly from a GraphQL response payload,
+avoiding a second `client.get()` round trip per peer. A
+generator that iterates `N` peers from the cascade query and
+re-fetches each one issues `N + 1` round trips; the same
+generator using `from_graphql` issues `1`.
+
+This rule is **detection-focused**: it tells you how to find
+generators that should adopt the pattern, what query coverage
+is required, and how to apply the refactor mechanically.
+
+### Why it matters
+
+Generators run on every proposed change touching the target
+group and again after merge. For wide fan-out designs (a
+topology with dozens of devices, a segment touching every
+leaf), the `N + 1` cost compounds quickly — both in wall-clock
+time and in pressure on the GraphQL endpoint. The fetched
+payload already contains everything the typed peer needs;
+re-fetching is purely wasted work.
+
+The pattern is also clearer at the call site: the loop body
+operates on a typed `InfrahubNode`, not on raw
+`edge["node"][<attr>]["value"]` dictionary access.
+
+### Decision tree — should this generator use `from_graphql`?
+
+Apply in order:
+
+1. **Does `generate()` iterate `data[<Kind>]["edges"]` or
+   nested `…["edges"][0]["node"][<rel>]["edges"]`?**
+   - YES → continue to (2)
+   - NO → `from_graphql` doesn't apply. The generator likely
+     creates new nodes via `client.create()` or fetches via
+     `client.filters()` — both are valid patterns, not refactor
+     candidates.
+
+2. **Inside the loop, does the code call
+   `self.client.get(kind=…, hfid=…)` or `(kind=…, id=…)` on
+   the peer it just iterated?**
+   - YES → **strong refactor candidate**. The `client.get` is
+     a wasted round trip; the peer's data is already in
+     `data`.
+   - NO → check (3).
+
+3. **Does the loop body only set 1–2 attributes and call
+   `.save()`?**
+   - YES → still a candidate, but verify the response payload
+     has enough fields for the `from_graphql` constructor
+     (must include `__typename` — see "Query coverage" below).
+   - NO → if the loop navigates deeper relationships on the
+     typed node or computes derived properties, `client.get()`
+     gives full hydration that may be required. Refactor with
+     caution and verify the deeper rels are present in the
+     payload.
+
+### Detection heuristic (grep)
+
+Run from the repo root:
+
+```bash
+# Outer loops over response edges
+grep -nE 'for [a-z_]+ in data\["[^"]+"\]\["edges"\]' \
+  generators/*.py
+
+# Peer re-fetches by hfid/id inside the same files
+grep -nE 'self\.client\.get\(kind=["\047][^"\047]+["\047],\s*(hfid|id)=' \
+  generators/*.py
+```
+
+A file that hits BOTH greps in the same function is a strong
+refactor candidate. Cross-check against the decision tree
+above.
+
+### Query coverage requirements
+
+For `from_graphql` to construct the typed node correctly, the
+GraphQL response for each iterated edge MUST include:
+
+1. **`__typename`** — required to resolve the kind when no
+   `schema=` argument is passed. Add it under the inline
+   fragment or as a sibling of `id`/`hfid`:
+
+   ```graphql
+   bgp_neighbors {
+     edges { node {
+       id
+       hfid
+       __typename
+       drained { value }
+     }}
+   }
+   ```
+
+2. **`id`** — required for upsert mutations (identifies the
+   node).
+3. **Every attribute the generator will MUTATE** — the
+   attribute-state machinery compares current values to
+   classify the save as a no-op vs. a change. A missing
+   current value forces every save into the "change" path even
+   when the value is identical.
+4. **(Recommended)** every attribute the generator READS for
+   downstream branching — otherwise the typed node sees
+   `value=None` for those fields.
+
+Unfetched optional one-cardinality relationships are preserved
+on save by the SDK's partial-hydration handling, but explicit
+query coverage is still good practice for clarity and
+future-proofing.
+
+### Refactor recipe
+
+**Before** (one `client.get()` round trip per peer):
+
+```python
+async def generate(self, data: dict) -> None:
+    edges = data[KIND]["edges"][0]["node"][REL]["edges"]
+    for edge in edges:
+        peer_hfid = edge["node"]["hfid"]
+        peer = await self.client.get(
+            kind=PEER_KIND, hfid=peer_hfid,
+        )
+        peer.<attr>.value = <new_value>
+        await peer.save(allow_upsert=True)
+```
+
+**After** (zero re-fetches; hydrated from response):
+
+```python
+from infrahub_sdk.node import InfrahubNode
+
+
+async def generate(self, data: dict) -> None:
+    edges = data[KIND]["edges"][0]["node"][REL]["edges"]
+    for edge in edges:
+        peer = await InfrahubNode.from_graphql(
+            client=self.client,
+            branch=self.branch,
+            data=edge,
+        )
+        peer.<attr>.value = <new_value>
+        await peer.save(allow_upsert=True)
+```
+
+**Query change** — add `__typename` to each iterated peer's
+node selection:
+
+```diff
+ bgp_neighbors {
+   edges { node {
+     id
+     hfid
++    __typename
+     drained { value }
+   }}
+ }
+```
+
+### When NOT to refactor
+
+- **Generator creates new nodes via `client.create()`** —
+  `from_graphql` needs an existing node payload, not a
+  creation contract.
+- **Generator uses `client.filters()` for runtime-discovered
+  peers** — `filters()` already returns typed nodes; no
+  re-fetch involved.
+- **Generator navigates deep relationship chains on the typed
+  node** — if the loop body does
+  `peer.local_interface.peer.device.peer.<attr>`, the partial
+  hydration may not include the deeper rels and navigation
+  triggers extra round trips anyway. `client.get()` with an
+  explicit `include=[…]` may be more readable.
+- **The query payload is intentionally trimmed for size
+  reasons** (large fan-out). The `client.get()` round trip per
+  peer may be cheaper than including every attribute on every
+  edge in the original query.
+
+### Relationship to `convert_query_response`
+
+When `convert_query_response: true` is set in `.infrahub.yml`,
+the SDK pre-hydrates the entire response into `self.nodes` for
+the generator's primary kind. That is the right tool when the
+generator works with the primary target's typed form. Use
+`from_graphql` instead when iterating a *nested relationship*
+inside the response — `self.nodes` doesn't cover nested peers
+transitively.
+
+### Reference
+
+- SDK source: `infrahub_sdk/node/node.py` —
+  `InfrahubNode.from_graphql` (async classmethod;
+  `from_graphql(client, branch, data, schema=None, timeout=None)`).
+  Accepts either the edge dict (`{"node": {…, "__typename": …}}`)
+  or the unwrapped node dict — both are checked for
+  `__typename`.
+- Canonical example in the OpsMill demos:
+  `infrahub-demo-service-catalog/generators/implement_dedicated_internet.py`
+  (uses `from_graphql` to hydrate the primary service node from
+  the cascade query; demonstrates the same constructor call
+  shape as this rule's recipe).
+- See [examples.md](../examples.md) §5 for a complete
+  before/after refactor with verification steps.


### PR DESCRIPTION
## Summary

- Adds `skills/infrahub-managing-generators/rules/patterns-hydration.md` — a detection-focused rule for response-driven hydration via `InfrahubNode.from_graphql`. Covers the decision tree, a grep heuristic for spotting candidates, the query-coverage contract (`__typename`, `id`, every mutated attribute), the mechanical refactor recipe, when not to refactor, and the relationship to `convert_query_response`.
- Adds a worked before/after refactor in `examples.md` §5 — drains BGP neighbors of a target interface, collapses `O(N+1)` round trips to `O(1)`, includes the query diff and verification steps.
- Wires a new step 5 into the generator workflow in `SKILL.md` pointing readers at the rule when their `generate()` iterates response edges and re-fetches peers.
- Bootstraps eval infrastructure for the `infrahub-managing-generators` skill (none existed before):
  - `graders/managing-generators/lib.py` with fenced-block extraction + AST checks
  - `graders/managing-generators/check_from_graphql_refactor.py`
  - new task block in `eval.yaml` under a "Generator Creator" section (3 trials)
  - regenerated `evaluations/infrahub-managing-generators.json` via `scripts/sync-evals.py`

## Verification

The grader was verified locally with hand-crafted fixtures:

- Compliant fixture → score `1.0`, all 6 checks pass.
- Violating fixture (the original N+1 generator unchanged) → score `0.33`, failures correctly named: `imports-infrahub-node`, `uses-from-graphql`, `no-client-get-in-loop`, `query-has-typename`.

## Test plan

- [x] Review the eval prompt for realism — does it read like a real refactor ask?
- [x] Confirm grader assertions match the rule's content.
- [x] Run `skillgrade --smoke` against the new task and confirm the model produces a compliant refactor under the skill's current prose.