### PR TITLE
feat(common): concrete llms.txt docs-fallback for uncovered tasks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "infrahub",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "A Claude Code plugin to support developing on top of Infrahub. Includes skills for schemas, objects, checks, generators, transforms, menus, data analysis, repo auditing, and ecosystem issue reporting.",
   "author": {
     "name": "Solution Engineering and Architecture",

--- a/.github/.release-manifest.json
+++ b/.github/.release-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.7",
+  "version": "1.2.8",
   "skills": [
     "infrahub-managing-schemas",
     "infrahub-managing-objects",

--- a/eval.yaml
+++ b/eval.yaml
@@ -1347,6 +1347,37 @@ tasks:
       - name: object-authors-template
         check: a template object is authored under a Template<Kind> with template_name
 
+  # --- Common: documentation fallback --- #
+  - name: docs-fallback-delete-node
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-managing-objects/SKILL.md
+      and follow its workflow and rules.
+
+      Task: How do I delete an object/node in Infrahub after I've already
+      loaded it — for example with infrahubctl or the CLI? I can't find
+      deletion in the object-authoring workflow.
+
+      Save your answer to: output.md
+    graders:
+      - type: deterministic
+        run: python graders/common/check_docs_fallback.py
+        weight: 1.0
+    expected_output: >-
+      A prose answer that recognizes deletion is not covered by the
+      object-authoring skill, consults docs.infrahub.app (the llms.txt
+      index, then the page's .md) for the procedure, cites the page URL,
+      and flags the answer as outside the skill's tested rules.
+    expectations:
+      - Recognizes the task is not covered by the loaded skill's rules
+      - Consults docs.infrahub.app (llms.txt index then the page .md)
+      - Cites the documentation page URL used
+      - Adds a caveat that the point is outside the skill's tested rules
+      - Does not override any skill rule
+    assertions:
+      - name: docs-fallback
+        check: Output cites a docs.infrahub.app page and flags the gap
+
   # --- Issue Reporter --- #
   - name: bug-sanitization
     instruction: |

--- a/evaluations/infrahub-managing-objects.json
+++ b/evaluations/infrahub-managing-objects.json
@@ -53,6 +53,25 @@
           "check": "a template object is authored under a Template<Kind> with template_name"
         }
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "How do I delete an object/node in Infrahub after I've already\nloaded it \u2014 for example with infrahubctl or the CLI? I can't find\ndeletion in the object-authoring workflow.\n\nSave your answer to: output.md",
+      "expected_output": "A prose answer that recognizes deletion is not covered by the object-authoring skill, consults docs.infrahub.app (the llms.txt index, then the page's .md) for the procedure, cites the page URL, and flags the answer as outside the skill's tested rules.",
+      "files": [],
+      "expectations": [
+        "Recognizes the task is not covered by the loaded skill's rules",
+        "Consults docs.infrahub.app (llms.txt index then the page .md)",
+        "Cites the documentation page URL used",
+        "Adds a caveat that the point is outside the skill's tested rules",
+        "Does not override any skill rule"
+      ],
+      "assertions": [
+        {
+          "name": "docs-fallback",
+          "check": "Output cites a docs.infrahub.app page and flags the gap"
+        }
+      ]
     }
   ]
 }

--- a/graders/common/check_docs_fallback.py
+++ b/graders/common/check_docs_fallback.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Grader for the docs-fallback-delete-node eval task.
+
+Asserts that a task not covered by the loaded skill is answered by
+consulting the official docs (cited) and flagged as outside the skill's
+tested rules, rather than silently answered from training.
+
+Usage::
+
+    python check_docs_fallback.py <output_file>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECK_NAMES = ["docs-fallback"]
+
+
+def main() -> None:
+    output_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output.md")
+    print(json.dumps(run_checks(CHECK_NAMES, output_path)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/common/lib.py
+++ b/graders/common/lib.py
@@ -1,0 +1,103 @@
+"""Shared grader library for cross-cutting infrahub-common rules.
+
+Currently covers the documentation-fallback behavior of
+`workflow-information-priority.md`: when a task is not covered by any
+loaded skill, the answer must consult the official docs and say so.
+
+Usage (in a per-task grader script)::
+
+    from pathlib import Path
+    from lib import run_checks
+
+    result = run_checks(["docs-fallback"], Path("output.md"))
+    print(result)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def load_output(path: Path) -> str:
+    """Read the model's output file as text."""
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+# Any of these phrases signals the answer flags the point as outside the
+# skill's tested guidance (a gap) and/or leans on the official docs.
+_CAVEAT_MARKERS = [
+    "not covered",
+    "not part of",
+    "outside",
+    "isn't covered",
+    "is not covered",
+    "verify",
+    "official doc",
+    "docs say",
+    "gap",
+    "not in the skill",
+]
+
+
+def check_docs_fallback(text: str) -> tuple[bool, str]:
+    """A gap-fill answer must cite a docs.infrahub.app page and flag the gap.
+
+    Fails if the answer silently resolves the gap from training with no
+    documentation citation, or cites the docs without flagging that the
+    point is outside the skill's tested rules.
+    """
+    lower = text.lower()
+    cites = "docs.infrahub.app" in lower
+    caveat = any(marker in lower for marker in _CAVEAT_MARKERS)
+    if not cites:
+        return False, "Answer does not cite a docs.infrahub.app page"
+    if not caveat:
+        return False, "Answer cites docs but lacks a gap/verify caveat"
+    return True, "Cites docs.infrahub.app and flags the gap"
+
+
+# ---------------------------------------------------------------------------
+# CHECKS registry
+# ---------------------------------------------------------------------------
+
+CHECKS = {
+    "docs-fallback": check_docs_fallback,
+}
+
+
+def run_checks(check_names: list[str], output_path: Path) -> dict:
+    """Run named checks against the output file and return skillgrade JSON."""
+    text = load_output(output_path)
+
+    entries: list[dict] = []
+    passed_count = 0
+
+    for name in check_names:
+        fn = CHECKS[name]
+        try:
+            ok, msg = fn(text)
+        except Exception as exc:  # pragma: no cover — defensive
+            ok, msg = False, f"Error running check: {exc}"
+        if ok:
+            passed_count += 1
+        entries.append({"name": name, "passed": ok, "message": msg})
+
+    total = len(check_names)
+    score = round(passed_count / total, 4) if total > 0 else 0.0
+    failed = [e["name"] for e in entries if not e["passed"]]
+    if failed:
+        details = f"{passed_count}/{total} checks passed. Failed: {', '.join(failed)}"
+    else:
+        details = f"All {total} checks passed."
+
+    return {"score": score, "details": details, "checks": entries}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output.md")
+    print(json.dumps(run_checks(list(CHECKS.keys()), out), indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infrahub-skills"
-version = "1.2.7"
+version = "1.2.8"
 description = "Claude Code plugin for Infrahub"
 requires-python = ">=3.10"
 

--- a/skills/infrahub-analyzing-data/SKILL.md
+++ b/skills/infrahub-analyzing-data/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
   - Bash
 argument-hint: "[question about infrastructure data]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-analyzing-data/SKILL.md
+++ b/skills/infrahub-analyzing-data/SKILL.md
@@ -206,5 +206,8 @@ query MaintenanceDevices {
   — Automated pipeline checks (for enforcement)
 - **[../infrahub-managing-transforms/SKILL.md](../infrahub-managing-transforms/SKILL.md)**
   — Transforms for scheduled report artifacts
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 - **[rules/](./rules/)** — Individual rules organized
   by category prefix

--- a/skills/infrahub-auditing-repo/SKILL.md
+++ b/skills/infrahub-auditing-repo/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools:
   - Glob
 argument-hint: "[focus-area]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-auditing-repo/SKILL.md
+++ b/skills/infrahub-auditing-repo/SKILL.md
@@ -170,6 +170,9 @@ The auditor checks rules from all skills:
   item properties, hierarchy, icons
 - **[../infrahub-common/](../infrahub-common/)** -- Git integration,
   caching, `.infrahub.yml` reference, GraphQL
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 
 ## Rules and Procedure
 

--- a/skills/infrahub-collecting-diagnostics/SKILL.md
+++ b/skills/infrahub-collecting-diagnostics/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools:
   - Glob
   - Write
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-collecting-diagnostics/SKILL.md
+++ b/skills/infrahub-collecting-diagnostics/SKILL.md
@@ -164,6 +164,9 @@ full index.
   notes. **Read in steps 2-4.**
 - [examples.md](examples.md) — end-to-end walk-throughs
   for common symptom classes.
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 
 ## Anti-patterns
 

--- a/skills/infrahub-common/SKILL.md
+++ b/skills/infrahub-common/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   DO NOT TRIGGER directly — loaded automatically by other Infrahub skills when they need shared references.
 user-invocable: false
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-common/SKILL.md
+++ b/skills/infrahub-common/SKILL.md
@@ -36,5 +36,6 @@ Infrahub skills. It is not meant to be invoked directly.
   - Git integration and deployment patterns
   - Recovery from partial repository syncs
   - Generated file protocol conventions
-  - Information-source priority (skill content before
-    external docs)
+  - Information-source priority (skill content first,
+    with a concrete last-resort procedure for consulting
+    `docs.infrahub.app` on a genuine gap)

--- a/skills/infrahub-common/rules/workflow-information-priority.md
+++ b/skills/infrahub-common/rules/workflow-information-priority.md
@@ -1,64 +1,107 @@
 ---
 title: Information-Source Priority
 impact: MEDIUM
-tags: workflow, references, external-docs, web-search, source-priority
+tags: workflow, references, external-docs, web-search, source-priority, llms-txt, documentation-fallback
 ---
 
 ## Information-Source Priority
 
 Impact: MEDIUM
 
-When answering an Infrahub question that the loaded skills
-already cover (schemas, objects, checks, generators,
-transforms, menus, data analysis, repository audits), read
-the active skill's own rules and reference files before
-reaching for external documentation or a web search.
+When answering an Infrahub question that the loaded skills already cover
+(schemas, objects, checks, generators, transforms, menus, data analysis,
+repository audits), read the active skill's own rules and reference files
+before reaching for external documentation or a web search. When the
+question is genuinely outside what any loaded skill covers, fall back to
+the official documentation using the procedure below — do not guess from
+training.
 
 ### Why it matters
 
-The skill's `rules/`, `reference.md`, `examples.md`, and the
-shared `infrahub-common/` references are curated for the
-Infrahub version this plugin targets and encode gotchas that
-generic sources miss — `Text` over the deprecated `String`,
-singular `display_label`, matched relationship identifiers
-on both peers, full kind references. External docs and model
-training are often a version behind, or silent on these, so
-skipping straight to them produces answers that contradict
-the skill's tested guidance and reintroduce the exact
-mistakes the rules exist to prevent. It also burns turns
-fetching what is already in context.
+The skill's `rules/`, `reference.md`, `examples.md`, and the shared
+`infrahub-common/` references are curated for the Infrahub version this
+plugin targets and encode gotchas that generic sources miss — `Text` over
+the deprecated `String`, singular `display_label`, matched relationship
+identifiers on both peers, full kind references. External docs and model
+training are often a version behind, or silent on these, so skipping
+straight to them produces answers that contradict the skill's tested
+guidance and reintroduce the exact mistakes the rules exist to prevent.
+It also burns turns fetching what is already in context. But when the
+skills are genuinely silent on a real Infrahub question, a guessed answer
+is worse than one grounded in the official docs — so the fallback below
+exists for exactly that case.
 
 ### Priority order
 
-1. **The active skill's own files** — its `rules/`,
-   `reference.md`, `examples.md`, and `validation.md`.
-2. **Shared `infrahub-common/` references** —
-   `graphql-queries.md`, `infrahub-yml-reference.md`,
-   `netbox-vs-infrahub.md`, and the cross-cutting `rules/`.
-3. **Last resort: external Infrahub documentation**
-   (`docs.infrahub.app`) or a web search — only when the
-   answer is genuinely absent above, and say so explicitly
-   so the gap in the skill can be filled later.
+1. **The active skill's own files** — its `rules/`, `reference.md`,
+   `examples.md`, and `validation.md`.
+2. **Shared `infrahub-common/` references** — `graphql-queries.md`,
+   `infrahub-yml-reference.md`, `netbox-vs-infrahub.md`, and the
+   cross-cutting `rules/`.
+3. **Last resort: the official Infrahub documentation**, consulted with
+   the procedure below — only when the answer is genuinely absent from
+   steps 1–2, and say so explicitly so the gap can be filled in a skill
+   later.
+
+### Consulting the documentation on a gap
+
+Applies only when steps 1–2 do not cover the task and it is still an
+Infrahub question (e.g. deleting a node, git-integration semantics).
+
+1. **Find the page.** Use your web-fetch tool (WebFetch in Claude Code;
+   the equivalent in Cursor/Copilot/Windsurf) on
+   `https://docs.infrahub.app/llms.txt` with a *targeted* question —
+   "Which documentation page(s) cover <topic>?" — so only the matching
+   page path(s) come back, not the whole 157 KB index.
+2. **Read the page.** Fetch that page's Markdown twin at
+   `https://docs.infrahub.app<path>.md` (small and clean) and answer
+   from it.
+3. **Cite and caveat.** Cite the page URL and add a short note that the
+   point is outside the skill's tested rules and should be verified, so
+   the gap can later be folded into a skill.
+
+Do not fetch `llms-full.txt` — it is a ~4 MB bulk export that will not
+fit in context. The index-then-page path above is the supported route.
+
+If `llms.txt` or the page cannot be fetched (a network error, or an HTML
+404 shell whose body starts with `<!doctype` or contains `<html>`), say
+so explicitly and give a best-effort answer clearly flagged as
+unverified. Never present training recall as authoritative when the docs
+were unreachable.
 
 ### Examples
 
-Compliant — a question about which attribute type to use is
-answered from the schema skill's `reference.md` and the
-`attribute-defaults-and-types` rule, which specify `Text`
-rather than the deprecated `String`.
+Compliant — a question about which attribute type to use is answered from
+the schema skill's `reference.md` and the `attribute-defaults-and-types`
+rule, which specify `Text` rather than the deprecated `String`.
 
-Non-compliant — the same question is answered from a web
-search that suggests `String`, contradicting the rule and
-shipping a deprecated type.
+Compliant — a question about deleting a node (not covered by any loaded
+skill) is answered by fetching `llms.txt` to locate the data-management
+page, fetching that page's `.md`, and answering with the page cited plus
+a "outside the skill's tested rules — verify" caveat.
+
+Non-compliant — the same attribute-type question is answered from a web
+search that suggests `String`, contradicting the rule and shipping a
+deprecated type.
+
+Non-compliant — a delete-node question is answered straight from training
+with no doc lookup and no caveat, or by dumping `llms-full.txt` into
+context.
 
 ### Common mistakes
 
-- Treating a fetched doc page or training recall as
-  authoritative over a skill rule that addresses the same
-  point. The rule wins — it is version-matched to this plugin.
-- Searching the web for `.infrahub.yml` fields or GraphQL
-  syntax that `infrahub-common/` already lays out.
-- Reaching for external docs without first checking whether
-  the active skill's reference files answer the question.
+- Treating a fetched doc page or training recall as authoritative over a
+  skill rule that addresses the same point. The rule wins — it is
+  version-matched to this plugin.
+- Fetching `llms-full.txt` (or the entire `llms.txt`) into context
+  instead of the targeted index-then-page lookup.
+- Answering a genuine gap silently from training — without consulting the
+  docs, or without flagging that the answer is outside the skill's tested
+  rules.
+- Searching the web for `.infrahub.yml` fields or GraphQL syntax that
+  `infrahub-common/` already lays out.
+- Reaching for external docs without first checking whether the active
+  skill's reference files answer the question.
 
-Reference: [Infrahub Docs](https://docs.infrahub.app)
+Reference: [Infrahub Docs](https://docs.infrahub.app) ·
+[llms.txt index](https://docs.infrahub.app/llms.txt)

--- a/skills/infrahub-importing-data/SKILL.md
+++ b/skills/infrahub-importing-data/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools:
   - Bash
 argument-hint: "[csv-file-or-folder] [more-paths...]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-importing-data/SKILL.md
+++ b/skills/infrahub-importing-data/SKILL.md
@@ -319,3 +319,6 @@ load-bearing — earlier steps gate later ones.
   — detect the project's Python env prefix
   (`uv run` / `poetry run`) for all `infrahubctl`
   invocations
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)

--- a/skills/infrahub-managing-checks/SKILL.md
+++ b/skills/infrahub-managing-checks/SKILL.md
@@ -182,6 +182,9 @@ Follow these steps when creating a check:
 - **[../infrahub-common/rules/](../infrahub-common/rules/)** -- Shared rules
   (git integration, caching gotchas) that apply across all
   skills
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 - **[../infrahub-managing-schemas/SKILL.md](../infrahub-managing-schemas/SKILL.md)**
   -- Schema definitions checks validate against
 - **[rules/](./rules/)** -- Individual rules organized by

--- a/skills/infrahub-managing-checks/SKILL.md
+++ b/skills/infrahub-managing-checks/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools:
   - Grep
 argument-hint: "[check-name] [description...]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-managing-generators/SKILL.md
+++ b/skills/infrahub-managing-generators/SKILL.md
@@ -166,6 +166,9 @@ Follow these steps when creating a generator:
   -- .infrahub.yml project configuration
 - **[../infrahub-common/rules/](../infrahub-common/rules/)** -- Shared rules
   (git integration, caching gotchas)
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 - **[../infrahub-managing-schemas/SKILL.md](../infrahub-managing-schemas/SKILL.md)**
   -- Schema definitions Generators work with
 - **[rules/](./rules/)** -- Individual rules organized by

--- a/skills/infrahub-managing-generators/SKILL.md
+++ b/skills/infrahub-managing-generators/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools:
   - Grep
 argument-hint: "[generator-name] [description...]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-managing-menus/SKILL.md
+++ b/skills/infrahub-managing-menus/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
   - Bash
 argument-hint: "[menu-structure-description]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-managing-menus/SKILL.md
+++ b/skills/infrahub-managing-menus/SKILL.md
@@ -131,6 +131,9 @@ Follow these steps when creating a menu:
 - **[common/rules/](../infrahub-common/rules/)**
   -- Shared rules (git integration, caching gotchas)
   that apply across all skills
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 - **[managing-schemas](../infrahub-managing-schemas/SKILL.md)**
   -- Schema node kinds that menus link to
 - **[rules/](./rules/)**

--- a/skills/infrahub-managing-objects/SKILL.md
+++ b/skills/infrahub-managing-objects/SKILL.md
@@ -157,6 +157,9 @@ Follow these steps when creating object data files:
   control edit access
 - **[../infrahub-common/rules/](../infrahub-common/rules/)** -- Shared rules
   (git integration, caching) across all skills
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 - **[../infrahub-managing-schemas/SKILL.md](../infrahub-managing-schemas/SKILL.md)**
   -- Schema definitions these objects conform to
 - **[rules/](./rules/)** -- Individual rules by category

--- a/skills/infrahub-managing-objects/SKILL.md
+++ b/skills/infrahub-managing-objects/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
   - Bash
 argument-hint: "[kind] [object-details...]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-managing-schemas/SKILL.md
+++ b/skills/infrahub-managing-schemas/SKILL.md
@@ -199,5 +199,8 @@ after data is loaded.
   -- .infrahub.yml project configuration
 - **[../infrahub-common/rules/](../infrahub-common/rules/)** -- Shared rules
   (git integration, caching) across all skills
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 - **[rules/](./rules/)** -- Individual rules by category
   prefix

--- a/skills/infrahub-managing-schemas/SKILL.md
+++ b/skills/infrahub-managing-schemas/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
   - Bash
 argument-hint: "[namespace] [node-names...]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-managing-transforms/SKILL.md
+++ b/skills/infrahub-managing-transforms/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools:
   - Grep
 argument-hint: "[transform-name] [format]"
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-managing-transforms/SKILL.md
+++ b/skills/infrahub-managing-transforms/SKILL.md
@@ -160,6 +160,9 @@ Follow these steps when creating a transform:
   -- .infrahub.yml project configuration
 - **[../infrahub-common/rules/](../infrahub-common/rules/)** -- Shared rules
   (git integration, caching) across all skills
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 - **[../infrahub-managing-schemas/SKILL.md](../infrahub-managing-schemas/SKILL.md)**
   -- Schema definitions transforms work with
 - **[rules/](./rules/)** -- Individual rules by category

--- a/skills/infrahub-reporting-issues/SKILL.md
+++ b/skills/infrahub-reporting-issues/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools:
   - Glob
   - WebFetch
 metadata:
-  version: 1.2.7
+  version: 1.2.8
   author: OpsMill
 ---
 

--- a/skills/infrahub-reporting-issues/SKILL.md
+++ b/skills/infrahub-reporting-issues/SKILL.md
@@ -285,6 +285,9 @@ index.
 - [rules/environment-info-sanitization.md](rules/environment-info-sanitization.md)
   — what to redact before submitting. Security-critical;
   read this for every bug report.
+- **[../infrahub-common/rules/workflow-information-priority.md](../infrahub-common/rules/workflow-information-priority.md)**
+  -- Skill content first; how to consult `docs.infrahub.app`
+  on a genuine gap (e.g. deleting nodes)
 
 ## Anti-patterns
 


### PR DESCRIPTION
## What & why

The shared rule `skills/infrahub-common/rules/workflow-information-priority.md` already ranks information sources (active skill → `infrahub-common` refs → external docs as a last resort), but step 3 was vague hand-waving ("last resort … or a web search"). When a task is genuinely Infrahub-related but not covered by any loaded skill (e.g. deleting nodes, git-integration semantics), the AI had no reliable, context-safe way to consult the official docs — so it guessed from (often version-drifted) training.

This PR **operationalizes step 3** into a concrete, context-safe documentation-fallback procedure, without changing the priority ordering and without letting docs override a version-matched skill rule.

## How it works (gap-fill fallback only)

Consulted **only** when no loaded skill's rules cover the task. The procedure follows the `llms.txt` convention's intended read-path:

1. **Find the page** — WebFetch `https://docs.infrahub.app/llms.txt` with a *targeted* prompt so only the matching page path(s) return (not the 157 KB index).
2. **Read the page** — fetch that page's small `.md` twin and answer from it.
3. **Cite + caveat** — cite the page URL and flag the point as outside the skill's tested rules.
4. **Graceful degradation** — on a network error or an HTML-404 shell, say so and flag the answer as unverified; never present training recall as authoritative.
5. **Never override a skill** — a version-matched skill rule always wins.

The 4.3 MB `llms-full.txt` is explicitly *not* fetched (won't fit in context). Tool phrasing is portable ("WebFetch in Claude Code; the equivalent in Cursor/Copilot/Windsurf").

## Changes

- **Rule**: rewrote step 3 of `workflow-information-priority.md` into the procedure above (impact stays MEDIUM).
- **Surfacing**: added a one-line named pointer to the rule in all 11 skills' Supporting References and updated the `infrahub-common/SKILL.md` contents bullet, so the fallback is reliably discovered (previously only reachable via the generic `rules/` directory link).
- **Test**: new `graders/common/` (`lib.py` + `check_docs_fallback.py`, deterministic — asserts a gap-fill answer cites a `docs.infrahub.app` page and flags the gap) and a `docs-fallback-delete-node` eval task under `infrahub-managing-objects`; `evaluations/*.json` regenerated via `scripts/sync-evals.py`.
- **Version**: bumped unified version 1.2.7 → 1.2.8 across `plugin.json`, `.release-manifest.json`, `pyproject.toml`, and every `SKILL.md`.

## Known risk

The `docs-fallback-delete-node` eval task needs a live WebFetch; CI without network egress could make that one task flaky against the 0.8 threshold. Kept at `trials: 3` per the design; if CI proves flaky, document the dependence rather than weakening the assertion.

## Verification

- Deterministic grader verified: compliant answer → `score 1.0`; training-only answer → `score 0.0`.
- All 11 non-common skills reference the rule; all version fields consistent at 1.2.8.
- `sync-evals.py` re-run produces no further diff.
