### PR TITLE
fix(skills): update analyzing-data MCP tool refs to v1.1.7

### DIFF
--- a/skills/infrahub-analyzing-data/SKILL.md
+++ b/skills/infrahub-analyzing-data/SKILL.md
@@ -107,22 +107,38 @@ The typical workflow:
 
 ## MCP Server Basics
 
-When the Infrahub MCP server is connected, Claude
-can call tools such as:
+When the Infrahub MCP server (v1.1.7) is connected,
+Claude can call these tools.
 
-- **`mcp__infrahub__infrahub_query`** — Execute a
-  GraphQL query (primary tool)
-- **`mcp__infrahub__infrahub_list_schema`** — List
-  available node kinds
-- **`mcp__infrahub__infrahub_get`** — Retrieve a
-  specific object by ID or filters
-- **`mcp__infrahub__infrahub_create`** — Create an
-  object (remediation, on a branch)
-- **`mcp__infrahub__infrahub_update`** — Update an
-  object (remediation, on a branch)
+**Read:**
+
+- **`mcp__infrahub__get_nodes`** — List nodes of a
+  kind with filtering/pagination (preferred typed
+  read)
+- **`mcp__infrahub__search_nodes`** — Find nodes of
+  a kind by partial substring
+- **`mcp__infrahub__get_schema`** — Discover schema
+  kinds and their filters
+- **`mcp__infrahub__query_graphql`** — Execute a
+  read-only GraphQL query
+- **`mcp__infrahub__get_session_info`** — Report the
+  active session branch and instance address
+
+**Write** (branch-isolated — land on an auto-created
+`mcp/session-*` branch, never the default branch):
+
+- **`mcp__infrahub__node_upsert`** — Create or update
+  an object
+- **`mcp__infrahub__node_delete`** — Delete an object
+- **`mcp__infrahub__mutate_graphql`** — Run a GraphQL
+  mutation for complex writes
+- **`mcp__infrahub__propose_changes`** — Open a
+  Proposed Change for human review
+- **`mcp__infrahub__reset_session_branch`** — Reset or
+  switch the active session branch
 
 Full per-tool signatures (parameters, examples,
-response shapes) are in
+response shapes) and the branch model are in
 [rules/mcp-tools.md](./rules/mcp-tools.md) — read
 that before invoking any of these.
 
@@ -165,7 +181,8 @@ query MaintenanceDevices {
      (or equivalent in your schema)
 
 3. Query current state
-   → mcp__infrahub__infrahub_query — one query
+   → mcp__infrahub__get_nodes per kind (typed), or
+     mcp__infrahub__query_graphql — one query
      per node type, or combined
 
 4. Correlate the data

--- a/skills/infrahub-analyzing-data/examples.md
+++ b/skills/infrahub-analyzing-data/examples.md
@@ -396,8 +396,8 @@ query TopologyDesigns {
 ### Step 2 — Query realized devices
 
 ```graphql
-query RealizedDevices($topology: String!) {
-  DcimDevice(topology__name__value: $topology) {
+query RealizedDevices {
+  DcimDevice(topology__name__value: "topology-par01-core") {
     edges {
       node {
         id
@@ -477,9 +477,9 @@ query ActiveMaintenanceWindows {
 ### Step 2 — Query services hosted on those devices
 
 ```graphql
-query DeviceServices($device: String!) {
+query DeviceServices {
   ServiceInstance(
-    device__name__value: $device
+    device__name__value: "par01-spine-01"
   ) {
     edges {
       node {
@@ -500,7 +500,10 @@ query DeviceServices($device: String!) {
 }
 ```
 
-Run this query for each device found in Step 1.
+Run this query once per device found in Step 1,
+inlining each device name into the filter —
+`query_graphql` takes no variables, so substitute the
+value into the query string each time.
 
 ### Step 3 — Report
 
@@ -550,8 +553,8 @@ everything that depends on it.
 ### Step 1 — Query the prefix and its consumers
 
 ```graphql
-query PrefixImpact($prefix: String!) {
-  IpamPrefix(prefix__value: $prefix) {
+query PrefixImpact {
+  IpamPrefix(prefix__value: "10.0.1.0/24") {
     edges {
       node {
         id
@@ -663,6 +666,7 @@ See detailed findings above for remediation steps.
 | Scenario | MCP Tool | Key Arguments |
 | -------- | -------- | ------------- |
 | List objects of a kind (typed) | `mcp__infrahub__get_nodes` | `kind`, `filters`, `include_attributes` |
+| Fetch one object by ID / HFID | `mcp__infrahub__get_nodes` | `kind`, `filters: {ids}` or `{hfid}` |
 | Substring search across attributes | `mcp__infrahub__search_nodes` | `kind`, `query` |
 | Raw read-only query | `mcp__infrahub__query_graphql` | `query` (GraphQL string) |
 | Discover schema kinds/filters | `mcp__infrahub__get_schema` | `kind` (optional) |

--- a/skills/infrahub-analyzing-data/examples.md
+++ b/skills/infrahub-analyzing-data/examples.md
@@ -45,8 +45,9 @@ query DeviceNamingCompliance {
 }
 ```
 
-Use `mcp__infrahub__infrahub_query` with the
-above query.
+Use `mcp__infrahub__query_graphql` with the above
+query, or `mcp__infrahub__get_nodes` with
+`kind: "DcimDevice"` for a typed read.
 
 ### Step 2 — Correlate against policy
 
@@ -81,7 +82,8 @@ Non-compliant devices:
     — missing sequence number
 
 Remediation: Rename via Infrahub UI or use
-mcp__infrahub__infrahub_update
+mcp__infrahub__node_upsert (lands on a session
+branch; submit with propose_changes)
 ```
 
 ---
@@ -631,7 +633,8 @@ Run a full analysis for site PAR01. Check:
 
 Claude will:
 
-1. Run `mcp__infrahub__infrahub_query` once per
+1. Run `mcp__infrahub__get_nodes` (or
+   `mcp__infrahub__query_graphql`) once per
    area (or combine into fewer queries)
 2. Evaluate each check independently
 3. Produce a consolidated summary
@@ -659,8 +662,17 @@ See detailed findings above for remediation steps.
 
 | Scenario | MCP Tool | Key Arguments |
 | -------- | -------- | ------------- |
-| Query objects | `mcp__infrahub__infrahub_query` | `query` (GraphQL string) |
-| List schema kinds | `mcp__infrahub__infrahub_list_schema` | none |
-| Get one object | `mcp__infrahub__infrahub_get` | `kind`, `id` or filters |
-| Update for remediation | `mcp__infrahub__infrahub_update` | `kind`, `id`, `data` |
-| Create missing object | `mcp__infrahub__infrahub_create` | `kind`, `data` |
+| List objects of a kind (typed) | `mcp__infrahub__get_nodes` | `kind`, `filters`, `include_attributes` |
+| Substring search across attributes | `mcp__infrahub__search_nodes` | `kind`, `query` |
+| Raw read-only query | `mcp__infrahub__query_graphql` | `query` (GraphQL string) |
+| Discover schema kinds/filters | `mcp__infrahub__get_schema` | `kind` (optional) |
+| Check the active session branch | `mcp__infrahub__get_session_info` | none |
+| Create or update for remediation | `mcp__infrahub__node_upsert` | `kind`, `data`, `id` or `hfid` |
+| Delete an object | `mcp__infrahub__node_delete` | `kind`, `id` or `hfid` |
+| Complex write (relationships/bulk) | `mcp__infrahub__mutate_graphql` | `query` (GraphQL mutation) |
+| Submit writes for human review | `mcp__infrahub__propose_changes` | `title`, `description` |
+
+Writes land on an auto-created `mcp/session-*`
+branch and reach the default branch only after
+`propose_changes` opens a Proposed Change that a
+human merges.

--- a/skills/infrahub-analyzing-data/rules/mcp-tools.md
+++ b/skills/infrahub-analyzing-data/rules/mcp-tools.md
@@ -18,10 +18,7 @@ The reworked server (v1.1.7) splits its surface into
 **read** tools (typed queries plus raw GraphQL) and
 **write** tools (typed upsert/delete, raw mutations,
 and proposed-change submission). Writes are
-**branch-isolated** by design: they land on an
-auto-created session branch, never the default
-branch, and reach the default branch only through a
-Proposed Change that a human reviews and merges.
+**branch-isolated** — see [Branch Model](#branch-model).
 
 ### Why it matters
 
@@ -127,6 +124,27 @@ several filters), use `get_nodes` with an explicit
 
 ---
 
+#### Fetching a single object by ID or HFID
+
+There is no dedicated single-object tool (the old
+`infrahub_get` is gone). Filter `get_nodes` by the
+object's `ids` / `hfid`, or query by ID with
+`query_graphql`:
+
+```text
+mcp__infrahub__get_nodes({
+  "kind": "DcimDevice",
+  "filters": { "ids": ["17f3a..."] },
+  "include_attributes": true
+})
+```
+
+Infrahub exposes `ids` and `hfid` as node filters on
+every kind; confirm the exact keys for a kind via
+`infrahub://schema/{kind}` (or `get_schema(kind="...")`).
+
+---
+
 #### `mcp__infrahub__get_schema`
 
 Discover available schema kinds — call this first
@@ -164,18 +182,9 @@ Arguments:
     — branch to read (default: the default branch)
 ```
 
-**Correct usage:**
-
-```text
-mcp__infrahub__query_graphql({
-  "query": "query { DcimDevice {
-    edges { node { id name { value } } }
-  } }"
-})
-```
-
 This tool takes no `variables` argument — inline
-concrete values into the query string.
+concrete values into the query string. See
+[examples.md](../examples.md) for full query bodies.
 
 ---
 
@@ -197,12 +206,11 @@ Arguments: none
 
 ### Write Tools
 
-Writes never touch the default branch. The first
-write of a session auto-creates a branch named
-`mcp/session-YYYYMMDD-<hex>`, and every subsequent
-write in the session lands there. Use
-`get_session_info` to see the active branch, and
-`propose_changes` to open it for human review.
+Writes never touch the default branch — they land on
+an auto-created session branch (see [Branch
+Model](#branch-model)). Check the active branch with
+`get_session_info`; open it for review with
+`propose_changes`.
 
 #### `mcp__infrahub__node_upsert`
 
@@ -285,22 +293,19 @@ default branch.
 #### `mcp__infrahub__reset_session_branch`
 
 Reset or switch the active session branch. With no
-`branch`, clears the cached session branch so the
-next write auto-creates a fresh one (use after your
-work has merged and you want a new change set). With
-a `branch`, points the session at that named branch
-(created if the name matches the configured branch
-pattern; the default branch and merged/read-only
-branches are rejected).
+`branch`, clears the cached branch so the next write
+starts a fresh session (use after your work has
+merged). With a `branch`, points the session at that
+named branch — the default branch and merged/read-only
+branches are rejected.
 
 ```text
 Arguments:
   branch (string, optional)
 ```
 
-A merged or deleted session branch is recovered
-automatically on the next write — this tool is the
-explicit override on top of that.
+A merged or deleted session branch is also recovered
+automatically on the next write.
 
 ---
 

--- a/skills/infrahub-analyzing-data/rules/mcp-tools.md
+++ b/skills/infrahub-analyzing-data/rules/mcp-tools.md
@@ -1,7 +1,7 @@
 ---
 title: Infrahub MCP Server Tool Reference
 impact: CRITICAL
-tags: mcp, tools, query, infrahub
+tags: mcp, tools, query, infrahub, branch, proposed-change
 ---
 
 ## Infrahub MCP Server Tool Reference
@@ -10,9 +10,18 @@ Impact: CRITICAL
 
 The Infrahub MCP server exposes a set of tools that
 allow Claude to interact with a live Infrahub
-instance directly. Compliance workflows depend on
-calling these tools correctly to fetch, evaluate,
-and optionally update data.
+instance directly. Analysis and remediation
+workflows depend on calling these tools correctly to
+fetch, evaluate, and — when asked — change data.
+
+The reworked server (v1.1.7) splits its surface into
+**read** tools (typed queries plus raw GraphQL) and
+**write** tools (typed upsert/delete, raw mutations,
+and proposed-change submission). Writes are
+**branch-isolated** by design: they land on an
+auto-created session branch, never the default
+branch, and reach the default branch only through a
+Proposed Change that a human reviews and merges.
 
 ### Why it matters
 
@@ -21,160 +30,318 @@ malformed GraphQL query comes back as "query
 failed" with a partial reason — the difference
 between an answer and a stack trace is the exact
 shape of the kind name, the `edges`/`node` envelope,
-and the attribute filter syntax. Schema introspection
-via `mcp__infrahub__infrahub_list_schema` is the
-cheap first step; reaching for `infrahub_query`
-without it leads to round trips that fail on a typo
-the introspection call would have surfaced. The same
-care applies to writes — `infrahub_create` and
-`infrahub_update` issued against the default branch skip
-the proposed-change review loop entirely, which is the
-single guard against accidental data drift from a
-remediation script.
+and the attribute filter syntax. Schema discovery
+via `get_schema` (or the `infrahub://schema`
+resource) is the cheap first step; reaching for
+`query_graphql` without it leads to round trips that
+fail on a typo the introspection call would have
+surfaced.
+
+For typed reads, prefer `get_nodes` / `search_nodes`
+over `query_graphql` — they return token-cheap
+display labels by default and validate the kind and
+filters against the schema. Reach for raw GraphQL
+only when you need relationship traversal,
+aggregation, or fields the typed tools don't expose.
+
+Writes are safe by construction: `node_upsert`,
+`node_delete`, and `mutate_graphql` all land on an
+auto-created session branch
+(`mcp/session-YYYYMMDD-<hex>`), never the default
+branch. Nothing you write is visible on the source
+of truth until you call `propose_changes` and a
+human approves the merge — the reworked server
+enforces the review loop the old
+`create`/`update`-on-`main` path could bypass.
 
 ---
 
-### Available Tools
+### Read Tools
 
-#### `mcp__infrahub__infrahub_query`
+#### `mcp__infrahub__get_nodes`
 
-Execute a raw GraphQL query against Infrahub. This
-is the primary tool for compliance data retrieval.
+List nodes of a specific kind — the default read
+path for typed queries. Prefer this over
+`query_graphql` when you just need objects of one
+kind.
+
+```text
+Arguments:
+  kind (string, required)
+    — node kind (e.g., "DcimDevice")
+  filters (object, optional)
+    — filter map; attribute filters use
+      `<attr>__value` (e.g. {"name__value": "atl1"}),
+      relationship filters chain via
+      `<rel>__<attr>__value`
+      (e.g. {"site__name__value": "atl1"})
+  include_attributes (boolean, optional)
+    — return full attribute dicts instead of
+      display labels
+  partial_match (boolean, optional)
+    — substring instead of exact match
+  limit / offset (integer, optional)
+    — page large result sets; the response
+      includes `total_count` and `has_more`
+  branch (string, optional)
+    — read from a branch (default: the default branch)
+```
+
+**Correct usage:**
+
+```text
+mcp__infrahub__get_nodes({
+  "kind": "DcimDevice",
+  "filters": { "role__value": "spine" },
+  "include_attributes": true
+})
+```
+
+Discover valid kinds via the `infrahub://schema`
+resource or `get_schema`; discover valid filter keys
+for a kind via `infrahub://schema/{kind}` or
+`get_schema(kind="...")`.
+
+---
+
+#### `mcp__infrahub__search_nodes`
+
+Find nodes of a kind by partial substring across
+**all** attributes — use when you only know part of
+a value. Works on concrete kinds (e.g.
+`LocationSite`) and generic/abstract kinds (e.g.
+`CoreNode`).
+
+```text
+Arguments:
+  kind  (string, required)
+  query (string, required)
+    — substring to match
+  limit (integer, optional)
+  branch (string, optional)
+```
+
+For a filter on one specific attribute (or combining
+several filters), use `get_nodes` with an explicit
+`filters` dict instead.
+
+---
+
+#### `mcp__infrahub__get_schema`
+
+Discover available schema kinds — call this first
+when you don't know what kinds or filters exist.
+Without a `kind`, returns the catalog of all kinds.
+With a `kind`, returns its attributes, relationships,
+and the full set of filter keys `get_nodes` accepts.
+
+```text
+Arguments:
+  kind   (string, optional)
+  branch (string, optional)
+```
+
+Prefer the `infrahub://schema` resource if your
+client supports MCP resources; this tool returns the
+same data for clients that don't.
+
+---
+
+#### `mcp__infrahub__query_graphql`
+
+Execute a **read-only** GraphQL query. Mutations are
+rejected at the AST level — use `mutate_graphql` for
+writes. For simple attribute reads prefer
+`get_nodes` / `search_nodes`; use GraphQL when you
+need relationship traversal, aggregation, or fields
+the typed tools don't expose.
 
 ```text
 Arguments:
   query  (string, required)
     — GraphQL query string
   branch (string, optional)
-    — Branch name (default: the default branch)
-  variables (object, optional)
-    — GraphQL variables for
-      parameterized queries
+    — branch to read (default: the default branch)
 ```
 
 **Correct usage:**
 
 ```text
-mcp__infrahub__infrahub_query({
+mcp__infrahub__query_graphql({
   "query": "query { DcimDevice {
     edges { node { id name { value } } }
   } }"
 })
 ```
 
-**With variables:**
-
-```text
-mcp__infrahub__infrahub_query({
-  "query": "query DevicesBySite(
-    $site: String!
-  ) { DcimDevice(
-    site__name__value: $site
-  ) { edges { node {
-    id name { value }
-  } } } }",
-  "variables": { "site": "PAR01" }
-})
-```
+This tool takes no `variables` argument — inline
+concrete values into the query string.
 
 ---
 
-#### `mcp__infrahub__infrahub_list_schema`
+#### `mcp__infrahub__get_session_info`
 
-List all available schema node kinds in the
-Infrahub instance. Use this when you don't know
-the exact kind name for a node type.
+Return the current MCP session state — call before
+writes to know which branch they target. Reports the
+active session branch (or `null` if no write has
+happened yet) and the Infrahub address. A session
+branch is lazily auto-created on the first write
+(`node_upsert` / `node_delete` / `mutate_graphql`)
+and named `mcp/session-YYYYMMDD-<hex>`.
 
 ```text
 Arguments: none
 ```
 
-Returns a list of kind names (e.g., `DcimDevice`,
-`IpamPrefix`, `NetworkBgpSession`).
-
 ---
 
-#### `mcp__infrahub__infrahub_get`
+### Write Tools
 
-Retrieve a single object by ID or
-human_friendly_id. Useful for fetching the full
-detail of a specific violation.
+Writes never touch the default branch. The first
+write of a session auto-creates a branch named
+`mcp/session-YYYYMMDD-<hex>`, and every subsequent
+write in the session lands there. Use
+`get_session_info` to see the active branch, and
+`propose_changes` to open it for human review.
+
+#### `mcp__infrahub__node_upsert`
+
+Create or update a node on the active session
+branch. Replaces the old `infrahub_create` /
+`infrahub_update` pair.
 
 ```text
 Arguments:
-  kind  (string, required)
-    — Node kind (e.g., "DcimDevice")
-  id    (string, optional)
-    — Infrahub object ID
-  filters (object, optional)
-    — Attribute filters
+  kind (string, required)
+  data (object, required)
+    — scalar attribute values only
+  id   (string, optional)
+    — supply to update by ID
+  hfid (list of strings, optional)
+    — supply to update by human-friendly ID
+```
+
+- **Create:** omit both `id` and `hfid`.
+- **Update:** supply either `id` or `hfid`.
+
+Only scalar attribute fields go in `data`. To set
+relationship fields, use `mutate_graphql`.
+
+---
+
+#### `mcp__infrahub__node_delete`
+
+Delete a node on the active session branch. Replaces
+the old `infrahub_delete`.
+
+```text
+Arguments:
+  kind (string, required)
+  id   (string, optional)
+  hfid (list of strings, optional)
 ```
 
 ---
 
-#### `mcp__infrahub__infrahub_create`
+#### `mcp__infrahub__mutate_graphql`
 
-Create a new object in Infrahub. Use for
-remediation workflows (e.g., creating a missing
-loopback interface).
+Execute a GraphQL mutation on the active session
+branch — for complex writes the typed tools can't
+express (relationship edits, bulk operations). There
+is no branch override; the mutation always runs on
+the session branch. Branch- and schema-management
+mutations are rejected.
 
 ```text
 Arguments:
-  kind   (string, required)
-    — Node kind
-  data   (object, required)
-    — Attribute values
+  query (string, required)
+    — GraphQL mutation string
+```
+
+---
+
+#### `mcp__infrahub__propose_changes`
+
+Open a Proposed Change (like a pull request) from
+the active session branch to the default branch, so
+a human can review, approve, and merge the session's
+changes. The session branch stays active after
+calling — you can keep making changes.
+
+```text
+Arguments:
+  title (string, required)
+  description (string, optional)
+  destination_branch (string, optional)
+    — defaults to the instance default branch
+```
+
+Call this once your writes are ready. Until a human
+merges it, nothing you wrote is visible on the
+default branch.
+
+---
+
+#### `mcp__infrahub__reset_session_branch`
+
+Reset or switch the active session branch. With no
+`branch`, clears the cached session branch so the
+next write auto-creates a fresh one (use after your
+work has merged and you want a new change set). With
+a `branch`, points the session at that named branch
+(created if the name matches the configured branch
+pattern; the default branch and merged/read-only
+branches are rejected).
+
+```text
+Arguments:
   branch (string, optional)
-    — Branch (default: the default branch)
 ```
 
-Create on a dedicated **branch**, not the default
-branch — see [Branch Considerations](#branch-considerations)
-below for why and how.
+A merged or deleted session branch is recovered
+automatically on the next write — this tool is the
+explicit override on top of that.
 
 ---
 
-#### `mcp__infrahub__infrahub_update`
+### Resources
 
-Update an existing object in Infrahub. Use for
-remediation (e.g., correcting a wrong VLAN
-assignment).
+For clients that support MCP resources, the server
+also exposes:
 
-```text
-Arguments:
-  kind   (string, required)
-    — Node kind
-  id     (string, required)
-    — Object ID
-  data   (object, required)
-    — Fields to update
-  branch (string, optional)
-    — Branch (default: the default branch)
-```
+| Resource | URI | Use |
+| -------- | --- | --- |
+| Schema catalog | `infrahub://schema` | All kinds → labels; discover kinds before `get_nodes` / `node_upsert` |
+| Schema kind detail | `infrahub://schema/{kind}` | One kind's attributes, relationships, and valid `get_nodes` filter keys |
+| GraphQL schema | `infrahub://graphql-schema` | Full GraphQL SDL — reference for complex `query_graphql` / `mutate_graphql` |
+| Branches | `infrahub://branches` | Branches present, including the active session branch |
+
+If your client does not support resources,
+`get_schema` returns the same schema data.
 
 ---
 
 ### Tool Invocation Patterns
 
-#### Pattern 1 — Single query compliance
+#### Pattern 1 — Typed single-kind read (preferred)
 
 ```text
-1. Call mcp__infrahub__infrahub_query
-   with your GraphQL
-2. Parse response:
-   data.<NodeKind>.edges[].node
+1. Call get_nodes with kind + filters
+   (or search_nodes for a substring match)
+2. Read display labels, or set
+   include_attributes=true for full dicts
 3. Evaluate each node against the policy
 4. Report violations
 ```
 
-#### Pattern 2 — Multi-query correlation
+#### Pattern 2 — GraphQL correlation across kinds
 
 ```text
-1. Call mcp__infrahub__infrahub_query
-   for node type A (policy source)
-2. Call mcp__infrahub__infrahub_query
-   for node type B (current state)
-3. Build lookup set from A
+1. Call query_graphql for node type A
+   (policy source)
+2. Call query_graphql for node type B
+   (current state)
+3. Build a lookup set from A
 4. Check each item in B against the set
 5. Report gaps
 ```
@@ -182,19 +349,34 @@ Arguments:
 #### Pattern 3 — Schema discovery first
 
 ```text
-1. Call mcp__infrahub__infrahub_list_schema
+1. Read infrahub://schema (or call get_schema)
    to find the right kind name
-2. Construct GraphQL query using the
-   correct kind
-3. Proceed with compliance query
+2. Read infrahub://schema/{kind}
+   (or get_schema(kind="...")) for valid filters
+3. Construct the get_nodes call or GraphQL
+   query with the correct kind + filters
+```
+
+#### Pattern 4 — Remediation write (branch-isolated)
+
+```text
+1. (Optional) get_session_info to see the
+   active branch
+2. node_upsert / node_delete / mutate_graphql
+   — lands on the session branch, never
+     the default branch
+3. propose_changes(title=..., description=...)
+   to open a Proposed Change
+4. A human reviews and merges; nothing reaches
+   the default branch until then
 ```
 
 ---
 
 ### Response Structure
 
-All query responses follow the Infrahub GraphQL
-convention:
+GraphQL responses from `query_graphql` follow the
+Infrahub GraphQL convention:
 
 ```json
 {
@@ -221,31 +403,51 @@ list of nodes — skipping the `edges` indirection —
 returns nothing and looks like missing data, when
 the data is actually one envelope away.
 
+`get_nodes` returns a simpler shape — display labels
+by default, or full attribute dicts when
+`include_attributes` is true — so you don't parse
+the `edges`/`node` envelope for typed reads.
+
 ---
 
-### Branch Considerations
+### Branch Model
 
-By default all MCP queries run against the default
-branch (`main` by convention). To audit a proposed
-change branch:
+All **reads** (`get_nodes`, `search_nodes`,
+`query_graphql`, `get_schema`) run against the
+default branch (`main` by convention) unless you
+pass a `branch` argument. To audit a proposed-change
+branch, pass its name:
 
 ```text
-mcp__infrahub__infrahub_query({
-  "query": "...",
+mcp__infrahub__get_nodes({
+  "kind": "DcimDevice",
   "branch": "cr-2026-03-change"
 })
 ```
 
-For remediation creates/updates, target a **dedicated
-branch**. Writes to the default branch bypass the
-proposed change review loop entirely, so a buggy
-remediation script lands unreviewed on the source of
-truth — and a wrong bulk remediation on the default
-branch is a per-object cleanup instead of a branch
-discard. Default to a branch for any MCP
-`infrahub_create` / `infrahub_update` /
-`infrahub_delete`; see the shared rule
+All **writes** (`node_upsert`, `node_delete`,
+`mutate_graphql`) are branch-isolated and take **no**
+branch argument. The first write of a session
+auto-creates a branch named
+`mcp/session-YYYYMMDD-<hex>`, and every write lands
+there — never on the default branch. Your changes
+become visible on the source of truth only after you
+call `propose_changes` and a human approves the
+merge. This is the review loop the old
+`infrahub_create` / `infrahub_update`-on-`main` path
+could bypass; the reworked server enforces it, so
+there is no way to write straight to the default
+branch.
+
+Use `get_session_info` to confirm which branch your
+writes are on, and `reset_session_branch` to start a
+fresh change set or take control of a specific
+branch. The branch-first principle across all
+Infrahub write paths (MCP, `infrahubctl`, the Python
+SDK) is covered in the shared rule
 [../../infrahub-common/rules/workflow-branch-for-crud.md](../../infrahub-common/rules/workflow-branch-for-crud.md).
 
 Reference:
 [Infrahub MCP Server Docs](https://docs.infrahub.app/mcp)
+</content>
+</invoke>

--- a/skills/infrahub-analyzing-data/rules/query-patterns.md
+++ b/skills/infrahub-analyzing-data/rules/query-patterns.md
@@ -313,7 +313,8 @@ dataset sizes). If a query returns an unexpectedly
 empty `edges` list:
 
 1. Verify the kind name is correct using
-   `mcp__infrahub__infrahub_list_schema`
+   `mcp__infrahub__get_schema` (or the
+   `infrahub://schema` resource)
 2. Check that the filter values match exactly
    (case-sensitive for `value` fields)
 3. Try without filters to confirm data exists

--- a/skills/infrahub-analyzing-data/rules/reporting-output.md
+++ b/skills/infrahub-analyzing-data/rules/reporting-output.md
@@ -87,12 +87,14 @@ Remediation
 ───────────
 • Rename affected devices via
   Infrahub UI or:
-    mcp__infrahub__infrahub_update(
+    mcp__infrahub__node_upsert(
       kind="DcimDevice",
       id="<id>",
       data={"name": "<correct-name>"}
     )
-  Note: always use a dedicated branch, not the default branch.
+  Note: writes land on an auto-created
+  session branch; call propose_changes to
+  open them for review, not the default branch.
 • Consider adding an InfrahubCheck to
   enforce naming on future proposed
   changes.
@@ -181,9 +183,9 @@ type:
 
 | Violation Type | Remediation Hint |
 | -------------- | ---------------- |
-| Missing required attribute | Set value via UI or `mcp__infrahub__infrahub_update` |
-| Wrong attribute value | Correct value via UI or `mcp__infrahub__infrahub_update` |
-| Missing related object | Create via `mcp__infrahub__infrahub_create` on a branch |
+| Missing required attribute | Set value via UI or `mcp__infrahub__node_upsert` |
+| Wrong attribute value | Correct value via UI or `mcp__infrahub__node_upsert` |
+| Missing related object | Create via `mcp__infrahub__node_upsert`, then `propose_changes` |
 | Naming convention | Rename via UI or update |
 | Structural gap (design vs reality) | Run the generator to reconcile, or create manually |
 | Recurring pattern | Suggest creating an `InfrahubCheck` to enforce on future changes |

--- a/skills/infrahub-common/rules/workflow-branch-for-crud.md
+++ b/skills/infrahub-common/rules/workflow-branch-for-crud.md
@@ -9,15 +9,23 @@ tags: branch, default-branch, crud, object-load, proposed-change, rollback, mcp
 Impact: CRITICAL
 
 When creating, updating, or deleting data in Infrahub —
-whether via `infrahubctl object load`, the MCP
-`infrahub_create` / `infrahub_update` / `infrahub_delete`
-tools, `infrahubctl generator run`, or the Python SDK —
-default to working on a dedicated branch. Reach for the
-**default branch** (the branch operations target when no
-branch is given — `main` by convention, but it can be
-renamed per deployment, so confirm with
-`infrahubctl branch list` rather than assuming `main`) only
-on a local, throwaway instance you are willing to discard.
+whether via `infrahubctl object load`, the MCP write tools
+(`node_upsert` / `node_delete` / `mutate_graphql`),
+`infrahubctl generator run`, or the Python SDK — default to
+working on a dedicated branch. Reach for the **default
+branch** (the branch operations target when no branch is
+given — `main` by convention, but it can be renamed per
+deployment, so confirm with `infrahubctl branch list`
+rather than assuming `main`) only on a local, throwaway
+instance you are willing to discard.
+
+The reworked Infrahub MCP server does this for you: its
+writes land on an auto-created `mcp/session-YYYYMMDD-<hex>`
+branch and reach the default branch only through
+`propose_changes` + human review — you never pick the
+branch. The other paths (`infrahubctl`, the Python SDK) do
+**not** isolate writes for you; there you must create and
+target the branch yourself.
 
 ### Why it matters
 


### PR DESCRIPTION
## Summary

The `infrahub-analyzing-data` skill documented the **pre-rework** Infrahub MCP tool names, so it instructed agents to call tools the reworked **v1.1.7** server no longer exposes. This aligns the skill with the current tool surface and its branch-isolated write model, so agents drive a live Infrahub instance with the correct tools instead of failing on unknown tool names.

## Key Changes

- Agents now reference the v1.1.7 **read** tools (`get_nodes`, `search_nodes`, `get_schema`, `query_graphql`, `get_session_info`) and **write** tools (`node_upsert`, `node_delete`, `mutate_graphql`, `propose_changes`, `reset_session_branch`) — replacing `infrahub_query` / `_get` / `_create` / `_update` / `_list_schema`.
- `rules/mcp-tools.md` rewritten to the full 10-tool surface plus the 4 MCP resources (`infrahub://schema`, `infrahub://schema/{kind}`, `infrahub://graphql-schema`, `infrahub://branches`), verified against `opsmill/infrahub-mcp` v1.1.7 `CAPABILITIES.md`.
- Remediation guidance now follows the **branch-isolated write flow**: writes land on an auto-created `mcp/session-YYYYMMDD-<hex>` branch and reach the default branch only via `propose_changes` + human review — replacing the old "writes to `main` bypass review" framing (addresses related #46).
- The shared `infrahub-common/rules/workflow-branch-for-crud.md` rule now notes the MCP server enforces branch isolation automatically, while `infrahubctl` / Python SDK paths still require manual branching.

## Related Context

Closes #65. Related to #46 (branch creation vs `main`) — the reworked server now enforces this via session branches + Proposed Changes.

## Documentation Updates

This skill *is* documentation. A repo-wide grep confirmed no `dev/` docs or other skills referenced the old tool names, so no separate doc updates were needed.

## Test Plan

- `uv run rumdl check .` passes on all 6 changed files.
- Repo-wide grep confirms no actionable pre-rework tool names remain (only intentional "replaces the old …" migration notes in `mcp-tools.md`).
- Tool names, arguments, and semantics cross-checked against `opsmill/infrahub-mcp` v1.1.7 `CAPABILITIES.md` (10 tools, 4 resources).
- No eval graders exist for `infrahub-analyzing-data`, so no "rule = test" work applies.