### PR TITLE
fix(schemas): clarify shared-identifier relationship rules and the not_supported schema-check error

### DIFF
--- a/eval.yaml
+++ b/eval.yaml
@@ -389,6 +389,75 @@ tasks:
       - name: human-friendly-id
         check: human_friendly_id defined on each node
 
+  - name: inverse-identifier-reuse
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-managing-schemas/SKILL.md and follow its workflow and rules.
+
+      Task: A schema is already loaded into a running Infrahub instance. The DcimDevice node
+      declares a forward relationship to its interfaces, and that relationship was first loaded
+      WITHOUT an explicit identifier, so Infrahub auto-generated one: dcimdevice__dciminterface.
+      The DcimInterface node currently has NO relationship back to its device, so consumers that
+      hold an interface cannot traverse to its device.
+
+      Existing schema (do not change the DcimDevice side):
+
+        version: "1.0"
+        nodes:
+          - name: Device
+            namespace: Dcim
+            human_friendly_id: ["name__value"]
+            attributes:
+              - name: name
+                kind: Text
+            relationships:
+              - name: interfaces
+                peer: DcimInterface
+                kind: Attribute
+                cardinality: many
+                identifier: "dcimdevice__dciminterface"
+          - name: Interface
+            namespace: Dcim
+            human_friendly_id: ["name__value"]
+            attributes:
+              - name: name
+                kind: Text
+
+      Add the missing inverse `device` relationship on DcimInterface (peer DcimDevice,
+      cardinality one) so the link is traversable from both sides.
+
+      Save ONLY the final schema YAML to: output.yml
+    graders:
+      - type: deterministic
+        run: python graders/managing-schemas/check_inverse_identifier.py
+        weight: 1.0
+    expected_output: >-
+      A schema where the new DcimInterface.device relationship reuses the
+      forward side's existing identifier 'dcimdevice__dciminterface'
+      verbatim, rather than inventing a new one (e.g. 'device__interfaces')
+      and renaming the forward side — which would fail with not_supported
+      because the identifier is immutable once loaded.
+    expectations:
+      - >-
+        The new device relationship on DcimInterface has
+        identifier "dcimdevice__dciminterface" (reused verbatim)
+      - >-
+        The forward DcimDevice.interfaces identifier is left unchanged
+        (not renamed to invent a matching pair)
+      - "The device relationship peer is the full kind DcimDevice"
+      - 'Schema starts with version: "1.0"'
+    assertions:
+      - name: schema-version
+        check: "Schema starts with version: '1.0'"
+      - name: inverse-reuses-forward-identifier
+        check: >-
+          The inverse reuses the forward identifier
+          'dcimdevice__dciminterface' verbatim on both sides
+      - name: matching-identifiers
+        check: Both sides of the link share one identifier
+      - name: full-kind-references
+        check: All peer references use full Namespace+Name kind
+
   - name: computed-jinja2-name
     trials: 3
     instruction: |

--- a/evaluations/infrahub-managing-schemas.json
+++ b/evaluations/infrahub-managing-schemas.json
@@ -173,6 +173,36 @@
     },
     {
       "id": 5,
+      "prompt": "A schema is already loaded into a running Infrahub instance. The DcimDevice node\ndeclares a forward relationship to its interfaces, and that relationship was first loaded\nWITHOUT an explicit identifier, so Infrahub auto-generated one: dcimdevice__dciminterface.\nThe DcimInterface node currently has NO relationship back to its device, so consumers that\nhold an interface cannot traverse to its device.\n\nExisting schema (do not change the DcimDevice side):\n\n  version: \"1.0\"\n  nodes:\n    - name: Device\n      namespace: Dcim\n      human_friendly_id: [\"name__value\"]\n      attributes:\n        - name: name\n          kind: Text\n      relationships:\n        - name: interfaces\n          peer: DcimInterface\n          kind: Attribute\n          cardinality: many\n          identifier: \"dcimdevice__dciminterface\"\n    - name: Interface\n      namespace: Dcim\n      human_friendly_id: [\"name__value\"]\n      attributes:\n        - name: name\n          kind: Text\n\nAdd the missing inverse `device` relationship on DcimInterface (peer DcimDevice,\ncardinality one) so the link is traversable from both sides.",
+      "expected_output": "A schema where the new DcimInterface.device relationship reuses the forward side's existing identifier 'dcimdevice__dciminterface' verbatim, rather than inventing a new one (e.g. 'device__interfaces') and renaming the forward side \u2014 which would fail with not_supported because the identifier is immutable once loaded.",
+      "files": [],
+      "expectations": [
+        "The new device relationship on DcimInterface has identifier \"dcimdevice__dciminterface\" (reused verbatim)",
+        "The forward DcimDevice.interfaces identifier is left unchanged (not renamed to invent a matching pair)",
+        "The device relationship peer is the full kind DcimDevice",
+        "Schema starts with version: \"1.0\""
+      ],
+      "assertions": [
+        {
+          "name": "schema-version",
+          "check": "Schema starts with version: '1.0'"
+        },
+        {
+          "name": "inverse-reuses-forward-identifier",
+          "check": "The inverse reuses the forward identifier 'dcimdevice__dciminterface' verbatim on both sides"
+        },
+        {
+          "name": "matching-identifiers",
+          "check": "Both sides of the link share one identifier"
+        },
+        {
+          "name": "full-kind-references",
+          "check": "All peer references use full Namespace+Name kind"
+        }
+      ]
+    },
+    {
+      "id": 6,
       "prompt": "Create an Infrahub schema for a BGP autonomous-system catalog. An AutonomousSystem\nnode has an asn (number) and a description. The display name should NOT be entered by\nthe user \u2014 it must be auto-derived from the ASN as 'AS<asn>' (e.g., 'AS65000') using a\nJinja2 computed attribute. The derived name is used as the display label and as part\nof human_friendly_id, so it must always be populated. Use namespace 'Routing'.",
       "expected_output": "A schema where the name attribute uses computed_attribute with kind: Jinja2 and a non-empty jinja2_template, paired with read_only: true (always required) and optional: false (because the value is load-bearing \u2014 used as display_label and in human_friendly_id).",
       "files": [],
@@ -204,7 +234,7 @@
       ]
     },
     {
-      "id": 6,
+      "id": 7,
       "prompt": "Create an Infrahub schema for a load-balancer VIP service. A VIPService has a\nname (Text) and references a frontend IP (IpamIPAddress). The VIPService owns a list\nof HealthCheck objects \u2014 health checks have no meaning on their own and should be\ndeleted when their VIPService is deleted. The frontend IP, however, is shared\ninfrastructure: deleting a VIPService must NOT delete its IP. Use namespace 'ServiceLB'.",
       "expected_output": "A schema where the VIPService \u2192 HealthCheck Component relationship sets on_delete: cascade explicitly (so health checks are removed when the parent VIP is deleted), and the VIPService \u2192 IP relationship either omits on_delete or sets on_delete: no-action (so the shared IP is preserved). Any kind: Parent relationship has optional: false.",
       "files": [],
@@ -245,7 +275,7 @@
       ]
     },
     {
-      "id": 7,
+      "id": 8,
       "prompt": "Create an Infrahub schema for a network-device inventory. Define a generic\nGenericDevice (with shared attributes like hostname and role) and a concrete Device\nnode that inherits from it. The concrete Device should:\n\n  - Be eligible for rendered configuration artifacts (so artifact definitions in\n    .infrahub.yml can attach to it).\n  - Be cloneable from the UI as a starter for new devices (one template per role \u2014\n    leaf, spine, edge \u2014 speeds onboarding).\n\nThe two capabilities are independent features and should be applied to the concrete\nDevice, not to the generic. Use namespace 'Dcim'.",
       "expected_output": "A schema with the GenericDevice generic carrying the shared attributes, and a concrete Device node that both inherits from CoreArtifactTarget AND sets generate_template: true. Neither flag appears on the generic.",
       "files": [],
@@ -279,7 +309,7 @@
       ]
     },
     {
-      "id": 8,
+      "id": 9,
       "prompt": "Add a DcimNetworkDiagram node to my Infrahub schema. Each diagram is a Visio\nfile attached to a LocationSite. Track a title, the author, and the date it was\nlast reviewed. The Visio file itself must be stored inside Infrahub, not as a URL.\nUse namespace 'Dcim'. The LocationSite node already exists \u2014 extend it via the\nschema's relationships rather than redefining it.",
       "expected_output": "A schema in which DcimNetworkDiagram inherits from CoreFileObject (so the Visio file lives in Infrahub object storage with auto file metadata and a GraphQL upload mutation), carries domain attributes (title, author, last_reviewed) but does NOT redeclare the reserved file_name/file_size/file_type/checksum/storage_id attributes, and links back to LocationSite via a cardinality:one relationship.",
       "files": [],
@@ -319,7 +349,7 @@
       ]
     },
     {
-      "id": 9,
+      "id": 10,
       "prompt": "Model a network-device inventory where many devices share the\nsame operational defaults (MTU, status, timezone) that operators want\nto manage in one place and change centrally. Define a generic\nGenericDevice (hostname, role) and a concrete Device node that inherits\nfrom it. Enable the mechanism that lets operators define reusable\ndefault-value sets and assign them to devices. Use namespace 'Dcim'.",
       "expected_output": "A schema whose concrete Device node sets generate_profile: true (never on the GenericDevice generic), inherits from DcimGenericDevice by full kind, and defines human_friendly_id. The shared attributes (mtu, status, timezone) are optional so Profile-supplied values apply.",
       "files": [],
@@ -344,7 +374,7 @@
       ]
     },
     {
-      "id": 10,
+      "id": 11,
       "prompt": "Create an Infrahub schema for a service-handoff intent model. Namespace: 'Service'.\n\nDefine a single node, HandoffIntent, with:\n\n  - intent_id: a Number, the unique identifier for the handoff intent.\n  - state: a Dropdown \u2014 one of draft, active, decommissioned.\n\nPlus two relationships on HandoffIntent:\n\n  - source_device: peer DcimDevice. Constraint: must point to a customer-edge\n    router where the provider hands traffic off. Non-edge devices are rejected at\n    submit by the generator's _validate() step.\n  - handoff_port: peer DcimInterface. The specific port on source_device where\n    the handover happens. The picker walks DcimDevice \u2192 DcimInterface via the\n    peer's human_friendly_id; only ports on the chosen source_device are valid.\n\nThese descriptions are operator-facing \u2014 they are the only docs operators see in the UI\ntooltip. Make sure the schema actually loads (`infrahubctl schema load`) without errors\nin addition to passing `infrahubctl schema check`.",
       "expected_output": "A schema where every string field (`description`, `label`, `identifier`, `deprecation`) stays within Infrahub's server-enforced Pydantic `max_length` caps so the schema loads cleanly. Limits are resolved live per the validation-string-limits rule (public JSON Schema primary, `/api/openapi.json` fallback); this eval does not pin specific numbers. Longer operator-facing context belongs in YAML comments next to the field, not in `description:` itself.",
       "files": [],
@@ -379,7 +409,7 @@
       ]
     },
     {
-      "id": 11,
+      "id": 12,
       "prompt": "Production incident \u2014 we need a new `maintenance_window` optional Dropdown\nattribute on DcimDevice live on our shared, team-wide Infrahub instance in the next 10\nminutes so on-call can start tagging devices. It's just one optional dropdown, totally\nadditive, zero risk. Give me the exact command to apply it to the server right now \u2014 we\ndon't have time to mess with branches and proposed changes.\n\nSave your full plan (the commands plus a brief rationale) to: output.md",
       "expected_output": "Despite the time pressure and the \"additive / zero risk\" framing, the answer should hold the line rather than hand over a bare `schema load` that targets the default branch. It creates or selects a dedicated branch (e.g. `infrahubctl branch create schema-maint-window`) and runs `infrahubctl schema check --branch <branch>` then `infrahubctl schema load --branch <branch>` on that branch, rather than loading directly into the default branch (`main` by convention, but it can be renamed). The rationale should explain that a schema load runs migrations against loaded data immediately, so applying on the default branch gives no preview and no per-step undo, whereas a branch can be previewed, merged via a proposed change after review, or discarded \u2014 and that the branch costs ~60 seconds, which is exactly what an incident needs.",
       "files": [],

--- a/graders/managing-schemas/check_inverse_identifier.py
+++ b/graders/managing-schemas/check_inverse_identifier.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Grader for the inverse-identifier-reuse eval task.
+
+Verifies that when the model adds a missing inverse relationship, it reuses
+the forward side's pre-existing (auto-generated-looking) identifier verbatim
+rather than inventing a new one and renaming the forward side — the latter
+fails with `not_supported` on a live instance because the identifier is
+immutable.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = [
+    "schema-version",
+    "inverse-reuses-forward-identifier",
+    "matching-identifiers",
+    "full-kind-references",
+]
+
+if __name__ == "__main__":
+    output_path = Path("output.yml")
+    result = run_checks(CHECKS, output_path)
+    print(json.dumps(result))

--- a/graders/managing-schemas/lib.py
+++ b/graders/managing-schemas/lib.py
@@ -835,6 +835,46 @@ def check_explains_default_branch_risk_or_review(schema: dict, *, raw_text: str 
 # Check registry
 # ---------------------------------------------------------------------------
 
+def check_inverse_reuses_forward_identifier(schema: dict, **_: Any) -> tuple[bool, str]:
+    """The added inverse reuses the pre-existing forward identifier verbatim.
+
+    The task seeds an existing forward relationship whose identifier is the
+    auto-generated-looking ``dcimdevice__dciminterface``. Adding the inverse
+    must reuse that exact string on both sides. Inventing a fresh identifier
+    (e.g. ``device__interfaces``) and renaming the forward side to match is
+    the antipattern this check guards against — a rename fails on a live
+    instance with ``not_supported`` because the identifier is immutable.
+    ``check_matching_identifiers`` cannot catch it: it passes as long as both
+    sides agree, even when both were renamed to an invented value.
+    """
+    expected = "dcimdevice__dciminterface"
+    all_items = _all_nodes(schema) + _all_generics(schema)
+
+    link_idents: set[str] = set()
+    inverse_found = False
+    for node in all_items:
+        for rel in _all_rels(node):
+            peer = rel.get("peer", "")
+            name = rel.get("name", "")
+            # Relationships that form the Device <-> Interface link.
+            if peer.startswith("Dcim") and ("Device" in peer or "Interface" in peer):
+                ident = rel.get("identifier")
+                if ident:
+                    link_idents.add(ident)
+                if name == "device":
+                    inverse_found = True
+
+    if not inverse_found:
+        return False, "No inverse 'device' relationship was added on the interface side"
+    if link_idents != {expected}:
+        return False, (
+            f"Device/Interface identifiers must reuse '{expected}' verbatim; "
+            f"found {sorted(link_idents)} — inventing a new identifier and renaming "
+            "the forward side is the antipattern (immutable identifier)"
+        )
+    return True, f"Inverse reuses the forward identifier '{expected}' verbatim"
+
+
 CHECKS: dict[str, Any] = {
     "attr-min-length": check_attr_min_length,
     "dropdown-for-status": check_dropdown_for_status,
@@ -844,6 +884,7 @@ CHECKS: dict[str, Any] = {
     "display-label-singular": check_display_label_singular,
     "schema-version": check_schema_version,
     "matching-identifiers": check_matching_identifiers,
+    "inverse-reuses-forward-identifier": check_inverse_reuses_forward_identifier,
     "hierarchical-generic": check_hierarchical_generic,
     "inherit-from-generic": check_inherit_from_generic,
     "root-no-parent": check_root_no_parent,

--- a/skills/infrahub-auditing-repo/rules/schema-relationships.md
+++ b/skills/infrahub-auditing-repo/rules/schema-relationships.md
@@ -52,18 +52,13 @@ rejects it without explaining why.
 ## Identifier is immutable after load
 
 `identifier` (and `direction`, `branch`,
-`hierarchical`) cannot be changed once a relationship
-exists in a running instance — the loader classifies
-the change as `not_supported` and
-`infrahubctl schema check` fails with
-`'not_supported': <Kind> <rel> None`. The usual cause
-is retrofitting an explicit identifier onto a
-relationship that was first loaded without one (so
-Infrahub auto-generated `sorted(kinds).lower()`).
-When adding a missing inverse or renaming an
-identifier, reuse the forward side's existing
-identifier verbatim. Full rule, error signature, and
-fix in
+`hierarchical`) cannot change once a relationship
+exists in the instance — `infrahubctl schema check`
+fails with `'not_supported': <Kind> <rel> None`. The
+usual cause is retrofitting an explicit identifier
+onto a relationship first loaded without one. When
+adding an inverse, reuse the forward side's existing
+identifier. See
 [relationship-identifiers](../../infrahub-managing-schemas/rules/relationship-identifiers.md).
 
 ## Common Issues

--- a/skills/infrahub-auditing-repo/rules/schema-relationships.md
+++ b/skills/infrahub-auditing-repo/rules/schema-relationships.md
@@ -49,9 +49,27 @@ rejects it without explaining why.
    optional defaults to `true` — flag when these
    defaults may cause confusion
 
+## Identifier is immutable after load
+
+`identifier` (and `direction`, `branch`,
+`hierarchical`) cannot be changed once a relationship
+exists in a running instance — the loader classifies
+the change as `not_supported` and
+`infrahubctl schema check` fails with
+`'not_supported': <Kind> <rel> None`. The usual cause
+is retrofitting an explicit identifier onto a
+relationship that was first loaded without one (so
+Infrahub auto-generated `sorted(kinds).lower()`).
+When adding a missing inverse or renaming an
+identifier, reuse the forward side's existing
+identifier verbatim. Full rule, error signature, and
+fix in
+[relationship-identifiers](../../infrahub-managing-schemas/rules/relationship-identifiers.md).
+
 ## Common Issues
 
 - `peer: Device` instead of `peer: InfraDevice`
 - Mismatched identifiers between two sides of a bidirectional relationship
+- Changing an existing relationship's `identifier` (fails with `not_supported`; remove + re-add instead)
 - Component side with `cardinality: one` (should be `many`)
 - Parent side with `cardinality: many` (should be `one`)

--- a/skills/infrahub-auditing-repo/rules/schema-relationships.md
+++ b/skills/infrahub-auditing-repo/rules/schema-relationships.md
@@ -54,7 +54,7 @@ rejects it without explaining why.
 `identifier` (and `direction`, `branch`,
 `hierarchical`) cannot change once a relationship
 exists in the instance — `infrahubctl schema check`
-fails with `'not_supported': <Kind> <rel> None`. The
+fails with `'not_supported': <Kind> <relationship> None`. The
 usual cause is retrofitting an explicit identifier
 onto a relationship first loaded without one. When
 adding an inverse, reuse the forward side's existing

--- a/skills/infrahub-auditing-repo/rules/yagni-missing-inverse-forces-python-filter.md
+++ b/skills/infrahub-auditing-repo/rules/yagni-missing-inverse-forces-python-filter.md
@@ -104,28 +104,17 @@ checks, and transforms over time.
 
 ## Fixing it: match the forward side's existing identifier
 
-When you add the inverse, it must carry the **same
-`identifier` as the forward relationship already has**
-— not a freshly-invented `peer__source` string. If
-the forward relationship is already loaded in a
-running instance without an explicit identifier,
-Infrahub auto-generated one
-(`"__".join(sorted([kind, peer])).lower()`), and the
-identifier is now immutable. Reusing that exact value
-on the new inverse connects the two into one
-bidirectional edge; inventing a new string and
-changing the forward side to match instead fails
-`infrahubctl schema check` with
-`'not_supported': <Kind> <rel> None`, because
-`identifier` cannot be changed after load.
-
-So: read the forward relationship's current
-`identifier` (from the schema file, or
-`GET /api/schema` on a live instance) and set the
-inverse to that same string. See
-[relationship-identifiers](../../infrahub-managing-schemas/rules/relationship-identifiers.md)
-("The identifier is immutable once loaded") for the
-full rule and the error signature.
+The inverse must carry the **same `identifier` as the
+forward relationship already has** — not a
+freshly-invented `peer__source` string. A forward
+relationship loaded without an explicit identifier got
+an auto-generated one, and that identifier is now
+immutable. Reuse the forward side's identifier (read
+it from the schema file, or run `infrahubctl schema
+check` and read the diff); inventing a new string and
+changing the forward side to match instead fails with
+`'not_supported': <Kind> <rel> None`. See
+[relationship-identifiers](../../infrahub-managing-schemas/rules/relationship-identifiers.md).
 
 ## Related
 

--- a/skills/infrahub-auditing-repo/rules/yagni-missing-inverse-forces-python-filter.md
+++ b/skills/infrahub-auditing-repo/rules/yagni-missing-inverse-forces-python-filter.md
@@ -102,6 +102,31 @@ checks, and transforms over time.
   [schema-relationships](./schema-relationships.md) rule 2
   (bidirectional identifiers).
 
+## Fixing it: match the forward side's existing identifier
+
+When you add the inverse, it must carry the **same
+`identifier` as the forward relationship already has**
+— not a freshly-invented `peer__source` string. If
+the forward relationship is already loaded in a
+running instance without an explicit identifier,
+Infrahub auto-generated one
+(`"__".join(sorted([kind, peer])).lower()`), and the
+identifier is now immutable. Reusing that exact value
+on the new inverse connects the two into one
+bidirectional edge; inventing a new string and
+changing the forward side to match instead fails
+`infrahubctl schema check` with
+`'not_supported': <Kind> <rel> None`, because
+`identifier` cannot be changed after load.
+
+So: read the forward relationship's current
+`identifier` (from the schema file, or
+`GET /api/schema` on a live instance) and set the
+inverse to that same string. See
+[relationship-identifiers](../../infrahub-managing-schemas/rules/relationship-identifiers.md)
+("The identifier is immutable once loaded") for the
+full rule and the error signature.
+
 ## Related
 
 - Downstream Python/query symptom:

--- a/skills/infrahub-auditing-repo/rules/yagni-missing-inverse-forces-python-filter.md
+++ b/skills/infrahub-auditing-repo/rules/yagni-missing-inverse-forces-python-filter.md
@@ -107,13 +107,14 @@ checks, and transforms over time.
 The inverse must carry the **same `identifier` as the
 forward relationship already has** — not a
 freshly-invented `peer__source` string. A forward
-relationship loaded without an explicit identifier got
-an auto-generated one, and that identifier is now
-immutable. Reuse the forward side's identifier (read
-it from the schema file, or run `infrahubctl schema
-check` and read the diff); inventing a new string and
-changing the forward side to match instead fails with
-`'not_supported': <Kind> <rel> None`. See
+relationship loaded without an explicit identifier gets
+an auto-generated one, and that identifier is
+immutable. Reuse the forward side's identifier — read
+it from the schema file or its git history, or from the
+running instance (`GET /api/schema`); inventing a new
+string and changing the forward side to match instead
+fails with `'not_supported': <Kind> <relationship>
+None`. See
 [relationship-identifiers](../../infrahub-managing-schemas/rules/relationship-identifiers.md).
 
 ## Related

--- a/skills/infrahub-managing-schemas/rules/relationship-component-parent.md
+++ b/skills/infrahub-managing-schemas/rules/relationship-component-parent.md
@@ -98,4 +98,18 @@ mandatory). For `kind: Parent` you have to set
 `optional: false` explicitly — leaving it unset
 triggers the error above.
 
+### A clean `schema check` does not prove the pairing
+
+The Parent-side validation above only fires on
+relationships declared `kind: Parent`. Model the child
+side as a plain `kind: Attribute` (many ↔ one) instead,
+and a fresh load passes `schema check` with no
+complaint — nothing asserts the child side *must* be
+`Parent`. A green check therefore confirms the YAML is
+well-formed, not that the ownership shape is right. Use
+this as a diagnosis aid, never as permission: when a
+check passes, still verify the Component side has a
+real `kind: Parent` inverse rather than assuming the
+shape is correct.
+
 Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/infrahub-managing-schemas/rules/relationship-identifiers.md
+++ b/skills/infrahub-managing-schemas/rules/relationship-identifiers.md
@@ -75,196 +75,57 @@ loader rejects it with a `not_supported` error (see
 
 ### Omitting the identifier auto-generates one
 
-If you leave `identifier` off, Infrahub generates
-one from the two peer kinds, sorted and lowercased:
-`"__".join(sorted([node_kind, peer_kind])).lower()`.
-Both sides derive the *same* string, so an omitted
-identifier still produces a correctly-linked
-bidirectional edge — for peers `IpamL2Domain` and
-`IpamVLAN` the auto-generated identifier is
-`ipaml2domain__ipamvlan` on both sides.
-
-The catch: that auto-generated string rarely matches
-the `parent__children` convention you would have
-written by hand. Once the relationship has been
-loaded once, the identifier is frozen (see below), so
-decide up front — set an explicit identifier from the
-very first load, or accept the auto-generated one and
-reuse it verbatim everywhere.
-
-Source: `_generate_identifier_string` in
-`infrahub/core/schema/schema_branch.py`.
+Leave `identifier` off and Infrahub derives it from
+the two peer kinds, sorted and lowercased — e.g.
+`IpamL2Domain` + `IpamVLAN` becomes
+`ipaml2domain__ipamvlan` on both sides. That still
+links correctly, but the string rarely matches the
+`parent__children` convention, and once loaded it is
+frozen. Decide up front: set an explicit identifier
+on the first load, or accept the auto-generated one
+and reuse it verbatim.
 
 ### The identifier is immutable once loaded
 
-`identifier` cannot be changed after a relationship
-exists in a running Infrahub instance. It is one of a
-handful of relationship fields the schema loader
-marks as *update: not_supported* — alongside
-`direction`, `branch`, and `hierarchical`. Changing
-any of them on an already-loaded relationship is
+`identifier`, `direction`, `branch`, and
+`hierarchical` cannot change after a relationship
+exists in the instance. Changing any of them is
 rejected by `infrahubctl schema check` (and
-`schema load`) with:
+`schema load`):
 
 ```text
 Unable to load the schema:
   'not_supported': IpamL2Domain vlans None, 'not_supported': IpamVLAN l2domain None
 ```
 
-Read the signature as
-`'<constraint>': <Kind> <relationship-name> <message>`
-— the trailing `None` is just the (empty) message.
-There is one entry per side because both sides carry
-the same, now-conflicting, identifier.
+Read it as `'<constraint>': <Kind> <relationship>
+<message>` (trailing `None` = empty message), one
+entry per side. The usual trigger: the relationship
+was first loaded without an explicit identifier (so
+Infrahub auto-generated one), then a schema adds a
+*different* explicit `identifier`. The `kind`,
+`cardinality`, and `optional` are irrelevant — they
+are mutable; only the identifier changed.
 
-**What actually triggers it** (this is the trap):
-the relationship was first loaded *without* an
-explicit identifier, so Infrahub auto-generated
-`ipaml2domain__ipamvlan`. Later you add an explicit
-`identifier: "l2domain__vlans"` — a *different*
-string — and the loader sees an attempt to change an
-immutable field. The error is not about the
-relationship `kind`, `cardinality`, or `optional`;
-those are all mutable. It is purely: *you tried to
-rename an existing relationship's identifier.*
+To fix, set the identifier you want on the first
+load, or keep the existing one — run `infrahubctl
+schema check` and read the diff to see what is
+already loaded. To genuinely rename it, remove the
+relationship (`state: absent`), load, then re-add it
+with the new identifier.
 
-**The fix** — pick one:
+Any `kind`/`cardinality` pairing is valid as long as
+both sides share one identifier and use compatible
+directions — the loader enforces no kind/cardinality
+matrix. `Component`(many) ↔ `Attribute`(one) loads
+fine, not only `Component` ↔ `Parent`.
 
-- Set the identifier you want on the **first** load,
-  before the nodes exist in the instance. Fresh
-  relationships accept any identifier.
-- If the relationship is already loaded, keep its
-  current identifier. Query it from the live schema
-  (`GET /api/schema` → the relationship's
-  `identifier`) and reuse that exact value. If it was
-  auto-generated, that means using
-  `sorted(kinds).lower()`.
-- If you genuinely must rename the identifier, that
-  is a destructive migration: remove the relationship
-  (`state: absent`), load, then re-add it with the
-  new identifier. Treat it like renaming a column.
+### Field mutability on update
 
-Verified against Infrahub v1.10.5:
-`infrahubctl schema check` on the same
-`IpamL2Domain`/`IpamVLAN` pair passes when the
-identifier keeps its existing
-`ipaml2domain__ipamvlan` value (even while flipping
-`optional` from `true` to `false`) and fails with the
-error above only when the identifier is changed to
-`l2domain__vlans`.
-
-Source: field `update` support flags in
-`infrahub/core/schema/generated/relationship_schema.py`
-(`identifier`, `direction`, `branch`, `hierarchical`
-are `not_supported`); error raised in
-`SchemaUpdateValidationResult._process_field` in
-`infrahub/core/models.py`; string built by
-`SchemaUpdateValidationError.to_string`.
-
-### Which kind / cardinality pairings are valid
-
-Any combination of `kind` and `cardinality` is a
-valid shared-identifier bidirectional edge, provided
-**both sides share one identifier** and use
-compatible `direction` values (the default
-`bidirectional` on both sides is always compatible).
-The loader does **not** enforce a kind-to-kind or
-cardinality-to-cardinality matrix — it only enforces
-direction compatibility (`bidirectional`↔`bidirectional`,
-or `inbound`↔`outbound` when the same kind sits on
-both ends). See `validate_identifiers` in
-`schema_branch.py`.
-
-Common, verified-valid pairings:
-
-| Side A (`kind` / `cardinality`) | Side B (`kind` / `cardinality`) | Use for |
-| --- | --- | --- |
-| `Component` / `many` | `Parent` / `one` (`optional: false`) | Child owned by parent; deleting the parent deletes the children |
-| `Attribute` / `one` | `Attribute` or plain / `many` | A reference and its reverse collection |
-| `Component` / `many` | `Attribute` / `one` | Ownership on one side, a plain back-reference on the other (valid — this is the `IvuVMHost` ↔ `IvuVirtualMachine` and `IpamL2Domain` ↔ `IpamVLAN` shape) |
-
-The `Component`(many) ↔ `Attribute`(one) row is worth
-calling out because it *looks* like it should be
-`Component` ↔ `Parent`, yet loads fine. It is the
-identifier — not the kind pairing — that decides
-whether `schema check` passes.
-
-**Component ↔ Parent** (owned children):
-
-```yaml
-# On Rack:
-- name: devices
-  peer: DcimDevice
-  kind: Component
-  cardinality: many
-  identifier: "rack__devices"
-
-# On Device:
-- name: rack
-  peer: DcimRack
-  kind: Parent
-  cardinality: one
-  optional: false
-  identifier: "rack__devices"
-```
-
-**Attribute(one) ↔ many** (reference + reverse
-collection):
-
-```yaml
-# On Interface:
-- name: device
-  peer: DcimDevice
-  kind: Attribute
-  cardinality: one
-  optional: false
-  identifier: "device__interfaces"
-
-# On Device:
-- name: interfaces
-  peer: DcimInterface
-  cardinality: many          # plain (Generic) kind
-  identifier: "device__interfaces"
-```
-
-**Component(many) ↔ Attribute(one)** (the case that
-looks wrong but is valid):
-
-```yaml
-# On L2Domain:
-- name: vlans
-  peer: IpamVLAN
-  kind: Component
-  cardinality: many
-  identifier: "l2domain__vlans"
-
-# On VLAN:
-- name: l2domain
-  peer: IpamL2Domain
-  kind: Attribute
-  cardinality: one
-  optional: false
-  identifier: "l2domain__vlans"   # SAME on both sides
-```
-
-This loads cleanly on a fresh instance. It fails with
-`not_supported` **only** if `IpamVLAN`/`IpamL2Domain`
-already exist with a *different* identifier for this
-link — see "The identifier is immutable once loaded".
-
-### Relationship field mutability reference
-
-When you change a field on a relationship that already
-exists in the instance, the loader classifies the
-change:
-
-| Field | On update | Meaning |
-| --- | --- | --- |
-| `identifier`, `direction`, `branch`, `hierarchical` | `not_supported` | Rejected outright — remove + re-add to change |
-| `peer`, `cardinality`, `min_count`, `max_count`, `optional`, `common_parent` | `validate_constraint` | Allowed if existing data satisfies the new rule |
-| `name`, `kind`, `label`, `description`, `order_weight`, `on_delete`, `read_only`, `display`, … | `allowed` | Changed freely |
-
-Source:
-`infrahub/core/schema/generated/relationship_schema.py`.
+| Field | On update |
+| --- | --- |
+| `identifier`, `direction`, `branch`, `hierarchical` | `not_supported` — remove + re-add to change |
+| `peer`, `cardinality`, `min_count`, `max_count`, `optional`, `common_parent` | `validate_constraint` — allowed if existing data conforms |
+| everything else (`name`, `kind`, `label`, …) | `allowed` |
 
 Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/infrahub-managing-schemas/rules/relationship-identifiers.md
+++ b/skills/infrahub-managing-schemas/rules/relationship-identifiers.md
@@ -24,6 +24,13 @@ silent: no validation error fires, the data simply
 behaves wrong, and the fix later requires
 backfilling every existing object.
 
+That silent behavior applies to a *fresh* load with
+two diverging identifiers. A different, *loud*
+failure happens when you try to **change** an
+identifier that already exists in the instance — the
+loader rejects it with a `not_supported` error (see
+"The identifier is immutable once loaded" below).
+
 **Incorrect:**
 
 ```yaml
@@ -65,5 +72,199 @@ backfilling every existing object.
 **Convention:** Use `snake_case` with `__` separator:
 `"parent__children"`, `"rack__devices"`,
 `"tenant__racks"`.
+
+### Omitting the identifier auto-generates one
+
+If you leave `identifier` off, Infrahub generates
+one from the two peer kinds, sorted and lowercased:
+`"__".join(sorted([node_kind, peer_kind])).lower()`.
+Both sides derive the *same* string, so an omitted
+identifier still produces a correctly-linked
+bidirectional edge — for peers `IpamL2Domain` and
+`IpamVLAN` the auto-generated identifier is
+`ipaml2domain__ipamvlan` on both sides.
+
+The catch: that auto-generated string rarely matches
+the `parent__children` convention you would have
+written by hand. Once the relationship has been
+loaded once, the identifier is frozen (see below), so
+decide up front — set an explicit identifier from the
+very first load, or accept the auto-generated one and
+reuse it verbatim everywhere.
+
+Source: `_generate_identifier_string` in
+`infrahub/core/schema/schema_branch.py`.
+
+### The identifier is immutable once loaded
+
+`identifier` cannot be changed after a relationship
+exists in a running Infrahub instance. It is one of a
+handful of relationship fields the schema loader
+marks as *update: not_supported* — alongside
+`direction`, `branch`, and `hierarchical`. Changing
+any of them on an already-loaded relationship is
+rejected by `infrahubctl schema check` (and
+`schema load`) with:
+
+```text
+Unable to load the schema:
+  'not_supported': IpamL2Domain vlans None, 'not_supported': IpamVLAN l2domain None
+```
+
+Read the signature as
+`'<constraint>': <Kind> <relationship-name> <message>`
+— the trailing `None` is just the (empty) message.
+There is one entry per side because both sides carry
+the same, now-conflicting, identifier.
+
+**What actually triggers it** (this is the trap):
+the relationship was first loaded *without* an
+explicit identifier, so Infrahub auto-generated
+`ipaml2domain__ipamvlan`. Later you add an explicit
+`identifier: "l2domain__vlans"` — a *different*
+string — and the loader sees an attempt to change an
+immutable field. The error is not about the
+relationship `kind`, `cardinality`, or `optional`;
+those are all mutable. It is purely: *you tried to
+rename an existing relationship's identifier.*
+
+**The fix** — pick one:
+
+- Set the identifier you want on the **first** load,
+  before the nodes exist in the instance. Fresh
+  relationships accept any identifier.
+- If the relationship is already loaded, keep its
+  current identifier. Query it from the live schema
+  (`GET /api/schema` → the relationship's
+  `identifier`) and reuse that exact value. If it was
+  auto-generated, that means using
+  `sorted(kinds).lower()`.
+- If you genuinely must rename the identifier, that
+  is a destructive migration: remove the relationship
+  (`state: absent`), load, then re-add it with the
+  new identifier. Treat it like renaming a column.
+
+Verified against Infrahub v1.10.5:
+`infrahubctl schema check` on the same
+`IpamL2Domain`/`IpamVLAN` pair passes when the
+identifier keeps its existing
+`ipaml2domain__ipamvlan` value (even while flipping
+`optional` from `true` to `false`) and fails with the
+error above only when the identifier is changed to
+`l2domain__vlans`.
+
+Source: field `update` support flags in
+`infrahub/core/schema/generated/relationship_schema.py`
+(`identifier`, `direction`, `branch`, `hierarchical`
+are `not_supported`); error raised in
+`SchemaUpdateValidationResult._process_field` in
+`infrahub/core/models.py`; string built by
+`SchemaUpdateValidationError.to_string`.
+
+### Which kind / cardinality pairings are valid
+
+Any combination of `kind` and `cardinality` is a
+valid shared-identifier bidirectional edge, provided
+**both sides share one identifier** and use
+compatible `direction` values (the default
+`bidirectional` on both sides is always compatible).
+The loader does **not** enforce a kind-to-kind or
+cardinality-to-cardinality matrix — it only enforces
+direction compatibility (`bidirectional`↔`bidirectional`,
+or `inbound`↔`outbound` when the same kind sits on
+both ends). See `validate_identifiers` in
+`schema_branch.py`.
+
+Common, verified-valid pairings:
+
+| Side A (`kind` / `cardinality`) | Side B (`kind` / `cardinality`) | Use for |
+| --- | --- | --- |
+| `Component` / `many` | `Parent` / `one` (`optional: false`) | Child owned by parent; deleting the parent deletes the children |
+| `Attribute` / `one` | `Attribute` or plain / `many` | A reference and its reverse collection |
+| `Component` / `many` | `Attribute` / `one` | Ownership on one side, a plain back-reference on the other (valid — this is the `IvuVMHost` ↔ `IvuVirtualMachine` and `IpamL2Domain` ↔ `IpamVLAN` shape) |
+
+The `Component`(many) ↔ `Attribute`(one) row is worth
+calling out because it *looks* like it should be
+`Component` ↔ `Parent`, yet loads fine. It is the
+identifier — not the kind pairing — that decides
+whether `schema check` passes.
+
+**Component ↔ Parent** (owned children):
+
+```yaml
+# On Rack:
+- name: devices
+  peer: DcimDevice
+  kind: Component
+  cardinality: many
+  identifier: "rack__devices"
+
+# On Device:
+- name: rack
+  peer: DcimRack
+  kind: Parent
+  cardinality: one
+  optional: false
+  identifier: "rack__devices"
+```
+
+**Attribute(one) ↔ many** (reference + reverse
+collection):
+
+```yaml
+# On Interface:
+- name: device
+  peer: DcimDevice
+  kind: Attribute
+  cardinality: one
+  optional: false
+  identifier: "device__interfaces"
+
+# On Device:
+- name: interfaces
+  peer: DcimInterface
+  cardinality: many          # plain (Generic) kind
+  identifier: "device__interfaces"
+```
+
+**Component(many) ↔ Attribute(one)** (the case that
+looks wrong but is valid):
+
+```yaml
+# On L2Domain:
+- name: vlans
+  peer: IpamVLAN
+  kind: Component
+  cardinality: many
+  identifier: "l2domain__vlans"
+
+# On VLAN:
+- name: l2domain
+  peer: IpamL2Domain
+  kind: Attribute
+  cardinality: one
+  optional: false
+  identifier: "l2domain__vlans"   # SAME on both sides
+```
+
+This loads cleanly on a fresh instance. It fails with
+`not_supported` **only** if `IpamVLAN`/`IpamL2Domain`
+already exist with a *different* identifier for this
+link — see "The identifier is immutable once loaded".
+
+### Relationship field mutability reference
+
+When you change a field on a relationship that already
+exists in the instance, the loader classifies the
+change:
+
+| Field | On update | Meaning |
+| --- | --- | --- |
+| `identifier`, `direction`, `branch`, `hierarchical` | `not_supported` | Rejected outright — remove + re-add to change |
+| `peer`, `cardinality`, `min_count`, `max_count`, `optional`, `common_parent` | `validate_constraint` | Allowed if existing data satisfies the new rule |
+| `name`, `kind`, `label`, `description`, `order_weight`, `on_delete`, `read_only`, `display`, … | `allowed` | Changed freely |
+
+Source:
+`infrahub/core/schema/generated/relationship_schema.py`.
 
 Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/infrahub-managing-schemas/rules/relationship-identifiers.md
+++ b/skills/infrahub-managing-schemas/rules/relationship-identifiers.md
@@ -75,15 +75,28 @@ loader rejects it with a `not_supported` error (see
 
 ### Omitting the identifier auto-generates one
 
-Leave `identifier` off and Infrahub derives it from
-the two peer kinds, sorted and lowercased — e.g.
-`IpamL2Domain` + `IpamVLAN` becomes
-`ipaml2domain__ipamvlan` on both sides. That still
-links correctly, but the string rarely matches the
-`parent__children` convention, and once loaded it is
-frozen. Decide up front: set an explicit identifier
-on the first load, or accept the auto-generated one
-and reuse it verbatim.
+Leave `identifier` off and Infrahub derives it on each
+side independently from that side's own kind and its
+peer kind, sorted and lowercased. When both peers are
+concrete and mirror each other — `IpamL2Domain` ↔
+`IpamVLAN` — both sides derive the same
+`ipaml2domain__ipamvlan` and the link forms correctly.
+The string rarely matches the `parent__children`
+convention, and once loaded it is frozen.
+
+Auto-generation is only safe when both sides'
+`(kind, peer)` pairs mirror each other. When one side
+peers a **generic** — e.g. `Device.interfaces →
+DcimInterface` while `Interface.device →
+DcimGenericDevice` — each side derives a *different*
+string and the link silently splits into the two
+phantom edges this rule exists to prevent. With a
+generic on either peer, set the identifier explicitly
+on both sides.
+
+Decide up front: set an explicit identifier on the
+first load, or — concrete peers only — accept the
+auto-generated one and reuse it verbatim.
 
 ### The identifier is immutable once loaded
 
@@ -98,34 +111,37 @@ Unable to load the schema:
   'not_supported': IpamL2Domain vlans None, 'not_supported': IpamVLAN l2domain None
 ```
 
-Read it as `'<constraint>': <Kind> <relationship>
-<message>` (trailing `None` = empty message), one
-entry per side. The usual trigger: the relationship
+Read it as `'<error_type>': <Kind> <relationship>
+<message>` (here the error type is `not_supported` and
+the trailing `None` is an empty message), one entry
+per side. The usual trigger: the relationship
 was first loaded without an explicit identifier (so
 Infrahub auto-generated one), then a schema adds a
-*different* explicit `identifier`. The `kind`,
-`cardinality`, and `optional` are irrelevant — they
-are mutable; only the identifier changed.
+*different* explicit `identifier`. Here `kind`,
+`cardinality`, and `optional` are not what triggered
+the error — only the identifier changed. They carry
+their own, looser update rules; see the table below.
 
-To fix, set the identifier you want on the first
-load, or keep the existing one — run `infrahubctl
-schema check` and read the diff to see what is
-already loaded. To genuinely rename it, remove the
+To fix, reuse the identifier already loaded rather
+than changing the forward side. Recover its value from
+the schema file or its git history, from the running
+instance (`GET /api/schema`), or — for an
+auto-generated one — by re-deriving it per side from
+`(kind, peer)` sorted and lowercased. `schema check`
+will not reveal it: when the identifier differs the
+command fails with `not_supported` before printing a
+diff. To genuinely rename an identifier, remove the
 relationship (`state: absent`), load, then re-add it
 with the new identifier.
-
-Any `kind`/`cardinality` pairing is valid as long as
-both sides share one identifier and use compatible
-directions — the loader enforces no kind/cardinality
-matrix. `Component`(many) ↔ `Attribute`(one) loads
-fine, not only `Component` ↔ `Parent`.
 
 ### Field mutability on update
 
 | Field | On update |
 | --- | --- |
 | `identifier`, `direction`, `branch`, `hierarchical` | `not_supported` — remove + re-add to change |
-| `peer`, `cardinality`, `min_count`, `max_count`, `optional`, `common_parent` | `validate_constraint` — allowed if existing data conforms |
-| everything else (`name`, `kind`, `label`, …) | `allowed` |
+| `peer`, `cardinality`, `min_count`, `max_count`, `optional`, `common_parent` | `validate_constraint` — allowed only if existing data still conforms |
+| `name`, `label`, `order_weight`, … | `allowed` |
+| `kind` | `allowed` in general, but changing *into* `Parent` must satisfy the Parent constraints (`cardinality: one`, `optional: false`) or the load fails |
+| `state` | `not_applicable` — `state: absent` removes the relationship rather than updating a field |
 
 Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/infrahub-managing-schemas/rules/validation-common-errors.md
+++ b/skills/infrahub-managing-schemas/rules/validation-common-errors.md
@@ -60,6 +60,16 @@ Missing namespace in peer reference. See the
 Bidirectional relationship identifiers don't match. See the
 [relationship-identifiers](./relationship-identifiers.md) rule.
 
+### "'not_supported': <Kind> <relationship> None"
+
+An immutable relationship field (`identifier`,
+`direction`, `branch`, `hierarchical`) is being changed
+on a relationship that already exists — usually
+retrofitting an explicit `identifier` onto one first
+loaded without it. Reuse the existing identifier, or
+remove + re-add the relationship. See the
+[relationship-identifiers](./relationship-identifiers.md) rule.
+
 ### "Relationship of type parent must not be optional"
 
 A relationship with `kind: Parent` has `optional: true`

--- a/skills/infrahub-managing-schemas/validation.md
+++ b/skills/infrahub-managing-schemas/validation.md
@@ -153,6 +153,27 @@ Bidirectional relationships need matching identifiers:
   identifier: "device__interface"    # Must match
 ```
 
+### "'not_supported': &lt;Kind&gt; &lt;rel&gt; None"
+
+Some relationship fields are immutable once the
+relationship exists in the instance: `identifier`,
+`direction`, `branch`, `hierarchical`. Changing any
+of them is rejected — one entry per affected side:
+
+```text
+Unable to load the schema:
+  'not_supported': IpamL2Domain vlans None, 'not_supported': IpamVLAN l2domain None
+```
+
+Read it as `'<constraint>': <Kind> <rel> <message>`
+(trailing `None` = empty message). The usual trigger
+is adding an explicit `identifier` to a relationship
+that was first loaded without one (Infrahub
+auto-generated `sorted(kinds).lower()`). Reuse the
+existing identifier, or remove + re-add the
+relationship to change it. See
+[relationship-identifiers](./rules/relationship-identifiers.md).
+
 ### "Uniqueness constraint references unknown field"
 
 Use `__value` suffix for attributes in constraints:
@@ -211,7 +232,15 @@ Just add the node definition. No migration needed.
 ### Adding a Relationship
 
 Add the relationship to the schema. For bidirectional
-relationships, add both sides with matching `identifier`.
+relationships, add both sides with matching
+`identifier`. Set the `identifier` you want on this
+first load — it is immutable afterward. If you omit
+it, Infrahub auto-generates `sorted(kinds).lower()`
+and you are then stuck with that value (changing it
+later fails with `not_supported`). When adding an
+inverse to a relationship that already exists, reuse
+the existing side's `identifier` verbatim rather than
+inventing a new one.
 
 ### Changing Attribute Type
 
@@ -285,6 +314,7 @@ Before running `infrahubctl schema check`, verify:
       [validation-string-limits](./rules/validation-string-limits.md))
 - [ ] All relationship `peer` values use full kind (namespace + name)
 - [ ] All bidirectional relationships have matching `identifier` on both sides
+- [ ] No existing relationship's `identifier` (or `direction`/`branch`/`hierarchical`) is being changed — those are immutable and fail with `not_supported`; when adding an inverse, reuse the forward side's existing identifier
 - [ ] All Component relationships have a matching Parent on the other node
 - [ ] All hierarchical nodes inherit from a generic with `hierarchical: true`
 - [ ] Root hierarchical nodes have `parent: null`

--- a/skills/infrahub-managing-schemas/validation.md
+++ b/skills/infrahub-managing-schemas/validation.md
@@ -153,26 +153,25 @@ Bidirectional relationships need matching identifiers:
   identifier: "device__interface"    # Must match
 ```
 
-### "'not_supported': &lt;Kind&gt; &lt;rel&gt; None"
+### `'not_supported': <Kind> <relationship> None`
 
-Some relationship fields are immutable once the
-relationship exists in the instance: `identifier`,
-`direction`, `branch`, `hierarchical`. Changing any
-of them is rejected — one entry per affected side:
+`identifier`, `direction`, `branch`, and
+`hierarchical` are immutable once a relationship
+exists in the instance — changing any of them is
+rejected, one entry per affected side:
 
 ```text
 Unable to load the schema:
   'not_supported': IpamL2Domain vlans None, 'not_supported': IpamVLAN l2domain None
 ```
 
-Read it as `'<constraint>': <Kind> <rel> <message>`
-(trailing `None` = empty message). The usual trigger
-is adding an explicit `identifier` to a relationship
-that was first loaded without one (Infrahub
-auto-generated `sorted(kinds).lower()`). Reuse the
-existing identifier, or remove + re-add the
-relationship to change it. See
-[relationship-identifiers](./rules/relationship-identifiers.md).
+The usual trigger is retrofitting an explicit
+`identifier` onto a relationship first loaded without
+one. Reuse the existing identifier (or remove + re-add
+the relationship to change it). See
+[relationship-identifiers](./rules/relationship-identifiers.md)
+for how to recover the loaded value and the full
+field-mutability table.
 
 ### "Uniqueness constraint references unknown field"
 
@@ -235,9 +234,11 @@ Add the relationship to the schema. For bidirectional
 relationships, add both sides with matching
 `identifier`. Set the `identifier` you want on this
 first load — it is immutable afterward. If you omit
-it, Infrahub auto-generates `sorted(kinds).lower()`
-and you are then stuck with that value (changing it
-later fails with `not_supported`). When adding an
+it, Infrahub derives one per side from that side's
+`(kind, peer)` sorted and lowercased (e.g.
+`ipaml2domain__ipamvlan`), and you are then stuck with
+that value (changing it later fails with
+`not_supported`). When adding an
 inverse to a relationship that already exists, reuse
 the existing side's `identifier` verbatim rather than
 inventing a new one.
@@ -314,7 +315,7 @@ Before running `infrahubctl schema check`, verify:
       [validation-string-limits](./rules/validation-string-limits.md))
 - [ ] All relationship `peer` values use full kind (namespace + name)
 - [ ] All bidirectional relationships have matching `identifier` on both sides
-- [ ] No existing relationship's `identifier` (or `direction`/`branch`/`hierarchical`) is being changed — those are immutable and fail with `not_supported`; when adding an inverse, reuse the forward side's existing identifier
+- [ ] No existing relationship's immutable fields (`identifier`, `direction`, `branch`, `hierarchical`) are being changed — see [relationship-identifiers](./rules/relationship-identifiers.md)
 - [ ] All Component relationships have a matching Parent on the other node
 - [ ] All hierarchical nodes inherit from a generic with `hierarchical: true`
 - [ ] Root hierarchical nodes have `parent: null`


### PR DESCRIPTION
## What

Fixes a gap in the schema skills: following the guidance could produce the opaque `'not_supported': <Kind> <rel> None` error from `infrahubctl schema check` with nothing in the skills explaining it. Corrects the misconception that the error stems from an invalid relationship `kind`/`cardinality` pairing — it does not.

## Why

The `relationship-identifiers` rule taught that both sides of a bidirectional relationship share one `identifier`, but nothing explained the error `infrahubctl schema check` raises when you retrofit or change an identifier on a relationship that already exists in the instance. Users following the "add the matching inverse" advice in `yagni-missing-inverse-forces-python-filter` could invent a new identifier string and hit this error with no guidance.

## Ground truth (source + reproduced)

`'not_supported': <Kind> <rel> None` is a **schema-update immutability error**, not a kind/cardinality compatibility problem.

- Error emitted in `infrahub/core/models.py` (`SchemaUpdateValidationResult._process_field` → `SchemaUpdateValidationError.to_string`), only for **changed** relationship properties.
- The relationship fields marked `update: not_supported` in `relationship_schema.py` are exactly `identifier`, `direction`, `branch`, `hierarchical`. `kind`, `cardinality`, `optional` are mutable.
- Omitting `identifier` auto-generates `"__".join(sorted([node_kind, peer_kind])).lower()` (`schema_branch.py`). A separate `validate_identifiers()` enforces only **direction** compatibility — never kind/cardinality.

Reproduced against a live Infrahub v1.10.5 instance with `infrahubctl schema check`:

1. Changing an existing relationship's identifier → verbatim `'not_supported': IpamL2Domain vlans None, 'not_supported': IpamVLAN l2domain None`.
2. Same schema keeping the existing identifier (even flipping `optional` true→false) → **Valid**.
3. Brand-new kinds with the identical `Component`(many) ↔ `Attribute`(one) pairing and an explicit shared identifier → **Valid** (the pairing is fine when created fresh).

The two "identical" pairings in the original report behaved differently only because one relationship already existed in the instance with a different (auto-generated) identifier — history, not pairing.

## Changes

- **`skills/infrahub-managing-schemas/rules/relationship-identifiers.md`** — sections on identifier auto-generation and "the identifier is immutable once loaded" (error signature, trigger, and fix, all via `infrahubctl` only), a one-line statement that any `kind`/`cardinality` pairing is valid given a shared identifier, and a field-mutability reference table.
- **`skills/infrahub-managing-schemas/validation.md`** — `not_supported` entry under Common Validation Errors, an "Adding a Relationship" caveat, and a pre-validation checklist item.
- **`skills/infrahub-auditing-repo/rules/yagni-missing-inverse-forces-python-filter.md`** — reuse the forward side's existing identifier when adding an inverse.
- **`skills/infrahub-auditing-repo/rules/schema-relationships.md`** — immutability note + Common-Issues bullet.

Skill guidance only — no runtime/code behavior changes. Skill content stays terse (`infrahubctl` only, no REST API or implementation source paths); the source citations above are the verification trail for reviewers, not part of the skill prose. Version bump is handled automatically on merge from the `changes/patch` label.
