### PR TITLE
docs(agents): load dev guides on demand instead of @-importing them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,26 +10,28 @@ The repository is a pure Markdown-based skills project (no Python code). Each sk
 
 ## Project Structure
 
-@dev/knowledges/architecture.md
+Read [dev/knowledges/architecture.md](dev/knowledges/architecture.md) for the component architecture, the progressive-disclosure model, the rule/eval systems, and the design decisions behind them.
 
 ## Getting Started
 
-@dev/guides/getting-started.md
+Read [dev/guides/getting-started.md](dev/guides/getting-started.md) for installation options, the typical workflow, and verification steps.
 
 ## Development Guides
 
-@dev/guides/adding-a-skill.md
-@dev/guides/adding-a-rule.md
-@dev/guides/running-evals.md
+Read the guide that matches the task before starting work:
+
+- [dev/guides/adding-a-skill.md](dev/guides/adding-a-skill.md) — creating a new skill (anatomy, SKILL.md, rules, evals, registration)
+- [dev/guides/adding-a-rule.md](dev/guides/adding-a-rule.md) — adding or tightening a rule; required reading for the Rule = Test workflow below
+- [dev/guides/running-evals.md](dev/guides/running-evals.md) — running skillgrade evals, writing graders and eval prompts
 
 ## Domain Knowledge
 
-@dev/knowledges/skill-writing-guide.md
-@dev/knowledges/infrahub-concepts.md
+- [dev/knowledges/skill-writing-guide.md](dev/knowledges/skill-writing-guide.md) — how to write effective skills: descriptions, rule structure, examples, common pitfalls
+- [dev/knowledges/infrahub-concepts.md](dev/knowledges/infrahub-concepts.md) — Infrahub concepts skill authors need: schema, relationships, metadata, proposed changes
 
 ## Custom Commands
 
-@dev/commands/
+AI command definitions live in [dev/commands/](dev/commands/).
 
 ## Quick Reference
 
@@ -48,18 +50,6 @@ The repository is a pure Markdown-based skills project (no Python code). Each sk
 | `infrahub-reporting-issues` | `skills/infrahub-reporting-issues/` | Route and prepare bug/feature reports for any opsmill/infrahub-* repo |
 | `infrahub-collecting-diagnostics` | `skills/infrahub-collecting-diagnostics/` | Collect a redacted local diagnostic bundle via the infrahub-collect tool (logs, config, version, state) for OpsMill expert hand-off |
 | `infrahub-importing-data` | `skills/infrahub-importing-data/` | Convert CSV/TSV inputs into Infrahub object YAML and load onto a fresh branch |
-
-### Key Directories
-
-- `skills/` — Skill definitions with rules, examples, and references
-- `eval.yaml` — skillgrade eval config (all skills)
-- `evaluations/` — Auto-generated JSON eval files (regenerate with `python scripts/sync-evals.py` after editing `eval.yaml`)
-- `graders/` — Deterministic grader scripts per skill
-- `skills/infrahub-common/` — Shared references and cross-cutting rules
-- `hooks/` — Hook definitions for Infrahub project detection
-- `scripts/` — Utility scripts (`sync-versions.sh`, `sync-evals.py`)
-- `dev/` — Development guides, domain knowledge, and AI commands
-- `.claude-plugin/` — Plugin manifest
 
 ### Rule = Test (Required)
 


### PR DESCRIPTION
### What

`AGENTS.md` force-loaded eight `dev/` files via `@`-imports — ~50 KB (est. ~12.5k tokens) injected into **every** AI session in this repo, before any work starts. This PR converts those imports to plain links with "read this when…" pointers, so each guide loads only when the task actually needs it, and drops the "Key Directories" list (reconstructible with one `ls`).

### What stays always-loaded

The conventions a session cannot derive from the tree:

- Repository Overview
- Development Guides / Domain Knowledge pointers (one line each)
- Skills Quick Reference table
- **Rule = Test (Required)** — kept resident on purpose; the full walkthrough link to `dev/guides/adding-a-rule.md` is unchanged
- Versioning

### Impact

Always-loaded project memory drops from ~50.1 KB to ~4.5 KB (est. ~12.5k → ~1.1k tokens per session). No content is deleted — every guide is untouched and one link away; only the loading behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
