### PR TITLE
docs(release-notes): add curated release notes for v0.0.1–v1.2.7

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -1,6 +1,8 @@
 agent
 Alibaba
+allowlists
 Ansible
+antipattern
 APIs
 append_git_suffix
 artifact_definitions
@@ -65,6 +67,7 @@ fanout
 file_path
 Fortinet
 FQDNs
+frontmatter
 generator_definition
 generator_definitions
 github
@@ -75,6 +78,7 @@ greymatter
 hfid
 hfids
 hostname
+hostnames
 http
 https
 httpx
@@ -84,6 +88,7 @@ include_in_menu
 Infrahub
 Infrahub's
 infrahubctl
+invocable
 IP
 IPAddress
 IPs
@@ -137,8 +142,10 @@ repos
 REST
 Reusability
 reusability
+sanitization
 schema_mapping
 sdk
+skillgrade
 snake_case
 ssl
 startup-config

--- a/docs/docs/release-notes/_category_.json
+++ b/docs/docs/release-notes/_category_.json
@@ -6,6 +6,6 @@
     "type": "generated-index",
     "title": "Release Notes",
     "slug": "/release-notes",
-    "description": "What each release of Infrahub Skills delivered — the problem it solves, what it enables, and when you need it. Newest first."
+    "description": "What changed in each release of Infrahub Skills, and what is different about your workflow after upgrading. Newest first."
   }
 }

--- a/docs/docs/release-notes/_category_.json
+++ b/docs/docs/release-notes/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "Release Notes",
+  "position": 6,
+  "collapsed": true,
+  "link": {
+    "type": "generated-index",
+    "title": "Release Notes",
+    "slug": "/release-notes",
+    "description": "What each release of Infrahub Skills delivered — the problem it solves, what it enables, and when you need it. Newest first."
+  }
+}

--- a/docs/docs/release-notes/release-0_0_1.mdx
+++ b/docs/docs/release-notes/release-0_0_1.mdx
@@ -20,32 +20,38 @@ sidebar_position: 9
   </tbody>
 </table>
 
-The first release of Infrahub Skills — an open-source skills package that gives an AI coding assistant built-in, best-practice knowledge of Infrahub's data model, conventions, and workflows. Describe what you want in plain language and the skills produce valid Infrahub resources, instead of the assistant inferring the platform from scratch on every request.
+The first release of Infrahub Skills — an open-source skills package that gives an AI coding assistant built-in, best-practice knowledge of Infrahub's data model, conventions, and workflows. It began as a single schema helper and grew, over the work in this release, into eight skills spanning the full development lifecycle. Describe what you want in plain language and the skills produce valid Infrahub resources, instead of the assistant inferring the platform from scratch on every request.
 
 ## Highlights
 
 ### Eight skills covering the full Infrahub lifecycle
 
 - **The problem.** An AI assistant pointed at Infrahub has to guess the platform's conventions on every request — relationship rules, attribute types, naming constraints, registration formats. The guesses surface as schemas that fail `infrahubctl schema check`, checks that never register, or transforms that emit the wrong content type, and you only find out after a round-trip through validation.
-- **What this enables.** One skill per task — [schemas](../skills-reference/managing-schemas.mdx), [objects](../skills-reference/managing-objects.mdx), [checks](../skills-reference/managing-checks.mdx), [generators](../skills-reference/managing-generators.mdx), [transforms](../skills-reference/managing-transforms.mdx), and [menus](../skills-reference/managing-menus.mdx) — each embedding the rules, examples, and references the assistant needs, plus [analyzing-data](../skills-reference/analyzing-data.mdx) for live queries and [auditing-repo](../skills-reference/auditing-repo.mdx) for compliance review.
+- **What this enables.** One skill per task — [schemas](../skills-reference/managing-schemas.mdx), [objects](../skills-reference/managing-objects.mdx), [checks](../skills-reference/managing-checks.mdx), [generators](../skills-reference/managing-generators.mdx), [transforms](../skills-reference/managing-transforms.mdx), and [menus](../skills-reference/managing-menus.mdx) — each embedding the rules, examples, and references the assistant needs, plus [analyzing-data](../skills-reference/analyzing-data.mdx) for live queries and [auditing-repo](../skills-reference/auditing-repo.mdx) for compliance review. The auditor cross-checks details that span files, such as whether query names line up between your Python and `.infrahub.yml`.
 - **When you need it.** Any time you build Infrahub artifacts with an AI assistant and want output that loads cleanly the first time rather than after several validation round-trips.
+
+### Catches the non-obvious mistakes that break a load
+
+- **The problem.** The failures that cost the most time aren't syntax slips — they're the conventions you can't guess. A relationship to a *generic* needs an explicit `kind:` and `data:` wrapper in the object file; a bare `location: chicago-1` silently fails to resolve. Attribute names and labels allow 64 characters, not 32. `regex` / `min_length` / `max_length` are deprecated as top-level attribute properties in favor of a `parameters` block. Generated SDK protocol files must never be hand-edited.
+- **What this enables.** Each skill encodes these as rules with side-by-side compliant and non-compliant examples — verified against Infrahub itself, not folklore — so the assistant emits the correct shape on the first attempt.
+- **When you need it.** Populating data across generic relationships, defining constrained attributes, or regenerating protocols after a schema change.
 
 ### Progressive disclosure keeps the assistant focused
 
 - **The problem.** Loading an entire domain manual into the model's context for every request burns the context window and dilutes attention — more to sift through, less room to reason.
-- **What this enables.** A three-level loading model: lightweight metadata decides whether a skill applies, the `SKILL.md` body supplies the workflow, and individual rule and reference files load only on demand.
+- **What this enables.** A three-level loading model: lightweight metadata decides whether a skill applies, the `SKILL.md` body supplies the workflow (with a per-skill step-by-step `## Workflow` that points at the exact rule to read at each step), and individual rule and reference files load only on demand.
 - **When you need it.** Larger schema or generator tasks where the assistant would otherwise exhaust its context juggling unrelated guidance.
 
-### Automatic project detection
+### Reliable activation with explicit triggers
 
-- **The problem.** Users had to remember to invoke the right skill for each task.
-- **What this enables.** A `SessionStart` hook detects Infrahub projects (`.infrahub.yml`, `infrahub.toml`, schema files) and steers the assistant to the matching skill with zero configuration.
-- **When you need it.** Working inside any existing Infrahub repository — the skills activate themselves.
+- **The problem.** Users had to remember to invoke the right skill for each task, and vague descriptions let the wrong skill fire — or none at all.
+- **What this enables.** A `SessionStart` hook detects Infrahub projects (`.infrahub.yml`, `infrahub.toml`, schema files) with zero configuration, and every skill description is written with explicit `TRIGGER when:` / `DO NOT TRIGGER when:` patterns so the right skill activates for the right request. The two highest-output skills — `analyzing-data` and `auditing-repo` — run in a forked context so their large reports don't crowd the main conversation.
+- **When you need it.** Working inside any existing Infrahub repository — the skills activate themselves and stay out of each other's way.
 
 ### Deterministic evaluation harness
 
 - **The problem.** Prose-based guidance rots silently: a refactor can drop a rule with nothing to flag the regression.
-- **What this enables.** A skillgrade eval suite with deterministic graders, so each skill's behavior is pinned by tests that fail when the guidance drifts.
+- **What this enables.** A skillgrade eval suite with deterministic Python graders and their own unit tests, so each skill's behavior is pinned by checks that fail when the guidance drifts — including guards against "vacuous pass" bugs where an empty output would otherwise have scored green.
 - **When you need it.** Contributing to, or relying on, the skills — the rules are backed by checks, not just intent.
 
 ## Other changes
@@ -53,5 +59,5 @@ The first release of Infrahub Skills — an open-source skills package that give
 #### Added
 
 - Apache 2.0 license and setup guidance for Claude Code, GitHub Copilot, and Cursor.
-- `infrahubctl` connectivity-check instructions and a shared rule for generated protocol files.
-- Skill descriptions written with explicit `TRIGGER` patterns so the right skill activates for the right request.
+- A shared rule guarding generated SDK protocol files, plus `infrahubctl info` connectivity and version checks (with `uv run` / Poetry environment detection) so the assistant validates its work against a live server.
+- CI automation: version auto-bump from PR labels, release-drafter release notes, and a Docusaurus docs build gate.

--- a/docs/docs/release-notes/release-0_0_1.mdx
+++ b/docs/docs/release-notes/release-0_0_1.mdx
@@ -1,0 +1,57 @@
+---
+title: Release 0.0.1
+sidebar_position: 9
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>0.0.1</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>April 9th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v0.0.1](https://github.com/opsmill/infrahub-skills/releases/tag/v0.0.1)</td>
+    </tr>
+  </tbody>
+</table>
+
+The first release of Infrahub Skills — an open-source skills package that gives an AI coding assistant built-in, best-practice knowledge of Infrahub's data model, conventions, and workflows. Describe what you want in plain language and the skills produce valid Infrahub resources, instead of the assistant inferring the platform from scratch on every request.
+
+## Highlights
+
+### Eight skills covering the full Infrahub lifecycle
+
+- **The problem.** An AI assistant pointed at Infrahub has to guess the platform's conventions on every request — relationship rules, attribute types, naming constraints, registration formats. The guesses surface as schemas that fail `infrahubctl schema check`, checks that never register, or transforms that emit the wrong content type, and you only find out after a round-trip through validation.
+- **What this enables.** One skill per task — [schemas](../skills-reference/managing-schemas.mdx), [objects](../skills-reference/managing-objects.mdx), [checks](../skills-reference/managing-checks.mdx), [generators](../skills-reference/managing-generators.mdx), [transforms](../skills-reference/managing-transforms.mdx), and [menus](../skills-reference/managing-menus.mdx) — each embedding the rules, examples, and references the assistant needs, plus [analyzing-data](../skills-reference/analyzing-data.mdx) for live queries and [auditing-repo](../skills-reference/auditing-repo.mdx) for compliance review.
+- **When you need it.** Any time you build Infrahub artifacts with an AI assistant and want output that loads cleanly the first time rather than after several validation round-trips.
+
+### Progressive disclosure keeps the assistant focused
+
+- **The problem.** Loading an entire domain manual into the model's context for every request burns the context window and dilutes attention — more to sift through, less room to reason.
+- **What this enables.** A three-level loading model: lightweight metadata decides whether a skill applies, the `SKILL.md` body supplies the workflow, and individual rule and reference files load only on demand.
+- **When you need it.** Larger schema or generator tasks where the assistant would otherwise exhaust its context juggling unrelated guidance.
+
+### Automatic project detection
+
+- **The problem.** Users had to remember to invoke the right skill for each task.
+- **What this enables.** A `SessionStart` hook detects Infrahub projects (`.infrahub.yml`, `infrahub.toml`, schema files) and steers the assistant to the matching skill with zero configuration.
+- **When you need it.** Working inside any existing Infrahub repository — the skills activate themselves.
+
+### Deterministic evaluation harness
+
+- **The problem.** Prose-based guidance rots silently: a refactor can drop a rule with nothing to flag the regression.
+- **What this enables.** A skillgrade eval suite with deterministic graders, so each skill's behavior is pinned by tests that fail when the guidance drifts.
+- **When you need it.** Contributing to, or relying on, the skills — the rules are backed by checks, not just intent.
+
+## Other changes
+
+#### Added
+
+- Apache 2.0 license and setup guidance for Claude Code, GitHub Copilot, and Cursor.
+- `infrahubctl` connectivity-check instructions and a shared rule for generated protocol files.
+- Skill descriptions written with explicit `TRIGGER` patterns so the right skill activates for the right request.

--- a/docs/docs/release-notes/release-0_0_1.mdx
+++ b/docs/docs/release-notes/release-0_0_1.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 0.0.1
 sidebar_position: 9
+description: The first release of Infrahub Skills — eight skills that build, query, and audit Infrahub resources from natural language.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 9
     <tr>
       <th>Release Number</th>
       <td>0.0.1</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Feature</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,44 +25,63 @@ sidebar_position: 9
   </tbody>
 </table>
 
-The first release of Infrahub Skills — an open-source skills package that gives an AI coding assistant built-in, best-practice knowledge of Infrahub's data model, conventions, and workflows. It began as a single schema helper and grew, over the work in this release, into eight skills spanning the full development lifecycle. Describe what you want in plain language and the skills produce valid Infrahub resources, instead of the assistant inferring the platform from scratch on every request.
+## Release summary
 
-## Highlights
+Describe a schema, object, check, generator, transform, or menu in plain language and get valid Infrahub resources without first mastering the platform's data model. Infrahub Skills is an open-source skills package for AI coding assistants, and this first release ships eight skills across the build, query, and audit lifecycle.
 
-### Eight skills covering the full Infrahub lifecycle
+### Build Infrahub resources from natural language
 
-- **The problem.** An AI assistant pointed at Infrahub has to guess the platform's conventions on every request — relationship rules, attribute types, naming constraints, registration formats. The guesses surface as schemas that fail `infrahubctl schema check`, checks that never register, or transforms that emit the wrong content type, and you only find out after a round-trip through validation.
-- **What this enables.** One skill per task — [schemas](../skills-reference/managing-schemas.mdx), [objects](../skills-reference/managing-objects.mdx), [checks](../skills-reference/managing-checks.mdx), [generators](../skills-reference/managing-generators.mdx), [transforms](../skills-reference/managing-transforms.mdx), and [menus](../skills-reference/managing-menus.mdx) — each embedding the rules, examples, and references the assistant needs, plus [analyzing-data](../skills-reference/analyzing-data.mdx) for live queries and [auditing-repo](../skills-reference/auditing-repo.mdx) for compliance review. The auditor cross-checks details that span files, such as whether query names line up between your Python and `.infrahub.yml`.
-- **When you need it.** Any time you build Infrahub artifacts with an AI assistant and want output that loads cleanly the first time rather than after several validation round-trips.
+Eight skills cover the Infrahub development lifecycle, one per task, each with the rules, examples, and references for that task.
 
-### Catches the non-obvious mistakes that break a load
+* Generate schemas, objects, checks, generators, transforms, and menus, one skill per task — [managing-schemas](../skills-reference/managing-schemas.mdx), [managing-objects](../skills-reference/managing-objects.mdx), and the rest.
+* Query live data with [analyzing-data](../skills-reference/analyzing-data.mdx), and audit a repository against Infrahub conventions with [auditing-repo](../skills-reference/auditing-repo.mdx), which checks details that span files, such as whether query names match between Python and `.infrahub.yml`.
+* Apply conventions verified against the server: a relationship to a generic needs an explicit `kind:` and `data:` wrapper, `regex` / `min_length` / `max_length` move into a `parameters` block, and generated SDK protocol files are never edited manually.
 
-- **The problem.** The failures that cost the most time aren't syntax slips — they're the conventions you can't guess. A relationship to a *generic* needs an explicit `kind:` and `data:` wrapper in the object file; a bare `location: chicago-1` silently fails to resolve. Attribute names and labels allow 64 characters, not 32. `regex` / `min_length` / `max_length` are deprecated as top-level attribute properties in favor of a `parameters` block. Generated SDK protocol files must never be hand-edited.
-- **What this enables.** Each skill encodes these as rules with side-by-side compliant and non-compliant examples — verified against Infrahub itself, not folklore — so the assistant emits the correct shape on the first attempt.
-- **When you need it.** Populating data across generic relationships, defining constrained attributes, or regenerating protocols after a schema change.
+### Let the right skill activate automatically inside an Infrahub repository
 
-### Progressive disclosure keeps the assistant focused
+Open an Infrahub project and the matching skill activates for the task at hand. Installed as a Claude Code plugin, a session-start hook detects the project automatically; with other tools, the skills are present in the project directory.
 
-- **The problem.** Loading an entire domain manual into the model's context for every request burns the context window and dilutes attention — more to sift through, less room to reason.
-- **What this enables.** A three-level loading model: lightweight metadata decides whether a skill applies, the `SKILL.md` body supplies the workflow (with a per-skill step-by-step `## Workflow` that points at the exact rule to read at each step), and individual rule and reference files load only on demand.
-- **When you need it.** Larger schema or generator tasks where the assistant would otherwise exhaust its context juggling unrelated guidance.
+* A `SessionStart` hook detects an Infrahub project from `.infrahub.yml`, `infrahub.toml`, or a schema file, then points the assistant at the matching skill.
+* Each skill description carries explicit `TRIGGER when:` and `DO NOT TRIGGER when:` patterns, so the matching skill activates for a request.
+* [analyzing-data](../skills-reference/analyzing-data.mdx) and [auditing-repo](../skills-reference/auditing-repo.mdx) run in a forked context, so their large reports run separately from the main conversation.
 
-### Reliable activation with explicit triggers
+### Work on large schema and generator tasks without exhausting context
 
-- **The problem.** Users had to remember to invoke the right skill for each task, and vague descriptions let the wrong skill fire — or none at all.
-- **What this enables.** A `SessionStart` hook detects Infrahub projects (`.infrahub.yml`, `infrahub.toml`, schema files) with zero configuration, and every skill description is written with explicit `TRIGGER when:` / `DO NOT TRIGGER when:` patterns so the right skill activates for the right request. The two highest-output skills — `analyzing-data` and `auditing-repo` — run in a forked context so their large reports don't crowd the main conversation.
-- **When you need it.** Working inside any existing Infrahub repository — the skills activate themselves and stay out of each other's way.
+Only the guidance the current step needs is loaded, leaving room in the context for the work itself.
 
-### Deterministic evaluation harness
+* Skill metadata decides whether a skill applies; the `SKILL.md` body supplies the workflow; rule and reference files load only when a step needs them.
+* Each skill includes a step-by-step `## Workflow` that names the exact rule to read at each step.
 
-- **The problem.** Prose-based guidance rots silently: a refactor can drop a rule with nothing to flag the regression.
-- **What this enables.** A skillgrade eval suite with deterministic Python graders and their own unit tests, so each skill's behavior is pinned by checks that fail when the guidance drifts — including guards against "vacuous pass" bugs where an empty output would otherwise have scored green.
-- **When you need it.** Contributing to, or relying on, the skills — the rules are backed by checks, not just intent.
+## Minor changes
 
-## Other changes
+**Testing**
 
-#### Added
+* A skillgrade evaluation suite with deterministic Python graders checks each skill's behavior, including guards against tests that would pass on empty output.
 
-- Apache 2.0 license and setup guidance for Claude Code, GitHub Copilot, and Cursor.
-- A shared rule guarding generated SDK protocol files, plus `infrahubctl info` connectivity and version checks (with `uv run` / Poetry environment detection) so the assistant validates its work against a live server.
-- CI automation: version auto-bump from PR labels, release-drafter release notes, and a Docusaurus docs build gate.
+**Developer experience**
+
+* A shared rule protects generated SDK protocol files from manual edits.
+* `infrahubctl info` connectivity and version checks (with uv and Poetry environment detection) validate output against a running server.
+* CI automation: version auto-bump from PR labels, release-drafter notes, and a documentation build check.
+
+## Full changelog
+
+### Added
+
+* Eight skills: managing-schemas, managing-objects, managing-checks, managing-generators, managing-transforms, managing-menus, auditing-repo, and analyzing-data ([#2](https://github.com/opsmill/infrahub-skills/pull/2), [#6](https://github.com/opsmill/infrahub-skills/pull/6), [#7](https://github.com/opsmill/infrahub-skills/pull/7)).
+* Project detection via a `SessionStart` hook ([#1](https://github.com/opsmill/infrahub-skills/pull/1)), and the skillgrade evaluation harness ([#13](https://github.com/opsmill/infrahub-skills/pull/13)).
+* Apache 2.0 license, with setup guidance for Claude Code, GitHub Copilot, and Cursor ([#3](https://github.com/opsmill/infrahub-skills/pull/3)).
+* CI automation: auto-bump, release-drafter, and documentation build ([#40](https://github.com/opsmill/infrahub-skills/pull/40)).
+
+See the [full list of merged pull requests](https://github.com/opsmill/infrahub-skills/releases/tag/v0.0.1).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data

--- a/docs/docs/release-notes/release-1_2_0.mdx
+++ b/docs/docs/release-notes/release-1_2_0.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 1.2.0
 sidebar_position: 8
+description: Version realignment from 0.0.1 to 1.2.0 ahead of the automated release tooling. No skill changes.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 8
     <tr>
       <th>Release Number</th>
       <td>1.2.0</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Maintenance</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,8 +25,23 @@ sidebar_position: 8
   </tbody>
 </table>
 
-A version realignment. `1.2.0` retrofits the plugin's version number ahead of the automated release tooling that owns versioning from here on. It carries the same content as `0.0.1` — the only difference is version strings and the lockfile — so there is no functional change to any skill.
+## Release summary
+
+The package version moves from `0.0.1` to `1.2.0` ahead of the automated release tooling. No skill changes.
+
+## Full changelog
 
 ### Changed
 
-- Plugin version bumped from `0.0.1` to `1.2.0`, with the version metadata synced across every `SKILL.md`, so the package version is consistent before release-drafter and the auto-bump workflow take over.
+* Plugin version bumped from `0.0.1` to `1.2.0`, with version metadata synced across every `SKILL.md`, before release-drafter and the auto-bump workflow manage versioning.
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data

--- a/docs/docs/release-notes/release-1_2_0.mdx
+++ b/docs/docs/release-notes/release-1_2_0.mdx
@@ -1,0 +1,27 @@
+---
+title: Release 1.2.0
+sidebar_position: 8
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.0</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>April 10th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.0](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.0)</td>
+    </tr>
+  </tbody>
+</table>
+
+A version realignment. `1.2.0` retrofits the plugin's version number ahead of the automated release tooling that owns versioning from here on. It carries the same content as `0.0.1` — the only difference is version strings and the lockfile — so there is no functional change to any skill.
+
+### Changed
+
+- Plugin version bumped from `0.0.1` to `1.2.0`, with the version metadata synced across every `SKILL.md`, so the package version is consistent before release-drafter and the auto-bump workflow take over.

--- a/docs/docs/release-notes/release-1_2_1.mdx
+++ b/docs/docs/release-notes/release-1_2_1.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 1.2.1
 sidebar_position: 7
+description: A documentation site for the skills package — installation, how-it-works, and a per-skill reference.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 7
     <tr>
       <th>Release Number</th>
       <td>1.2.1</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Improvement</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,6 +25,23 @@ sidebar_position: 7
   </tbody>
 </table>
 
+## Release summary
+
+Browse the installation guide, how-it-works, and per-skill reference as a documentation site, instead of reading them only from inside an AI assistant.
+
+## Full changelog
+
 ### Added
 
-- A documentation site for the skills package — installation, how-it-works, and a per-skill reference — published alongside the repository so the guidance is browsable on its own, not only from inside an AI assistant.
+* A documentation site covering installation, how the skills work, and a per-skill reference ([#33](https://github.com/opsmill/infrahub-skills/pull/33)).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data

--- a/docs/docs/release-notes/release-1_2_1.mdx
+++ b/docs/docs/release-notes/release-1_2_1.mdx
@@ -1,0 +1,25 @@
+---
+title: Release 1.2.1
+sidebar_position: 7
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.1</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>April 16th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.1](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.1)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Added
+
+- A documentation site for the skills package — installation, how-it-works, and a per-skill reference — published alongside the repository so the guidance is browsable on its own, not only from inside an AI assistant.

--- a/docs/docs/release-notes/release-1_2_1.mdx
+++ b/docs/docs/release-notes/release-1_2_1.mdx
@@ -27,7 +27,7 @@ description: A documentation site for the skills package — installation, how-i
 
 ## Release summary
 
-Browse the installation guide, how-it-works, and per-skill reference as a documentation site, instead of reading them only from inside an AI assistant.
+Browse the installation guide, how-it-works, and per-skill reference on a documentation site, now available alongside the repository instead of only from inside an AI assistant.
 
 ## Full changelog
 

--- a/docs/docs/release-notes/release-1_2_2.mdx
+++ b/docs/docs/release-notes/release-1_2_2.mdx
@@ -1,0 +1,33 @@
+---
+title: Release 1.2.2
+sidebar_position: 6
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.2</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 11th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.2](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.2)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Added
+
+- Six new schema rules distilled from production OpsMill repositories: computed (Jinja2) attributes, branch-aware vs branch-agnostic attributes, relationship `on_delete` (`cascade` vs `no-action`), menu-placement strategy, artifact-target extensions (`CoreArtifactTarget`), and object templates (`generate_template`).
+
+### Changed
+
+- `kind: Parent` relationship constraints tightened to match the server-side validator: a Parent relationship must be `optional: false` and `cardinality: one`, and a node may have at most one of them.
+
+### Fixed
+
+- Clarified that `check_definitions` does **not** accept a `query:` field — unlike `generator_definitions`. The query binds from the Python class's `query` attribute, so the conflation was producing repository configs that fail validation.

--- a/docs/docs/release-notes/release-1_2_2.mdx
+++ b/docs/docs/release-notes/release-1_2_2.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 1.2.2
 sidebar_position: 6
+description: New managing-schemas rules for production patterns, plus relationship and check-registration fixes.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 6
     <tr>
       <th>Release Number</th>
       <td>1.2.2</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Improvement</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,14 +25,46 @@ sidebar_position: 6
   </tbody>
 </table>
 
+## Release summary
+
+Model schema patterns common in production OpsMill repositories so they pass Infrahub's validators on the first load. Express constructs that often fail validation — computed attributes, branch behavior, delete handling, menu placement, artifact targets, and object templates — and define relationships and register checks the way the server-side validator expects.
+
+### Model schema patterns common in production repositories
+
+When you model a schema with one of these constructs, you no longer have to infer the shape Infrahub expects — you get it from the managing-schemas skill, with compliant and non-compliant examples.
+
+* Define an attribute whose value is computed from other fields with a Jinja2 expression (`computed_attribute`, paired with `read_only: true`), instead of storing it directly.
+* Mark an attribute `branch: agnostic` so its value applies across every branch, or leave it branch-aware (the default) so changes stay scoped to a branch until merge.
+* Set a relationship's `on_delete` to `cascade` or `no-action` to control whether deleting a node also deletes its related nodes.
+* Control where a node appears in the sidebar with `menu_placement`, instead of relying on the default position.
+* Extend `CoreArtifactTarget` so a node can be rendered against by artifact definitions, and set `generate_template: true` to create nodes from a reusable template.
+* Define a `kind: Parent` relationship as `optional: false` and `cardinality: one`, with at most one per node, so it matches the server-side validator.
+
+## Bug fixes
+
+* `check_definitions` does not accept a `query:` field, unlike `generator_definitions`. The query binds from the Python class's `query` attribute, which must match a `name` under the top-level `queries:` section; the configuration model forbids extra keys, so a stray `query:` makes the repository configuration fail validation.
+
+## Full changelog
+
 ### Added
 
-- Six new schema rules distilled from production OpsMill repositories: computed (Jinja2) attributes, branch-aware vs branch-agnostic attributes, relationship `on_delete` (`cascade` vs `no-action`), menu-placement strategy, artifact-target extensions (`CoreArtifactTarget`), and object templates (`generate_template`).
+* Six schema rules from production repositories: computed attributes, branch behavior, relationship `on_delete`, menu placement, `CoreArtifactTarget`, and object templates ([#41](https://github.com/opsmill/infrahub-skills/pull/41)).
 
 ### Changed
 
-- `kind: Parent` relationship constraints tightened to match the server-side validator: a Parent relationship must be `optional: false` and `cardinality: one`, and a node may have at most one of them.
+* `kind: Parent` constraints tightened to match the server-side validator ([#41](https://github.com/opsmill/infrahub-skills/pull/41)).
 
 ### Fixed
 
-- Clarified that `check_definitions` does **not** accept a `query:` field — unlike `generator_definitions`. The query binds from the Python class's `query` attribute, so the conflation was producing repository configs that fail validation.
+* Clarified that `check_definitions` has no `query:` field ([#41](https://github.com/opsmill/infrahub-skills/pull/41)).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data

--- a/docs/docs/release-notes/release-1_2_2.mdx
+++ b/docs/docs/release-notes/release-1_2_2.mdx
@@ -27,7 +27,7 @@ description: New managing-schemas rules for production patterns, plus relationsh
 
 ## Release summary
 
-Model schema patterns common in production OpsMill repositories so they pass Infrahub's validators on the first load. Express constructs that often fail validation — computed attributes, branch behavior, delete handling, menu placement, artifact targets, and object templates — and define relationships and register checks the way the server-side validator expects.
+Model schema patterns common in production OpsMill repositories so they pass Infrahub's validators on the first load. You can now express constructs that often fail validation — computed attributes, branch behavior, delete handling, menu placement, artifact targets, and object templates — and define relationships and register checks the way the server-side validator expects.
 
 ### Model schema patterns common in production repositories
 

--- a/docs/docs/release-notes/release-1_2_3.mdx
+++ b/docs/docs/release-notes/release-1_2_3.mdx
@@ -1,0 +1,25 @@
+---
+title: Release 1.2.3
+sidebar_position: 5
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.3</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 11th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.3](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.3)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- Removed the non-standard `paths:` frontmatter from the six `managing-*` skills. Claude Code's skills loader was treating `paths:` as an unsupported field and silently hiding those skills from the invocable list — `/infrahub-managing-schemas` returned "Unknown skill" after a fresh install. All skills now appear and invoke correctly.

--- a/docs/docs/release-notes/release-1_2_3.mdx
+++ b/docs/docs/release-notes/release-1_2_3.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 1.2.3
 sidebar_position: 5
+description: Every managing-* skill appears again after a fresh install; a frontmatter field had hidden six of them.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 5
     <tr>
       <th>Release Number</th>
       <td>1.2.3</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Improvement</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,6 +25,27 @@ sidebar_position: 5
   </tbody>
 </table>
 
+## Release summary
+
+Every `managing-*` skill now appears after a fresh install. A non-standard frontmatter field had hidden six of them from Claude Code's invocable list.
+
+## Bug fixes
+
+* Removed the non-standard `paths:` frontmatter from the six `managing-*` skills. Claude Code's loader treated `paths:` as unsupported and silently hid those skills — `/infrahub-managing-schemas` returned "Unknown skill" after a fresh install. All six now appear and invoke.
+
+## Full changelog
+
 ### Fixed
 
-- Removed the non-standard `paths:` frontmatter from the six `managing-*` skills. Claude Code's skills loader was treating `paths:` as an unsupported field and silently hiding those skills from the invocable list — `/infrahub-managing-schemas` returned "Unknown skill" after a fresh install. All skills now appear and invoke correctly.
+* Removed unsupported `paths:` frontmatter that hid the `managing-*` skills ([#44](https://github.com/opsmill/infrahub-skills/pull/44)).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data

--- a/docs/docs/release-notes/release-1_2_4.mdx
+++ b/docs/docs/release-notes/release-1_2_4.mdx
@@ -1,0 +1,25 @@
+---
+title: Release 1.2.4
+sidebar_position: 4
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.4</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 11th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.4](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.4)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Fixed
+
+- [analyzing-data](../skills-reference/analyzing-data.mdx) now requires the user's question to be passed as `args`. The skill runs in a forked context with no view of the parent conversation; without `args` it was falling back to the example question baked into the skill and answering that instead of what the user asked. It now fails loudly with a re-invoke instruction rather than silently answering the wrong question.

--- a/docs/docs/release-notes/release-1_2_4.mdx
+++ b/docs/docs/release-notes/release-1_2_4.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 1.2.4
 sidebar_position: 4
+description: analyzing-data now answers the question you asked instead of a built-in example when none is passed.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 4
     <tr>
       <th>Release Number</th>
       <td>1.2.4</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Improvement</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,6 +25,27 @@ sidebar_position: 4
   </tbody>
 </table>
 
+## Release summary
+
+Ask analyzing-data a question and get an answer to that question. When the question was omitted, it had answered a built-in example instead.
+
+## Bug fixes
+
+* [analyzing-data](../skills-reference/analyzing-data.mdx) now requires the question as `args`. It runs in a forked context with no view of the parent conversation; without `args` it had used the example question built into the skill. It now stops with a re-invoke instruction instead of answering a different question.
+
+## Full changelog
+
 ### Fixed
 
-- [analyzing-data](../skills-reference/analyzing-data.mdx) now requires the user's question to be passed as `args`. The skill runs in a forked context with no view of the parent conversation; without `args` it was falling back to the example question baked into the skill and answering that instead of what the user asked. It now fails loudly with a re-invoke instruction rather than silently answering the wrong question.
+* Require the question as `args` for analyzing-data ([#45](https://github.com/opsmill/infrahub-skills/pull/45)).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data

--- a/docs/docs/release-notes/release-1_2_5.mdx
+++ b/docs/docs/release-notes/release-1_2_5.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 1.2.5
 sidebar_position: 3
+description: Report Infrahub bugs and feature requests with the reporting-issues skill, sanitized and routed automatically.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 3
     <tr>
       <th>Release Number</th>
       <td>1.2.5</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Feature</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,24 +25,46 @@ sidebar_position: 3
   </tbody>
 </table>
 
-## Highlights
+## Release summary
 
-### Report bugs and features across the Infrahub ecosystem
+Report Infrahub bugs and feature requests without first working out which repository owns them or manually redacting your terminal output.
 
-- **The problem.** Filing a good Infrahub issue means knowing which of the ecosystem's repositories owns it (main, SDK, Ansible, VS Code, Nornir, Helm, MCP, schema-library, backup, sync, skills), matching each repo's issue template, and not leaking sensitive data from your environment into a public tracker.
-- **What this enables.** The `infrahub-reporting-issues` skill routes a report to the right repository — defaulting to `opsmill/infrahub` when ambiguous, since the main repo re-routes downstream more easily than the reverse — fills the correct template, and runs a deterministic sanitization pass that strips IPs, internal hostnames, tokens, and filesystem paths. It never auto-submits: it stops at a review gate and lets you choose `gh`, MCP, or manual submission.
-- **When you need it.** Any time you hit a bug or have a feature request and want it filed cleanly in the right place without hand-redacting your terminal output. See the [reporting-issues skill](https://github.com/opsmill/infrahub-skills/tree/main/skills/infrahub-reporting-issues).
+### Report bugs and feature requests across the Infrahub ecosystem
 
-## Other changes
+Report an issue from your AI assistant with the reporting-issues skill, and it is routed to the right repository, filled into that repository's template, and cleared of sensitive data before submission.
 
-#### Added
+* Route a report to the correct repository in the Infrahub ecosystem, defaulting to `opsmill/infrahub` when the target is unclear.
+* Run a deterministic sanitization pass that replaces IPs, internal hostnames, URLs, and filesystem paths, and stops to ask you when it detects a token or database connection string.
+* Stop at a review step instead of submitting automatically — choose `gh`, the MCP server, or manual submission.
 
-- Documentation of Infrahub schema string-length limits in the schema skill.
+## Minor changes
 
-#### Changed
+**Documentation**
 
-- Dropped the stale `CHANGELOG.md`; release-drafter now owns release notes.
+* Infrahub schema string-length limits documented in the schema skill ([#48](https://github.com/opsmill/infrahub-skills/pull/48)).
 
-#### Fixed
+## Full changelog
 
-- Typo in the skills update instructions.
+### Added
+
+* `infrahub-reporting-issues` skill ([#47](https://github.com/opsmill/infrahub-skills/pull/47)).
+
+### Changed
+
+* Dropped the stale `CHANGELOG.md`; release-drafter now owns release notes ([#50](https://github.com/opsmill/infrahub-skills/pull/50)).
+
+### Fixed
+
+* Typo in the skills update instructions ([#51](https://github.com/opsmill/infrahub-skills/pull/51)).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data
+* infrahub-reporting-issues

--- a/docs/docs/release-notes/release-1_2_5.mdx
+++ b/docs/docs/release-notes/release-1_2_5.mdx
@@ -1,0 +1,43 @@
+---
+title: Release 1.2.5
+sidebar_position: 3
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.5</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>May 26th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.5](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.5)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Highlights
+
+### Report bugs and features across the Infrahub ecosystem
+
+- **The problem.** Filing a good Infrahub issue means knowing which of the ecosystem's repositories owns it (main, SDK, Ansible, VS Code, Nornir, Helm, MCP, schema-library, backup, sync, skills), matching each repo's issue template, and not leaking sensitive data from your environment into a public tracker.
+- **What this enables.** The `infrahub-reporting-issues` skill routes a report to the right repository — defaulting to `opsmill/infrahub` when ambiguous, since the main repo re-routes downstream more easily than the reverse — fills the correct template, and runs a deterministic sanitization pass that strips IPs, internal hostnames, tokens, and filesystem paths. It never auto-submits: it stops at a review gate and lets you choose `gh`, MCP, or manual submission.
+- **When you need it.** Any time you hit a bug or have a feature request and want it filed cleanly in the right place without hand-redacting your terminal output. See the [reporting-issues skill](https://github.com/opsmill/infrahub-skills/tree/main/skills/infrahub-reporting-issues).
+
+## Other changes
+
+#### Added
+
+- Documentation of Infrahub schema string-length limits in the schema skill.
+
+#### Changed
+
+- Dropped the stale `CHANGELOG.md`; release-drafter now owns release notes.
+
+#### Fixed
+
+- Typo in the skills update instructions.

--- a/docs/docs/release-notes/release-1_2_5.mdx
+++ b/docs/docs/release-notes/release-1_2_5.mdx
@@ -27,7 +27,7 @@ description: Report Infrahub bugs and feature requests with the reporting-issues
 
 ## Release summary
 
-Report Infrahub bugs and feature requests without first working out which repository owns them or manually redacting your terminal output.
+You can now report Infrahub bugs and feature requests without first working out which repository owns them or manually redacting your terminal output.
 
 ### Report bugs and feature requests across the Infrahub ecosystem
 

--- a/docs/docs/release-notes/release-1_2_6.mdx
+++ b/docs/docs/release-notes/release-1_2_6.mdx
@@ -1,0 +1,59 @@
+---
+title: Release 1.2.6
+sidebar_position: 2
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.6</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>June 15th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.6](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.6)</td>
+    </tr>
+  </tbody>
+</table>
+
+The largest release since launch — a new diagnostics skill, file-attachment schema support, a branch-first safety default for every data change, and a wave of empirically verified fixes across the skill set.
+
+## Highlights
+
+### Collect a redacted diagnostic bundle for expert hand-off
+
+- **The problem.** When an Infrahub deployment misbehaves and you need OpsMill's help, assembling the right logs, config, and state — across Docker Compose or Kubernetes, across multiple replicas — is manual and error-prone, and it's easy to leak secrets into whatever you share.
+- **What this enables.** The `infrahub-collecting-diagnostics` skill walks through collecting a redacted local bundle: it detects the deployment type, covers multi-replica setups, probes the running instance through `infrahubctl` only (read-only), and applies tiered redaction before producing a manifest-described bundle ready to hand off.
+- **When you need it.** Escalating an issue to OpsMill experts, or capturing a point-in-time snapshot of a misbehaving deployment. See the [collecting-diagnostics skill](https://github.com/opsmill/infrahub-skills/tree/main/skills/infrahub-collecting-diagnostics).
+
+### Model file attachments with `CoreFileObject`
+
+- **The problem.** Storing PDFs, network diagrams, KMZ overlays, certificates, or contracts against Infrahub nodes had no guidance — so the assistant defaulted to the antipattern of a `kind: Text` url/path string instead of using Infrahub's object storage.
+- **What this enables.** Schema-side rules for `CoreFileObject`, the built-in generic that turns a node into a file-bearing entity with automatic file metadata and a GraphQL upload mutation, plus an audit rule that flags reserved-attribute collisions and the text-string bypass.
+- **When you need it.** Modeling any document or binary attachment — rack photos, compliance docs, runbooks, circuit contracts — as first-class Infrahub data. See [managing-schemas](../skills-reference/managing-schemas.mdx).
+
+### Branch-first by default for all data changes
+
+- **The problem.** Writing data straight to the default branch (`main` by convention, configurable per deployment) has no per-changeset undo and skips the proposed-change review pipeline — schema validation, checks, human review. A real import of roughly 38,000 objects landed on the default branch and then had to be unwound by hand, one object at a time.
+- **What this enables.** A shared cross-cutting rule steering every CRUD path — object loads, MCP `infrahub_create`/`infrahub_update`/`infrahub_delete`, generator runs, and the SDK — toward a dedicated branch, with a rationalization table and red-flags list so the assistant holds the line under pressure. A branch is a single discard; the default branch is not.
+- **When you need it.** Any bulk import or data change you might want to review or roll back — which is to say, most of them.
+
+## Other changes
+
+#### Added
+
+- Resources testing-framework documentation for the check and transform skills.
+
+#### Changed
+
+- "Information Priority" guidance relocated to a shared rule so every skill inherits it.
+
+#### Fixed
+
+- Integration-layer gaps surfaced by a live build: union-typed GraphQL queries missing inline fragments, relationship references passed as bare strings or mis-packed lists, natural-key collisions on create, and artifact regeneration treated as synchronous (managing-generators, managing-transforms).
+- Owner vs source metadata semantics corrected across skills — source is lineage only; `owner` plus `is_protected` is what controls write access.
+- A cross-skill empirical accuracy pass: content-type allowlists, `extensions:` scope, `__typename` resolution, the Jinja2 filter sandbox, and more — each claim verified against Infrahub source or a running server.

--- a/docs/docs/release-notes/release-1_2_6.mdx
+++ b/docs/docs/release-notes/release-1_2_6.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 1.2.6
 sidebar_position: 2
+description: A diagnostics skill, CoreFileObject schema support, and a branch-first default for every data change.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 2
     <tr>
       <th>Release Number</th>
       <td>1.2.6</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Feature</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,40 +25,74 @@ sidebar_position: 2
   </tbody>
 </table>
 
-The largest release since launch — a new diagnostics skill, file-attachment schema support, a branch-first safety default for every data change, and a wave of empirically verified fixes across the skill set.
+## Release summary
 
-## Highlights
+After upgrading, data changes target a dedicated branch by default, you can model file attachments with `CoreFileObject`, and you can collect a redacted diagnostic bundle to share when you escalate an issue to OpsMill.
 
-### Collect a redacted diagnostic bundle for expert hand-off
+### Keep data changes on a branch you can review or roll back
 
-- **The problem.** When an Infrahub deployment misbehaves and you need OpsMill's help, assembling the right logs, config, and state — across Docker Compose or Kubernetes, across multiple replicas — is manual and error-prone, and it's easy to leak secrets into whatever you share.
-- **What this enables.** The `infrahub-collecting-diagnostics` skill walks through collecting a redacted local bundle: it detects the deployment type, covers multi-replica setups, probes the running instance through `infrahubctl` only (read-only), and applies tiered redaction before producing a manifest-described bundle ready to hand off.
-- **When you need it.** Escalating an issue to OpsMill experts, or capturing a point-in-time snapshot of a misbehaving deployment. See the [collecting-diagnostics skill](https://github.com/opsmill/infrahub-skills/tree/main/skills/infrahub-collecting-diagnostics).
+Data changes now target a dedicated branch by default instead of the default branch, so you can review them through a proposed change or discard the branch instead of reverting each object manually.
+
+* Direct every write path — `infrahubctl object load`, the MCP `infrahub_create` / `infrahub_update` / `infrahub_delete` tools, `infrahubctl generator run`, and the Python SDK — to a dedicated branch instead of the default branch (`main` by convention, configurable per deployment).
+* A shared rule in `infrahub-common` covers when a direct write to the default branch is and is not appropriate, so the assistant defaults to a branch even when a request asks to write directly.
 
 ### Model file attachments with `CoreFileObject`
 
-- **The problem.** Storing PDFs, network diagrams, KMZ overlays, certificates, or contracts against Infrahub nodes had no guidance — so the assistant defaulted to the antipattern of a `kind: Text` url/path string instead of using Infrahub's object storage.
-- **What this enables.** Schema-side rules for `CoreFileObject`, the built-in generic that turns a node into a file-bearing entity with automatic file metadata and a GraphQL upload mutation, plus an audit rule that flags reserved-attribute collisions and the text-string bypass.
-- **When you need it.** Modeling any document or binary attachment — rack photos, compliance docs, runbooks, circuit contracts — as first-class Infrahub data. See [managing-schemas](../skills-reference/managing-schemas.mdx).
+Store documents and binary files — diagrams, certificates, contracts, rack photos — on Infrahub nodes with the managing-schemas skill, using the built-in `CoreFileObject` generic instead of a text attribute that holds a URL or path.
 
-### Branch-first by default for all data changes
+* Make a node a file-bearing entity by inheriting `CoreFileObject`; Infrahub adds a `file:` argument to the node's create, update, and upsert mutations so a file can be uploaded against it.
+* An audit rule flags reserved-attribute collisions (`file_name`, `file_size`, `file_type`, `checksum`, `storage_id`) and the antipattern of storing a file as a URL or path in a `kind: Text` attribute.
 
-- **The problem.** Writing data straight to the default branch (`main` by convention, configurable per deployment) has no per-changeset undo and skips the proposed-change review pipeline — schema validation, checks, human review. A real import of roughly 38,000 objects landed on the default branch and then had to be unwound by hand, one object at a time.
-- **What this enables.** A shared cross-cutting rule steering every CRUD path — object loads, MCP `infrahub_create`/`infrahub_update`/`infrahub_delete`, generator runs, and the SDK — toward a dedicated branch, with a rationalization table and red-flags list so the assistant holds the line under pressure. A branch is a single discard; the default branch is not.
-- **When you need it.** Any bulk import or data change you might want to review or roll back — which is to say, most of them.
+### Collect a redacted diagnostic bundle to share with OpsMill
 
-## Other changes
+Assemble a redacted, manifest-described diagnostic bundle from a local deployment with the infrahub-collecting-diagnostics skill when you escalate an issue to OpsMill.
 
-#### Added
+* Collect from Docker Compose or Kubernetes deployments, including multi-replica setups where one replica's missing logs can hide a bug, and read instance state through `infrahubctl` only.
+* Apply tiered redaction before producing the bundle, and describe its contents in a `manifest.yml`.
 
-- Resources testing-framework documentation for the check and transform skills.
+## Bug fixes
 
-#### Changed
+* Fixed integration-layer gaps found in a live build: union-typed GraphQL queries missing inline fragments, relationship references passed as bare strings or mis-packed lists, natural-key collisions on create, and artifact regeneration treated as synchronous (managing-generators, managing-transforms).
+* Corrected owner and source metadata semantics: source records lineage only, while `owner` together with `is_protected` controls write access.
+* Verified content-type allowlists, `extensions:` scope, `__typename` resolution, and the Jinja2 filter sandbox against Infrahub source or a running server.
 
-- "Information Priority" guidance relocated to a shared rule so every skill inherits it.
+## Minor changes
 
-#### Fixed
+**Documentation**
 
-- Integration-layer gaps surfaced by a live build: union-typed GraphQL queries missing inline fragments, relationship references passed as bare strings or mis-packed lists, natural-key collisions on create, and artifact regeneration treated as synchronous (managing-generators, managing-transforms).
-- Owner vs source metadata semantics corrected across skills — source is lineage only; `owner` plus `is_protected` is what controls write access.
-- A cross-skill empirical accuracy pass: content-type allowlists, `extensions:` scope, `__typename` resolution, the Jinja2 filter sandbox, and more — each claim verified against Infrahub source or a running server.
+* Resources testing-framework documentation added to the check and transform skills.
+
+**Developer experience**
+
+* "Information Priority" guidance moved to a shared rule inherited by every skill.
+
+## Full changelog
+
+### Added
+
+* `infrahub-collecting-diagnostics` skill ([#54](https://github.com/opsmill/infrahub-skills/pull/54)).
+* `CoreFileObject` schema and audit rules ([#55](https://github.com/opsmill/infrahub-skills/pull/55)).
+
+### Changed
+
+* Branch-default across object loads, MCP CRUD, generators, and the SDK ([#56](https://github.com/opsmill/infrahub-skills/pull/56)).
+* "Information Priority" moved to a shared rule ([#57](https://github.com/opsmill/infrahub-skills/pull/57)).
+
+### Fixed
+
+* Integration-layer fixes from a live build ([#49](https://github.com/opsmill/infrahub-skills/pull/49), [#53](https://github.com/opsmill/infrahub-skills/pull/53)).
+* Owner and source metadata semantics corrected ([#27](https://github.com/opsmill/infrahub-skills/pull/27)).
+* Testing-framework documentation added to the check and transform skills ([#18](https://github.com/opsmill/infrahub-skills/pull/18)).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data
+* infrahub-reporting-issues
+* infrahub-collecting-diagnostics

--- a/docs/docs/release-notes/release-1_2_7.mdx
+++ b/docs/docs/release-notes/release-1_2_7.mdx
@@ -1,6 +1,7 @@
 ---
 title: Release 1.2.7
 sidebar_position: 1
+description: Build generators that reuse query results instead of requesting each related object separately.
 ---
 
 <table>
@@ -8,6 +9,10 @@ sidebar_position: 1
     <tr>
       <th>Release Number</th>
       <td>1.2.7</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Improvement</td>
     </tr>
     <tr>
       <th>Release Date</th>
@@ -20,6 +25,33 @@ sidebar_position: 1
   </tbody>
 </table>
 
+## Release summary
+
+When you build a generator that works through the results of a query, you can read each related object from the response it already returned instead of sending a separate request for each one. For generators that handle many objects, that means far fewer requests.
+
+### Build generators that reuse query results instead of requesting each object
+
+Build a generator with the managing-generators skill so that, when its query already returns the related objects it needs, the generated code builds them from that response instead of fetching each one again.
+
+* Create related objects from the data already in the query response with `from_graphql`, instead of calling `client.get` once per object.
+* Follow the query-coverage requirement so the response carries everything those objects need: `__typename`, `id`, and every attribute the generator changes.
+* Use the before/after example in [managing-generators](../skills-reference/managing-generators.mdx) to refactor an existing generator.
+
+## Full changelog
+
 ### Added
 
-- A `from_graphql` hydration rule for [managing-generators](../skills-reference/managing-generators.mdx). When a generator's `generate()` loops over query-response edges and re-fetches each peer with `client.get`, it can hydrate `InfrahubNode` objects directly from the GraphQL response instead — collapsing `O(N+1)` round trips to `O(1)`. The rule covers the decision tree, the query-coverage contract (`__typename`, `id`, and every mutated attribute), and a worked before/after refactor.
+* `from_graphql` rule for managing-generators: build related objects from the query response instead of requesting them again ([#58](https://github.com/opsmill/infrahub-skills/pull/58)).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data
+* infrahub-reporting-issues
+* infrahub-collecting-diagnostics

--- a/docs/docs/release-notes/release-1_2_7.mdx
+++ b/docs/docs/release-notes/release-1_2_7.mdx
@@ -1,0 +1,25 @@
+---
+title: Release 1.2.7
+sidebar_position: 1
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.7</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>June 16th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.7](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.7)</td>
+    </tr>
+  </tbody>
+</table>
+
+### Added
+
+- A `from_graphql` hydration rule for [managing-generators](../skills-reference/managing-generators.mdx). When a generator's `generate()` loops over query-response edges and re-fetches each peer with `client.get`, it can hydrate `InfrahubNode` objects directly from the GraphQL response instead — collapsing `O(N+1)` round trips to `O(1)`. The rule covers the decision tree, the query-coverage contract (`__typename`, `id`, and every mutated attribute), and a worked before/after refactor.

--- a/docs/docs/release-notes/release-1_2_7.mdx
+++ b/docs/docs/release-notes/release-1_2_7.mdx
@@ -27,7 +27,7 @@ description: Build generators that reuse query results instead of requesting eac
 
 ## Release summary
 
-When you build a generator that works through the results of a query, you can read each related object from the response it already returned instead of sending a separate request for each one. For generators that handle many objects, that means far fewer requests.
+When you build a generator that works through the results of a query, you can now read each related object from the response it already returned instead of sending a separate request for each one. For generators that handle many objects, that means far fewer requests.
 
 ### Build generators that reuse query results instead of requesting each object
 


### PR DESCRIPTION
## Summary
Back-fills curated, user-facing release notes for every release since 0.0.1, so users and evaluators can understand what each version delivered and *why it matters* — not just a raw commit list. Mirrors the format used in the `infrahub` and `infrahub-mcp` docs.

## Key Changes
- New **Release Notes** section in the docs site covering **v0.0.1 → v1.2.7** (9 releases), wired into the autogenerated sidebar with a generated index (newest first).
- Feature releases (initial launch, `reporting-issues`, `collecting-diagnostics`) frame each highlight as **the problem → what it enables → when you need it**.
- Patch releases use terse Added / Changed / Fixed sections.
- Metadata table + GitHub tag link per release.

## Related Context
Content sourced from the GitHub release bodies, the merged PRs behind each release (#41, #44, #45, #47, #49, #53, #54, #55, #56, #58), and the inter-tag diffs.

Note: `v1.2.0` is documented as a pure version realignment of `0.0.1` (the diff is version strings + lockfile only). `v1.2.7` is still a Draft release, so its tag link resolves once published.

## Documentation Updates
- `docs/docs/release-notes/_category_.json` — new sidebar category + generated index
- `docs/docs/release-notes/release-0_0_1.mdx` … `release-1_2_7.mdx` (9 new pages)

## Test Plan
- `cd docs && npm run build` — passes; all 9 pages + the generated index render under `onBrokenLinks: 'throw'` with no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)