### PR TITLE
feat(auditing-repo): add yagni-untyped-python-vs-generated-protocols rule + protocols adoption guidance

### DIFF
--- a/eval.yaml
+++ b/eval.yaml
@@ -3019,6 +3019,69 @@ tasks:
       - name: severity-cap
         check: No yagni finding exceeds MEDIUM severity
 
+  - name: yagni-untyped-protocols
+    instruction: |
+      Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and
+      walk Phase 9. Emit JSON findings to output.json (same shape as
+      yagni-python-validator).
+
+      Audit this generator (generators/generate_tenant.py). A generated
+      protocol module already exists at src/protocols.py and defines
+      IpamIPAddress, NetworkDevice, and NetworkInterface.
+
+      ```python
+      from infrahub_sdk.generator import InfrahubGenerator
+      from src.protocols import NetworkDevice, NetworkInterface
+
+      class GenerateTenant(InfrahubGenerator):
+          async def generate(self, data: dict) -> None:
+              for t in data["Tenant"]["edges"]:
+                  node = t["node"]
+                  device = await self.client.create(
+                      NetworkDevice,
+                      hostname=node["name"]["value"],
+                      role="leaf",
+                  )
+                  await device.save()
+                  # untyped string kind, though IpamIPAddress is generated
+                  gateway = await self.client.create(
+                      kind="IpamIPAddress",
+                      address=node["gateway"]["value"],
+                      description=node["descr"]["value"],
+                  )
+                  await gateway.save()
+                  ifaces = await self.client.filters(
+                      kind="NetworkInterface",
+                      device__ids=[device.id],
+                  )
+      ```
+
+      Save ONLY the JSON findings to: output.json
+    graders:
+      - type: deterministic
+        run: python graders/auditing-repo/check_yagni_rule.py yagni-untyped-python-vs-generated-protocols LOW 7
+        weight: 1.0
+    expected_output: >-
+      JSON listing a yagni-untyped-python-vs-generated-protocols finding with
+      severity LOW and ladder_step 7, pointing at the kind="IpamIPAddress"
+      (and kind="NetworkInterface") calls. The already-typed NetworkDevice
+      create call is not flagged.
+    expectations:
+      - Output is JSON with a findings array (or an object with a findings key)
+      - Contains a yagni-untyped-python-vs-generated-protocols finding
+      - That finding has severity LOW and ladder_step 7
+      - The already-typed NetworkDevice create call is NOT flagged
+      - No yagni finding exceeds MEDIUM severity
+    assertions:
+      - name: finding-present
+        check: A yagni-untyped-python-vs-generated-protocols finding is emitted
+      - name: correct-severity
+        check: The yagni-untyped-python-vs-generated-protocols finding has severity LOW
+      - name: correct-ladder-step
+        check: The yagni-untyped-python-vs-generated-protocols finding has ladder_step 7
+      - name: severity-cap
+        check: No yagni finding exceeds MEDIUM severity
+
   - name: yagni-generator-hardcoding
     instruction: |
       Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and
@@ -3736,7 +3799,7 @@ tasks:
       ladder_step ascending (cheapest fix on top), then by file path.
 
       Audit this minimal repo, which deliberately exhibits one of each
-      yagni-* violation. Emit ALL fifteen yagni findings and order them
+      yagni-* violation. Emit ALL sixteen yagni findings and order them
       correctly.
 
       For each artifact, the violation shape and expected rule:
@@ -3790,6 +3853,11 @@ tasks:
           purpose is to push shared timezone/syslog_server VALUES onto
           every cloned device (no distinct child components) →
           yagni-template-profile-confusion (step 3).
+      15. generators/provision_hosts.py — a generated src/protocols.py
+          defines IpamIPAddress, but the generator still calls
+          client.create(kind="IpamIPAddress", ...) with a bare string kind
+          across several attributes → yagni-untyped-python-vs-generated-protocols
+          (step 7).
 
       Save ONLY the JSON findings to: output.json
     graders:
@@ -3797,18 +3865,18 @@ tasks:
         run: python graders/auditing-repo/check_yagni_findings_sorted.py
         weight: 1.0
     expected_output: >-
-      JSON with fifteen findings, one per yagni-* rule above, ordered
-      ascending by ladder_step (1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 6)
+      JSON with sixteen findings, one per yagni-* rule above, ordered
+      ascending by ladder_step (1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 6, 7)
       and then by file path within each step.
     expectations:
       - Output is JSON with a findings array (or an object with a findings key)
-      - All fifteen yagni-* rules are represented, one finding each
+      - All sixteen yagni-* rules are represented, one finding each
       - Findings are ordered by ladder_step ascending, then by file path
       - No yagni finding exceeds MEDIUM severity
     assertions:
-      - name: all-fifteen-present
+      - name: all-sixteen-present
         check: >-
-          One finding is emitted for each of the fifteen yagni-* rules
+          One finding is emitted for each of the sixteen yagni-* rules
       - name: sorted-by-ladder-then-file
         check: >-
           Findings are ordered by (ladder_step, file path) ascending

--- a/evaluations/infrahub-auditing-repo.json
+++ b/evaluations/infrahub-auditing-repo.json
@@ -93,6 +93,37 @@
     },
     {
       "id": 4,
+      "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json (same shape as\nyagni-python-validator).\n\nAudit this generator (generators/generate_tenant.py). A generated\nprotocol module already exists at src/protocols.py and defines\nIpamIPAddress, NetworkDevice, and NetworkInterface.\n\n```python\nfrom infrahub_sdk.generator import InfrahubGenerator\nfrom src.protocols import NetworkDevice, NetworkInterface\n\nclass GenerateTenant(InfrahubGenerator):\n    async def generate(self, data: dict) -> None:\n        for t in data[\"Tenant\"][\"edges\"]:\n            node = t[\"node\"]\n            device = await self.client.create(\n                NetworkDevice,\n                hostname=node[\"name\"][\"value\"],\n                role=\"leaf\",\n            )\n            await device.save()\n            # untyped string kind, though IpamIPAddress is generated\n            gateway = await self.client.create(\n                kind=\"IpamIPAddress\",\n                address=node[\"gateway\"][\"value\"],\n                description=node[\"descr\"][\"value\"],\n            )\n            await gateway.save()\n            ifaces = await self.client.filters(\n                kind=\"NetworkInterface\",\n                device__ids=[device.id],\n            )\n```\n\nSave ONLY the JSON findings to: output.json",
+      "expected_output": "JSON listing a yagni-untyped-python-vs-generated-protocols finding with severity LOW and ladder_step 7, pointing at the kind=\"IpamIPAddress\" (and kind=\"NetworkInterface\") calls. The already-typed NetworkDevice create call is not flagged.",
+      "files": [],
+      "expectations": [
+        "Output is JSON with a findings array (or an object with a findings key)",
+        "Contains a yagni-untyped-python-vs-generated-protocols finding",
+        "That finding has severity LOW and ladder_step 7",
+        "The already-typed NetworkDevice create call is NOT flagged",
+        "No yagni finding exceeds MEDIUM severity"
+      ],
+      "assertions": [
+        {
+          "name": "finding-present",
+          "check": "A yagni-untyped-python-vs-generated-protocols finding is emitted"
+        },
+        {
+          "name": "correct-severity",
+          "check": "The yagni-untyped-python-vs-generated-protocols finding has severity LOW"
+        },
+        {
+          "name": "correct-ladder-step",
+          "check": "The yagni-untyped-python-vs-generated-protocols finding has ladder_step 7"
+        },
+        {
+          "name": "severity-cap",
+          "check": "No yagni finding exceeds MEDIUM severity"
+        }
+      ]
+    },
+    {
+      "id": 5,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit these two generators:\n\nFile generators/device_roles.py (production path):\n```python\nfrom infrahub_sdk.generator import InfrahubGenerator\n\nROLES = [\n    {\"name\": \"spine\", \"description\": \"spine switch\"},\n    {\"name\": \"leaf\", \"description\": \"leaf switch\"},\n    {\"name\": \"edge\", \"description\": \"edge router\"},\n]\n\nclass DeviceRolesGenerator(InfrahubGenerator):\n    async def generate(self, data):\n        for r in ROLES:\n            obj = await self.client.create(kind=\"DcimRole\", data=r)\n            await obj.save(allow_upsert=True)\n```\n\nFile bootstrap/seed_statuses.py (initial seed):\n```python\nfrom infrahub_sdk.generator import InfrahubGenerator\n\nSTATUSES = [\n    {\"name\": \"active\"}, {\"name\": \"draft\"}, {\"name\": \"retired\"},\n]\n\nclass SeedStatuses(InfrahubGenerator):\n    async def generate(self, data):\n        for s in STATUSES:\n            obj = await self.client.create(kind=\"DcimStatus\", data=s)\n            await obj.save(allow_upsert=True)\n```\n\nImportant: the audit must NOT flag the bootstrap/ file (see \"What\nNOT to flag\" in the rule).\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON listing one yagni-generator-hardcoding-data finding for generators/device_roles.py (severity MEDIUM, ladder_step 2). No finding should be emitted for bootstrap/seed_statuses.py.",
       "files": [],
@@ -127,7 +158,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this schema (schemas/dcim.yml):\n\n```yaml\nversion: \"1.0\"\nnodes:\n  - name: Device\n    namespace: Dcim\n    attributes:\n      - name: name\n        kind: Text\n      - name: region_code\n        kind: Text\n    relationships:\n      - name: location\n        peer: LocationSite\n        kind: Attribute\n        cardinality: one\n        identifier: device__location\n  - name: Site\n    namespace: Location\n    attributes:\n      - name: name\n        kind: Text\n      - name: region_code\n        kind: Text\n    relationships:\n      - name: region\n        peer: LocationRegion\n        kind: Parent\n        cardinality: one\n        identifier: site__region\n```\n\n`region_code` is denormalized onto `DcimDevice` when\n`device.location.region.code` is the canonical path.\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON listing one yagni-denormalized-vs-indirect-relationship finding with severity LOW and ladder_step 4. Replacement points to traversing device.location.region.code.",
       "files": [],
@@ -157,7 +188,7 @@
       ]
     },
     {
-      "id": 6,
+      "id": 7,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this schema (schemas/devices.yml) \u2014 five device nodes each\nrepeating the same six attributes:\n\n```yaml\nversion: \"1.0\"\nnodes:\n  - name: DeviceSpine\n    namespace: Dcim\n    attributes:\n      - {name: name, kind: Text}\n      - {name: serial, kind: Text}\n      - {name: model, kind: Text}\n      - {name: vendor, kind: Text}\n      - {name: status, kind: Dropdown, choices: [{name: active}, {name: draft}]}\n      - {name: notes, kind: Text, optional: true}\n  - name: DeviceLeaf\n    namespace: Dcim\n    attributes:\n      - {name: name, kind: Text}\n      - {name: serial, kind: Text}\n      - {name: model, kind: Text}\n      - {name: vendor, kind: Text}\n      - {name: status, kind: Dropdown, choices: [{name: active}, {name: draft}]}\n      - {name: notes, kind: Text, optional: true}\n  - name: DeviceEdge\n    namespace: Dcim\n    attributes:\n      - {name: name, kind: Text}\n      - {name: serial, kind: Text}\n      - {name: model, kind: Text}\n      - {name: vendor, kind: Text}\n      - {name: status, kind: Dropdown, choices: [{name: active}, {name: draft}]}\n      - {name: notes, kind: Text, optional: true}\n```\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON listing one yagni-duplicate-shape-not-extracted-to-generic finding with severity MEDIUM and ladder_step 2. Replacement points to a shared DeviceCommon generic.",
       "files": [],
@@ -187,7 +218,7 @@
       ]
     },
     {
-      "id": 7,
+      "id": 8,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this schema (schemas/ipam.yml) \u2014 defines custom IP-address\nand VLAN nodes without inheriting from the Infrahub built-in\nprimitives:\n\n```yaml\nversion: \"1.0\"\nnodes:\n  - name: IPAddress\n    namespace: Net\n    attributes:\n      - {name: address, kind: Text}\n      - {name: description, kind: Text, optional: true}\n  - name: Vlan\n    namespace: Net\n    attributes:\n      - {name: vlan_id, kind: Number}\n      - {name: name, kind: Text}\n```\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON listing one yagni-custom-domain-primitives-instead-of-builtin finding with severity MEDIUM and ladder_step 2. Replacement should reference BuiltinIPAddress / IpamIPAddress and IpamVLAN.",
       "files": [],
@@ -217,7 +248,7 @@
       ]
     },
     {
-      "id": 8,
+      "id": 9,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this schema (schemas/dcim.yml). The forward\n`Interface.device` rel is `kind: Attribute, cardinality: one` but\n`Device` declares no inverse \u2014 consumers with an interface in hand\nhave no way to traverse back to its device without filtering.\n\n```yaml\nversion: \"1.0\"\nnodes:\n  - name: Device\n    namespace: Dcim\n    attributes:\n      - {name: name, kind: Text}\n    # no `interfaces` relationship declared\n  - name: Interface\n    namespace: Dcim\n    attributes:\n      - {name: name, kind: Text}\n    relationships:\n      - name: device\n        peer: DcimDevice\n        kind: Attribute\n        cardinality: one\n        identifier: device__interfaces\n```\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON listing one yagni-missing-inverse-forces-python-filter finding with severity MEDIUM and ladder_step 3.",
       "files": [],
@@ -247,7 +278,7 @@
       ]
     },
     {
-      "id": 9,
+      "id": 10,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this generator. The `.gql` references the trigger group\n`CoreGeneratorGroup` and the Python contains a focal-exclude loop\n\u2014 both signatures of cascade-shape.\n\nFile generators/pop_designs.py:\n```python\nfrom infrahub_sdk.generator import InfrahubGenerator\n\nclass PopDesignsGenerator(InfrahubGenerator):\n    query = \"pop_designs_query\"\n\n    async def generate(self, data):\n        for design in data[\"TopologyPopDesign\"][\"edges\"]:\n            if design[\"node\"][\"name\"][\"value\"] == self.focal.name.value:\n                continue\n            # ...\n```\n\nFile queries/pop_designs_query.gql:\n```graphql\nquery {\n  CoreGeneratorGroup(name__value: \"pop_designs\") { edges { node { id } } }\n  TopologyPopDesign { edges { node { name { value } } } }\n}\n```\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON listing one yagni-generator-query-shape-too-broad finding with severity LOW and ladder_step 4. Either or both of the cascade-shape signatures (CoreGeneratorGroup in query, focal- exclude loop) should be cited in the replacement.",
       "files": [],
@@ -277,7 +308,7 @@
       ]
     },
     {
-      "id": 10,
+      "id": 11,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit these two generators:\n\nFile generators/provision_circuit.py (production path):\n```python\nimport ipaddress\nimport random\nfrom infrahub_sdk.generator import InfrahubGenerator\n\nclass ProvisionCircuit(InfrahubGenerator):\n    query = \"circuit_request\"\n\n    async def generate(self, data):\n        req = data[\"CircuitRequest\"][\"edges\"][0][\"node\"]\n\n        # VLANs already come from a pool \u2014 this part is fine.\n        vlan = await self.client.allocate_next_ip_prefix(\n            resource_pool=\"circuit_vlan_pool\"\n        )\n\n        # Subnet: hand-split a /30 out of the parent block.\n        parent = ipaddress.ip_network(req[\"block\"][\"value\"])\n        child = next(parent.subnets(new_prefix=30))\n        await (await self.client.create(\n            kind=\"IpamIPPrefix\", data={\"prefix\": str(child)}\n        )).save(allow_upsert=True)\n\n        # Port: roll a switch and scan peers for the first free one.\n        switch_index = random.randint(1, 2)\n        switch = req[\"switches\"][\"edges\"][switch_index][\"node\"]\n        port = next(\n            (p for p in switch[\"interfaces\"][\"edges\"]\n             if p[\"node\"][\"status\"][\"value\"] == \"free\"),\n            None,\n        )\n```\n\nFile generators/router_id.py (legitimate derivation):\n```python\nimport ipaddress\nfrom infrahub_sdk.generator import InfrahubGenerator\n\nclass RouterId(InfrahubGenerator):\n    async def generate(self, data):\n        # router-id must EQUAL the loopback address \u2014 a deterministic\n        # derivation, not a \"next free\" allocation. Do not flag.\n        loopback = data[\"Device\"][\"edges\"][0][\"node\"][\"loopback\"][\"value\"]\n        router_id = str(ipaddress.ip_interface(loopback).ip)\n        # ... set router_id on the device, no IPAM object created ...\n```\n\nImportant: the audit must NOT flag generators/router_id.py \u2014 it\nderives a value deterministically and persists no allocation (see\n\"What NOT to flag\" in the rule).\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON listing one yagni-imperative-allocation-vs-resource-pool finding for generators/provision_circuit.py (severity MEDIUM, ladder_step 2), citing the subnet math and/or the random port scan and pointing at Infrahub resource pools (CoreIPPrefixPool / CoreNumberPool / allocate_next_ip_*). No finding should be emitted for generators/router_id.py.",
       "files": [],
@@ -317,7 +348,7 @@
       ]
     },
     {
-      "id": 11,
+      "id": 12,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit these two schema files:\n\nschemas/dcim.yml:\n```yaml\nversion: \"1.0\"\nnodes:\n  - name: Device\n    namespace: Dcim\n    attributes:\n      - {name: name, kind: Text}\n      - {name: serial, kind: Text, optional: true}\n    relationships:\n      - name: interfaces\n        peer: DcimInterface\n        cardinality: many\n        kind: Component\n        identifier: device__interfaces\n      - name: rack\n        peer: DcimRack\n        cardinality: one\n        kind: Attribute\n        identifier: device__rack\n  - name: Interface\n    namespace: Dcim\n    attributes:\n      - {name: name, kind: Text}\n      - {name: speed, kind: Number, optional: true}\n  - name: Rack\n    namespace: Dcim\n    attributes:\n      - {name: name, kind: Text}\n      - {name: height, kind: Number, optional: true}\n```\n\nschemas/location.yml:\n```yaml\n# Pulled with: infrahubctl marketplace get infrahub/location\nversion: \"1.0\"\nnodes:\n  - name: Region\n    namespace: Location\n    inherit_from: [LocationGeneric]\n    attributes:\n      - {name: name, kind: Text}\n  - name: Site\n    namespace: Location\n    inherit_from: [LocationGeneric]\n    attributes:\n      - {name: name, kind: Text}\n      - {name: facility_code, kind: Text, optional: true}\n```\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON listing exactly one yagni-reuse-existing-marketplace-schema finding, attributed to schemas/dcim.yml, with severity MEDIUM and ladder_step 1. schemas/location.yml must NOT be flagged \u2014 it is pulled via `infrahubctl marketplace get` and inherits from a marketplace generic, which is the reuse pattern the rule wants. The replacement should recommend `infrahubctl marketplace get` of the DCIM schema and inheriting from its generics rather than hand-rolling.",
       "files": [],
@@ -352,7 +383,7 @@
       ]
     },
     {
-      "id": 12,
+      "id": 13,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this schema and profile data:\n\nschemas/dcim.yml:\n```yaml\nversion: \"1.0\"\nnodes:\n  - name: Device\n    namespace: Dcim\n    generate_profile: true\n    attributes:\n      - name: name\n        kind: Text\n      - name: timezone\n        kind: Text\n        optional: true\n```\n\nobjects/profiles.yml (the only Profile for DcimDevice, and its\ntimezone value is the same constant every device would use):\n```yaml\napiVersion: infrahub.app/v1\nkind: Object\nspec:\n  kind: ProfileDcimDevice\n  data:\n    - profile_name: global-timezone\n      timezone: UTC\n```\n\nThere is exactly one Profile and its value never varies across\nobjects \u2014 a plain default_value would cover it.\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON with one yagni-profile-over-default finding (severity MEDIUM, ladder_step 2) pointing at the single-value Profile, recommending an attribute default_value instead.",
       "files": [],
@@ -360,7 +391,7 @@
       "assertions": []
     },
     {
-      "id": 13,
+      "id": 14,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this generator:\n\nFile generators/leaf_ports.py (production path):\n```python\nfrom infrahub_sdk.generator import InfrahubGenerator\n\nclass LeafPortsGenerator(InfrahubGenerator):\n    async def generate(self, data):\n        device = await self.client.create(kind=\"DcimDevice\", data={\"name\": \"leaf-new\"})\n        await device.save(allow_upsert=True)\n        for i in range(1, 49):\n            port = await self.client.create(\n                kind=\"DcimInterface\",\n                data={\"name\": f\"Ethernet1/{i}\", \"device\": device, \"speed\": 10000},\n            )\n            await port.save(allow_upsert=True)\n```\n\nThe generator always builds the same fixed 48-port leaf with constant\nspeed and no dependence on input data \u2014 a curated Object Template that\nusers clone would replace it.\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON with one yagni-generator-that-should-be-template finding (severity MEDIUM, ladder_step 2) for generators/leaf_ports.py, recommending an Object Template + clone instead of the imperative generator.",
       "files": [],
@@ -368,7 +399,7 @@
       "assertions": []
     },
     {
-      "id": 14,
+      "id": 15,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this repo excerpt:\n\nschemas/dcim.yml:\n```yaml\nversion: \"1.0\"\nnodes:\n  - name: Device\n    namespace: Dcim\n    generate_profile: true\n    generate_template: true\n    attributes:\n      - name: name\n        kind: Text\n```\n\nThe repo contains NO Profile instances, no profiles: assignments, no\ntemplate instances, and no object_template references anywhere in\nobjects/ \u2014 both flags are enabled but unused.\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON with a yagni-unused-generate-flag finding (severity MEDIUM, ladder_step 3) for the Device node whose generate_profile / generate_template flags have no consumer in the repo.",
       "files": [],
@@ -376,7 +407,7 @@
       "assertions": []
     },
     {
-      "id": 15,
+      "id": 16,
       "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json.\n\nAudit this setup:\n\nschemas/dcim.yml:\n```yaml\nversion: \"1.0\"\nnodes:\n  - name: Device\n    namespace: Dcim\n    generate_template: true\n    attributes:\n      - name: name\n        kind: Text\n      - name: timezone\n        kind: Text\n        optional: true\n      - name: syslog_server\n        kind: Text\n        optional: true\n```\n\nobjects/templates.yml \u2014 a set of object templates whose ONLY purpose is\nto carry the same shared timezone and syslog_server values onto every\ncloned device (no distinct child components), so operators clone a\ntemplate just to get shared defaults:\n```yaml\napiVersion: infrahub.app/v1\nkind: Object\nspec:\n  kind: TemplateDcimDevice\n  data:\n    - template_name: standard-defaults\n      timezone: UTC\n      syslog_server: 10.0.0.53\n```\n\nThe template is being used to distribute shared VALUES that should be a\nProfile (they must stay in sync across devices), not to clone structure.\n\nSave ONLY the JSON findings to: output.json",
       "expected_output": "JSON with one yagni-template-profile-confusion finding (severity MEDIUM, ladder_step 3) noting the Object Template is pushing shared values that belong in a Profile.",
       "files": [],
@@ -384,20 +415,20 @@
       "assertions": []
     },
     {
-      "id": 16,
-      "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json sorted by\nladder_step ascending (cheapest fix on top), then by file path.\n\nAudit this minimal repo, which deliberately exhibits one of each\nyagni-* violation. Emit ALL fifteen yagni findings and order them\ncorrectly.\n\nFor each artifact, the violation shape and expected rule:\n\n0. schemas/circuits.yml \u2014 hand-rolls a full circuits domain\n   (Circuit, CircuitEndpoint, Provider) from scratch with no\n   `infrahubctl marketplace get` provenance for the circuits\n   schema published on the Infrahub Marketplace \u2192\n   yagni-reuse-existing-marketplace-schema (step 1).\n1. schemas/devices.yml \u2014 five sibling DcimDevice* nodes sharing\n   attributes \u2192 yagni-duplicate-shape-not-extracted-to-generic\n   (step 2).\n2. generators/device_roles.py \u2014 module-level ROLES list of dicts\n   \u2192 yagni-generator-hardcoding-data (step 2).\n3. schemas/ipam.yml \u2014 custom NetIPAddress/NetVlan without\n   inheriting Builtin/Ipam primitives \u2192\n   yagni-custom-domain-primitives-instead-of-builtin (step 2).\n4. generators/provision_circuit.py \u2014 hand-splits a /30 subnet and\n   random-scans ports instead of using a resource pool \u2192\n   yagni-imperative-allocation-vs-resource-pool (step 2).\n5. checks/check_vpn_unique.py \u2014 uniqueness check that could be\n   uniqueness_constraints \u2192\n   yagni-python-validator-vs-schema-constraint (step 3).\n6. schemas/dcim-interfaces.yml \u2014 `Interface.device` rel without\n   a matching inverse on `Device` \u2192\n   yagni-missing-inverse-forces-python-filter (step 3).\n7. schemas/dcim.yml \u2014 `Device.region_code` denormalized when\n   `device.location.region.code` exists \u2192\n   yagni-denormalized-vs-indirect-relationship (step 4).\n8. generators/pop_designs.py + queries/pop_designs.gql \u2014\n   CoreGeneratorGroup in data query + focal-exclude loop \u2192\n   yagni-generator-query-shape-too-broad (step 4).\n9. transforms/interface_config.py \u2014 pure string formatting that\n   Jinja2 would express \u2192\n   yagni-python-transform-that-could-be-jinja2 (step 5).\n10. checks/check_no_unmanaged_devices.py \u2014 GraphQL already\n   filters; Python is `for x in edges: log_error` \u2192\n   yagni-redundant-check-that-graphql-can-answer (step 6).\n11. objects/device_profiles.yml \u2014 the only Profile for DcimDevice,\n    carrying a single never-varying value (timezone: UTC) that a\n    default_value would cover \u2192 yagni-profile-over-default (step 2).\n12. generators/leaf_ports.py \u2014 generate() always builds the same\n    fixed 48-port leaf with constant speed and no dependence on\n    input data \u2192 yagni-generator-that-should-be-template (step 2).\n13. schemas/access.yml \u2014 AccessPolicy sets generate_profile and\n    generate_template, but no ProfileAccessPolicy/TemplateAccessPolicy\n    instances, `profiles:` assignments, or object_template references\n    exist for it anywhere in the repo \u2192\n    yagni-unused-generate-flag (step 3).\n14. objects/device_templates.yml \u2014 an Object Template whose only\n    purpose is to push shared timezone/syslog_server VALUES onto\n    every cloned device (no distinct child components) \u2192\n    yagni-template-profile-confusion (step 3).\n\nSave ONLY the JSON findings to: output.json",
-      "expected_output": "JSON with fifteen findings, one per yagni-* rule above, ordered ascending by ladder_step (1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 6) and then by file path within each step.",
+      "id": 17,
+      "prompt": "Read the skill at .agents/skills/infrahub-auditing-repo/SKILL.md and\nwalk Phase 9. Emit JSON findings to output.json sorted by\nladder_step ascending (cheapest fix on top), then by file path.\n\nAudit this minimal repo, which deliberately exhibits one of each\nyagni-* violation. Emit ALL sixteen yagni findings and order them\ncorrectly.\n\nFor each artifact, the violation shape and expected rule:\n\n0. schemas/circuits.yml \u2014 hand-rolls a full circuits domain\n   (Circuit, CircuitEndpoint, Provider) from scratch with no\n   `infrahubctl marketplace get` provenance for the circuits\n   schema published on the Infrahub Marketplace \u2192\n   yagni-reuse-existing-marketplace-schema (step 1).\n1. schemas/devices.yml \u2014 five sibling DcimDevice* nodes sharing\n   attributes \u2192 yagni-duplicate-shape-not-extracted-to-generic\n   (step 2).\n2. generators/device_roles.py \u2014 module-level ROLES list of dicts\n   \u2192 yagni-generator-hardcoding-data (step 2).\n3. schemas/ipam.yml \u2014 custom NetIPAddress/NetVlan without\n   inheriting Builtin/Ipam primitives \u2192\n   yagni-custom-domain-primitives-instead-of-builtin (step 2).\n4. generators/provision_circuit.py \u2014 hand-splits a /30 subnet and\n   random-scans ports instead of using a resource pool \u2192\n   yagni-imperative-allocation-vs-resource-pool (step 2).\n5. checks/check_vpn_unique.py \u2014 uniqueness check that could be\n   uniqueness_constraints \u2192\n   yagni-python-validator-vs-schema-constraint (step 3).\n6. schemas/dcim-interfaces.yml \u2014 `Interface.device` rel without\n   a matching inverse on `Device` \u2192\n   yagni-missing-inverse-forces-python-filter (step 3).\n7. schemas/dcim.yml \u2014 `Device.region_code` denormalized when\n   `device.location.region.code` exists \u2192\n   yagni-denormalized-vs-indirect-relationship (step 4).\n8. generators/pop_designs.py + queries/pop_designs.gql \u2014\n   CoreGeneratorGroup in data query + focal-exclude loop \u2192\n   yagni-generator-query-shape-too-broad (step 4).\n9. transforms/interface_config.py \u2014 pure string formatting that\n   Jinja2 would express \u2192\n   yagni-python-transform-that-could-be-jinja2 (step 5).\n10. checks/check_no_unmanaged_devices.py \u2014 GraphQL already\n   filters; Python is `for x in edges: log_error` \u2192\n   yagni-redundant-check-that-graphql-can-answer (step 6).\n11. objects/device_profiles.yml \u2014 the only Profile for DcimDevice,\n    carrying a single never-varying value (timezone: UTC) that a\n    default_value would cover \u2192 yagni-profile-over-default (step 2).\n12. generators/leaf_ports.py \u2014 generate() always builds the same\n    fixed 48-port leaf with constant speed and no dependence on\n    input data \u2192 yagni-generator-that-should-be-template (step 2).\n13. schemas/access.yml \u2014 AccessPolicy sets generate_profile and\n    generate_template, but no ProfileAccessPolicy/TemplateAccessPolicy\n    instances, `profiles:` assignments, or object_template references\n    exist for it anywhere in the repo \u2192\n    yagni-unused-generate-flag (step 3).\n14. objects/device_templates.yml \u2014 an Object Template whose only\n    purpose is to push shared timezone/syslog_server VALUES onto\n    every cloned device (no distinct child components) \u2192\n    yagni-template-profile-confusion (step 3).\n15. generators/provision_hosts.py \u2014 a generated src/protocols.py\n    defines IpamIPAddress, but the generator still calls\n    client.create(kind=\"IpamIPAddress\", ...) with a bare string kind\n    across several attributes \u2192 yagni-untyped-python-vs-generated-protocols\n    (step 7).\n\nSave ONLY the JSON findings to: output.json",
+      "expected_output": "JSON with sixteen findings, one per yagni-* rule above, ordered ascending by ladder_step (1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 6, 7) and then by file path within each step.",
       "files": [],
       "expectations": [
         "Output is JSON with a findings array (or an object with a findings key)",
-        "All fifteen yagni-* rules are represented, one finding each",
+        "All sixteen yagni-* rules are represented, one finding each",
         "Findings are ordered by ladder_step ascending, then by file path",
         "No yagni finding exceeds MEDIUM severity"
       ],
       "assertions": [
         {
-          "name": "all-fifteen-present",
-          "check": "One finding is emitted for each of the fifteen yagni-* rules"
+          "name": "all-sixteen-present",
+          "check": "One finding is emitted for each of the sixteen yagni-* rules"
         },
         {
           "name": "sorted-by-ladder-then-file",

--- a/graders/auditing-repo/check_yagni_findings_sorted.py
+++ b/graders/auditing-repo/check_yagni_findings_sorted.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Grader: assert all 15 yagni-* findings emit sorted by ladder_step ascending.
+"""Grader: assert all 16 yagni-* findings emit sorted by ladder_step ascending.
 
 Companion to the per-rule graders. The fixture for this task contains
-violations of all 15 yagni-* rules; the auditor must emit them in
+violations of all 16 yagni-* rules; the auditor must emit them in
 ascending ladder_step order (cheapest fix on top).
 """
 
@@ -35,6 +35,7 @@ ALL_RULES = [
     ("yagni-generator-query-shape-too-broad", 4, "LOW"),
     ("yagni-python-transform-that-could-be-jinja2", 5, "LOW"),
     ("yagni-redundant-check-that-graphql-can-answer", 6, "LOW"),
+    ("yagni-untyped-python-vs-generated-protocols", 7, "LOW"),
 ]
 
 CHECKS: list[str] = []

--- a/graders/auditing-repo/check_yagni_findings_sorted.py
+++ b/graders/auditing-repo/check_yagni_findings_sorted.py
@@ -19,7 +19,7 @@ from lib import run_checks  # noqa: E402
 ALL_RULES = [
     # (rule, ladder_step, severity) — severity tracks the ladder, capped at
     # MEDIUM: cheap, unambiguous fixes (steps 1-3) emit MEDIUM; costlier
-    # rewrites where the Python is more defensible (steps 4-6) emit LOW.
+    # rewrites where the Python is more defensible (steps 4-7) emit LOW.
     ("yagni-reuse-existing-marketplace-schema", 1, "MEDIUM"),
     ("yagni-duplicate-shape-not-extracted-to-generic", 2, "MEDIUM"),
     ("yagni-generator-hardcoding-data", 2, "MEDIUM"),

--- a/skills/infrahub-auditing-repo/SKILL.md
+++ b/skills/infrahub-auditing-repo/SKILL.md
@@ -78,7 +78,7 @@ report.
 | HIGH | Relationships | Bidirectional IDs, cardinality |
 | HIGH | Registration | All files registered, no orphans |
 | MEDIUM | Best Practices | human_friendly_id, display_label |
-| MEDIUM–LOW | YAGNI / Cost-to-Fix | Python doing what schema, GraphQL, Jinja2, or built-in IPAM/VLAN can do; denormalized data; un-extracted duplicate shapes; a whole domain hand-rolled when the marketplace ships it. Severity tracks the cost-to-fix ladder: steps 1–3 MEDIUM, steps 4–6 LOW |
+| MEDIUM–LOW | YAGNI / Cost-to-Fix | Python doing what schema, GraphQL, Jinja2, or built-in IPAM/VLAN can do; denormalized data; un-extracted duplicate shapes; a whole domain hand-rolled when the marketplace ships it. Severity tracks the cost-to-fix ladder: steps 1–3 MEDIUM, steps 4–7 LOW |
 | MEDIUM | Deployment | Git status, bootstrap placement |
 | LOW | Patterns & Style | Code organization, naming |
 

--- a/skills/infrahub-auditing-repo/audit-procedure.md
+++ b/skills/infrahub-auditing-repo/audit-procedure.md
@@ -390,10 +390,11 @@ clear-cut wins surface loudest:
   (step 1), inherit a built-in primitive, move data to
   YAML, add a schema constraint or a missing inverse.
   Low cost, unambiguous benefit.
-- **Steps 4–6 → LOW.** A larger rewrite where the
+- **Steps 4–7 → LOW.** A larger rewrite where the
   Python is more defensible: re-model a relationship
   traversal, narrow a query, port a transform to
-  Jinja2, restructure a check. Still advisory, just
+  Jinja2, restructure a check, or adopt a generated
+  protocol for typed SDK access. Still advisory, just
   lower priority.
 
 The ladder steps come from each rule's `ladder_step`
@@ -472,7 +473,20 @@ phases keep their existing order).
   already allocates another resource from a pool. Do not
   flag deterministic derivations that persist no allocation.
 
-### 9.5 Output
+### 9.5 Cross-artifact Python rules (checks, transforms, generators)
+
+- `yagni-untyped-python-vs-generated-protocols` (step 7, LOW)
+  — a bare string `kind` (`kind="Foo"` or positional `"Foo"`)
+  passed to `client.create/get/all/filters/count`, or a
+  hand-built dict payload, when a generated protocol class for
+  that kind is available (a repo `protocols.py` /
+  `schema_protocols.py` / `*_sync.py` / `*_async.py`, or
+  `infrahub_sdk.protocols`). Pass the class instead for
+  author-time type checking. Attributes only — do not flag
+  relationship-only access, trivial one-offs, or code already
+  using protocol classes.
+
+### 9.6 Output
 
 When emitting YAGNI findings in `AUDIT_REPORT.md`,
 sort by `ladder_step` ascending (cheapest fix on top),

--- a/skills/infrahub-auditing-repo/rules/_sections.md
+++ b/skills/infrahub-auditing-repo/rules/_sections.md
@@ -12,6 +12,6 @@ contains the checks to perform and the expected outcomes.
 | HIGH | Cross-Refs | `xref-` | Query name consistency |
 | HIGH | Registration | `registration-` | All components declared |
 | MEDIUM | Practices | `practices-` | human_friendly_id, display |
-| MEDIUM–LOW | YAGNI | `yagni-` | Cheaper layer available; cost-to-fix ladder (steps 1–3 MEDIUM, steps 4–6 LOW) |
+| MEDIUM–LOW | YAGNI | `yagni-` | Cheaper layer available; cost-to-fix ladder (steps 1–3 MEDIUM, steps 4–7 LOW) |
 | MEDIUM | Deployment | `deployment-` | Git status, bootstrap |
 | LOW | Patterns | `patterns-` | Code org, file naming |

--- a/skills/infrahub-auditing-repo/rules/yagni-untyped-python-vs-generated-protocols.md
+++ b/skills/infrahub-auditing-repo/rules/yagni-untyped-python-vs-generated-protocols.md
@@ -1,0 +1,78 @@
+---
+title: yagni-untyped-python-vs-generated-protocols
+impact: LOW
+ladder_step: 7
+tags: audit, yagni, protocols, generators, transforms, checks, type-safety
+---
+
+# Rule: yagni-untyped-python-vs-generated-protocols
+
+**Severity**: LOW
+**Category**: YAGNI / Cost-to-Fix
+**Ladder step**: 7 — Can a generated protocol class type it at author time?
+
+## What It Checks
+
+Non-trivial, schema-coupled Python (generators, transforms, checks) that
+passes a bare string `kind` to the SDK — `client.create/get/all/filters/count`
+with `kind="DcimDevice"` (or the kind as a positional string) — or hand-builds
+node payloads as untyped dicts, when a generated protocol class for that kind
+is available. Importing the class and passing it instead gives dev-time type
+checking and autocomplete, so a later schema change surfaces as a type error
+on the exact line rather than a runtime failure in the pipeline.
+
+## Why it matters
+
+The official SDK guidance is explicit: whenever you specify the kind of object
+as a string, you can use the corresponding protocol instead. A bare-string
+`kind` returns an untyped node — every `.attribute.value` access is unchecked,
+and a renamed or retyped attribute compiles fine and fails only at runtime,
+deep in a proposed-change pipeline or a failed artifact generation. With the
+generated class, the type checker turns that same schema drift into a list of
+errors pointing at the exact lines to fix. The cost of *not* adopting
+protocols is paid later, and in a worse place.
+
+## Checks
+
+1. `client.create/get/all/filters/count` called with a string-literal kind
+   (`kind="Foo"` or a positional `"Foo"`) for a kind that has a generated
+   protocol class available — a repo module (`protocols.py`,
+   `schema_protocols.py`, a `*_sync.py` / `*_async.py` protocols file) or
+   `infrahub_sdk.protocols`.
+2. Node payloads hand-built as untyped `dict`s and passed to `create` /
+   `update` instead of constructed against a protocol class.
+3. Multiple such call sites, or one file reading/writing many attributes or
+   several kinds — i.e. non-trivial schema-coupled Python, not a one-off.
+
+## What NOT to flag
+
+- Relationship-only access — generated protocols type attributes, not
+  relationship peers (`RelatedNode` / `RelationshipManager` carry no peer
+  type). Do not claim protocols would type `.interfaces`.
+- Trivial one-offs: a script touching a single kind and one or two attributes.
+  Adopting protocols there is itself over-engineering.
+- Code already importing and passing protocol classes — including SDK-provided
+  core protocols (`from infrahub_sdk.protocols import CoreIPPrefixPool`); that
+  is the target pattern, not a violation.
+- A second, trimmed protocol module kept deliberately (e.g. a generator that
+  runs inside Infrahub and cannot import the repo package).
+- Repos with no managed schema, or no Python artifacts.
+
+## Common Issues
+
+- `await client.create(kind="IpamIPAddress", address=...)` in a generator that
+  already imports and uses other protocol classes — drop the quotes:
+  `from ...protocols import IpamIPAddress` then
+  `await client.create(IpamIPAddress, address=...)`.
+- A transform fetching `client.filters(kind="NetworkLink", ...)` and reading
+  many untyped `["value"]` fields, when `NetworkLink` is already generated.
+- Untyped `dict` payloads assembled field-by-field for `create`, losing every
+  attribute-name and optionality check the protocol class would enforce.
+
+## Related
+
+- [protocols-adopt-typed-kinds](../../infrahub-common/rules/protocols-adopt-typed-kinds.md)
+  — how to generate and adopt protocols (the authoring half).
+- [protocols-generated](../../infrahub-common/rules/protocols-generated.md)
+  — generated files are build artifacts; regenerate, don't hand-edit (the
+  maintenance half).

--- a/skills/infrahub-common/SKILL.md
+++ b/skills/infrahub-common/SKILL.md
@@ -41,6 +41,7 @@ Infrahub skills. It is not meant to be invoked directly.
   - Git integration and deployment patterns
   - Recovery from partial repository syncs
   - Generated file protocol conventions
+  - Adopting generated protocols for typed SDK calls
   - Information-source priority (skill content first,
     with a concrete last-resort procedure for consulting
     `docs.infrahub.app` on a genuine gap)

--- a/skills/infrahub-common/rules/_sections.md
+++ b/skills/infrahub-common/rules/_sections.md
@@ -23,7 +23,7 @@ specific to any single workflow.
    alone misses GraphQL/schema mismatches).
 
 3. **Protocols (protocols-)** -- CRITICAL. Protocol files
-   are generated code (`infrahubctl protocols generate`),
+   are generated code (`infrahubctl protocols`),
    never edit directly, regenerate after schema changes,
    supports local schema directory.
 

--- a/skills/infrahub-common/rules/protocols-adopt-typed-kinds.md
+++ b/skills/infrahub-common/rules/protocols-adopt-typed-kinds.md
@@ -26,8 +26,12 @@ infrahubctl protocols --out lib/protocols.py
 infrahubctl protocols --schemas schemas/ --out lib/protocols.py
 
 # Sync client
-infrahubctl protocols --schemas schemas/ --sync --out lib/protocols.py
+infrahubctl protocols --schemas schemas/ --sync --out lib/protocols_sync.py
 ```
+
+> The full regeneration workflow and the "never hand-edit" rule live in
+> [protocols-generated](./protocols-generated.md) — keep the two in step if
+> the CLI changes.
 
 ### Use them
 

--- a/skills/infrahub-common/rules/protocols-adopt-typed-kinds.md
+++ b/skills/infrahub-common/rules/protocols-adopt-typed-kinds.md
@@ -18,8 +18,8 @@ exact line rather than a runtime failure.
 schema. The async client is the default; add `--sync` for the sync client.
 
 ```bash
-# From a running instance (async client)
-export INFRAHUB_ADDRESS=https://infrahub.example.com
+# From a running instance (async client, default) — reads the configured
+# INFRAHUB_ADDRESS (defaults to http://localhost:8000)
 infrahubctl protocols --out lib/protocols.py
 
 # From local schema files, no instance needed
@@ -28,6 +28,15 @@ infrahubctl protocols --schemas schemas/ --out lib/protocols.py
 # Sync client
 infrahubctl protocols --schemas schemas/ --sync --out lib/protocols_sync.py
 ```
+
+Prefix `infrahubctl` with your project's Python runner and confirm the
+server first — see
+[connectivity-server-check](./connectivity-server-check.md) for how
+`INFRAHUB_ADDRESS` / `INFRAHUB_API_TOKEN` are resolved (and `infrahubctl
+info` as the connectivity test) and
+[connectivity-python-environment](./connectivity-python-environment.md)
+for the `uv run` / `poetry run` prefix. The instance address is not
+hardcoded here — it comes from your environment or `infrahubctl.toml`.
 
 > The full regeneration workflow and the "never hand-edit" rule live in
 > [protocols-generated](./protocols-generated.md) — keep the two in step if

--- a/skills/infrahub-common/rules/protocols-adopt-typed-kinds.md
+++ b/skills/infrahub-common/rules/protocols-adopt-typed-kinds.md
@@ -1,0 +1,57 @@
+---
+title: Adopt Generated Protocols for Typed Schema Access
+impact: LOW
+tags: protocols, infrahubctl, type-safety, generators, transforms, checks
+---
+
+## Adopt Generated Protocols for Typed Schema Access
+
+When Python — a generator, transform, or check — reads or writes schema
+objects through the SDK, pass a generated protocol class as the `kind` instead
+of a string. You get dev-time type checking and IDE autocomplete on the
+object's attributes, and a later schema change becomes a type error on the
+exact line rather than a runtime failure.
+
+### Generate the protocols
+
+`infrahubctl protocols` writes a Python module of typed classes for your
+schema. The async client is the default; add `--sync` for the sync client.
+
+```bash
+# From a running instance (async client)
+export INFRAHUB_ADDRESS=https://infrahub.example.com
+infrahubctl protocols --out lib/protocols.py
+
+# From local schema files, no instance needed
+infrahubctl protocols --schemas schemas/ --out lib/protocols.py
+
+# Sync client
+infrahubctl protocols --schemas schemas/ --sync --out lib/protocols.py
+```
+
+### Use them
+
+```python
+from lib.protocols import NetworkDevice   # or a protocols.py beside the script
+
+device = await client.create(NetworkDevice, hostname="spine-1", role="spine")
+device.hostname.value            # type-checked and autocompleted
+```
+
+For core and internal kinds you generate nothing — import them straight from
+the SDK: `from infrahub_sdk.protocols import CoreIPPrefixPool`.
+
+### Caveats
+
+- **Attributes only.** Relationships are `RelatedNode` / `RelationshipManager`
+  with no peer type; re-`get(Peer, ...)` when you need typed peer access.
+- **Regenerate after any schema change** and commit the file — it does not
+  update itself, and a stale file gives wrong types silently.
+- **Match sync vs async to your client** — a sync check imports the `--sync`
+  variant; async uses the default.
+- Local-directory generation does not emit Profile or Object-Template
+  protocols.
+
+See [protocols-generated](./protocols-generated.md) for why the file is a
+build artifact you never hand-edit. The auditor flags untyped string kinds via
+[yagni-untyped-python-vs-generated-protocols](../../infrahub-auditing-repo/rules/yagni-untyped-python-vs-generated-protocols.md).

--- a/skills/infrahub-common/rules/protocols-generated.md
+++ b/skills/infrahub-common/rules/protocols-generated.md
@@ -9,7 +9,7 @@ tags: protocols, generated-code, infrahubctl, schema, checks, generators, transf
 Impact: CRITICAL
 
 Protocol files under `generated/` (or `protocols/`)
-are output from `infrahubctl protocols generate` —
+are output from `infrahubctl protocols` —
 hand-edits to them are overwritten on the next
 regeneration.
 
@@ -45,41 +45,36 @@ Infrahub schema. Common indicators:
 
 ### Generating Protocols
 
-Use `infrahubctl protocols generate` to create or
-update protocol files. The command can work against
-a **running Infrahub instance** or directly from
-**local schema files**:
+Use `infrahubctl protocols` to create or update protocol
+files. It can read from a **running Infrahub instance**
+or directly from **local schema files**:
 
 ```bash
-# Generate from a running Infrahub instance (default)
-infrahubctl protocols generate
+# From a running Infrahub instance (async client, default)
+export INFRAHUB_ADDRESS=https://infrahub.example.com
+infrahubctl protocols --out lib/protocols.py
 
-# Generate from local schema directory (no instance needed)
-infrahubctl protocols generate --schema-dir schemas/
-
-# Generate from specific schema files
-infrahubctl protocols generate \
-  --schema-dir schemas/base/ \
-  --schema-dir schemas/extensions/
+# From local schema files (no instance needed)
+infrahubctl protocols --schemas schemas/ --out lib/protocols.py
 ```
 
-Using `--schema-dir` is especially useful during
+Using `--schemas` is especially useful during
 development when iterating on schema changes without
-needing to load them into Infrahub first.
+loading them into Infrahub first. Note: local-directory
+generation does not emit Profile or Object-Template
+protocols.
 
-The command generates both **sync** and **async**
-protocol classes. Usually only one variant is needed
--- choose based on whether your code uses the sync
-or async Infrahub SDK client. In rare cases (e.g., a
-project mixing sync utilities with async
-generators), both may be required.
+The async client is the default. Generate the **sync**
+variant with `--sync` when your code uses the sync SDK
+client; a project mixing sync utilities with async
+generators may need both.
 
 ```bash
-# Generate only sync protocols
-infrahubctl protocols generate --sync
+# Sync protocols
+infrahubctl protocols --schemas schemas/ --sync --out lib/protocols_sync.py
 
-# Generate only async protocols (default)
-infrahubctl protocols generate --async
+# Async protocols (default)
+infrahubctl protocols --schemas schemas/ --out lib/protocols.py
 ```
 
 ### Correct Workflow
@@ -88,7 +83,7 @@ When the schema changes, the correct sequence is:
 
 1. **Update the schema** files (YAML in `schemas/`)
 2. **Regenerate protocols**:
-   `infrahubctl protocols generate --schema-dir schemas/`
+   `infrahubctl protocols --schemas schemas/ --out lib/protocols.py`
 3. **Use the updated protocols** in checks,
    generators, and transforms
 4. **Commit** the regenerated protocol files

--- a/skills/infrahub-common/rules/protocols-generated.md
+++ b/skills/infrahub-common/rules/protocols-generated.md
@@ -50,13 +50,21 @@ files. It can read from a **running Infrahub instance**
 or directly from **local schema files**:
 
 ```bash
-# From a running Infrahub instance (async client, default)
-export INFRAHUB_ADDRESS=https://infrahub.example.com
+# From a running Infrahub instance (async client, default) — reads the
+# configured INFRAHUB_ADDRESS (defaults to http://localhost:8000)
 infrahubctl protocols --out lib/protocols.py
 
 # From local schema files (no instance needed)
 infrahubctl protocols --schemas schemas/ --out lib/protocols.py
 ```
+
+The instance address is not hardcoded — it comes from
+your environment or `infrahubctl.toml`
+(`INFRAHUB_ADDRESS`, default `http://localhost:8000`);
+confirm with `infrahubctl info` first, and prefix with
+your project's Python runner (`uv run` / `poetry run`).
+See
+[connectivity-server-check](./connectivity-server-check.md).
 
 Using `--schemas` is especially useful during
 development when iterating on schema changes without

--- a/skills/infrahub-managing-checks/SKILL.md
+++ b/skills/infrahub-managing-checks/SKILL.md
@@ -97,6 +97,12 @@ out-of-band reconciliations, and stateful assertions
 in [rules/python-validate.md](./rules/python-validate.md)
 are the legitimate use cases.
 
+When the check reads objects through the SDK (rather than only its GraphQL
+query), type those calls with generated protocol classes rather than string
+kinds — `client.get(DcimDevice, ...)`, not `kind="DcimDevice"`. Match the
+`--sync` protocol variant to the check's client. See
+[protocols-adopt-typed-kinds](../infrahub-common/rules/protocols-adopt-typed-kinds.md).
+
 ## Check Basics
 
 Every check has three components:

--- a/skills/infrahub-managing-generators/SKILL.md
+++ b/skills/infrahub-managing-generators/SKILL.md
@@ -95,6 +95,12 @@ objects from a design definition; see
 [rules/python-generate.md](./rules/python-generate.md)
 for the legitimate cases.
 
+Once you *are* writing Python, type your SDK calls with generated protocol
+classes rather than string kinds — `client.create(NetworkDevice, ...)`, not
+`kind="NetworkDevice"` — so a schema change fails type-check instead of at
+runtime. See
+[protocols-adopt-typed-kinds](../infrahub-common/rules/protocols-adopt-typed-kinds.md).
+
 ## Generator Basics
 
 Every generator has three components:

--- a/skills/infrahub-managing-transforms/SKILL.md
+++ b/skills/infrahub-managing-transforms/SKILL.md
@@ -92,6 +92,12 @@ aggregation, structural JSON re-shaping. See
 [rules/python-transform.md](./rules/python-transform.md)
 for the legitimate cases.
 
+When the transform reads objects through the SDK, type those calls with
+generated protocol classes rather than string kinds — `client.filters(NetworkLink, ...)`,
+not `kind="NetworkLink"` — so schema drift fails type-check instead of at
+runtime. See
+[protocols-adopt-typed-kinds](../infrahub-common/rules/protocols-adopt-typed-kinds.md).
+
 ## Transform Basics
 
 Two types of transforms:


### PR DESCRIPTION
## What

Adds a new YAGNI / cost-to-fix audit rule and the authoring guidance that pairs with it, so the plugin both **flags** untyped schema-coupled Python and **teaches** the typed alternative.

- **New rule** `yagni-untyped-python-vs-generated-protocols` (LOW, ladder step 7) in `infrahub-auditing-repo`. Flags non-trivial Python (generators / transforms / checks) that passes a bare-string `kind` to the SDK — `client.create/get/all/filters/count(kind="Foo", …)` — or hand-builds dict payloads, when a generated protocol class for that kind is available. Passing the class instead gives author-time type checking, so a schema change becomes a type error on the exact line instead of a runtime failure in the pipeline.
- **Adoption guidance** — a new shared rule `infrahub-common/rules/protocols-adopt-typed-kinds.md` plus short pointers in the *Before writing Python* sections of `managing-generators`, `managing-transforms`, and `managing-checks`.
- **CLI correctness fix** — `protocols-generated.md` and `infrahub-common/rules/_sections.md` documented `infrahubctl protocols generate --schema-dir … --async`. The real command is `infrahubctl protocols` (no `generate` subcommand), `--schemas`, `--sync / --no-sync` (async is the default; there is no `--async` flag), `--out`. Corrected both; the wrong form had also propagated into demo repos' vendored skills, so fixing the source stops that.

## Why

Untyped `kind="…"` calls and hand-built payloads are a recurring integration-layer bug source: a renamed or retyped attribute compiles fine and fails only at runtime. `infrahubctl protocols` generates typed classes from the schema; the official SDK guidance is "use the corresponding protocol instead of the string kind." The rule is intentionally LOW and step-7 (its own new ladder rung) because it is type-safety *hygiene*, not a cheaper declarative layer — and it carries honest limits (protocols type attributes only, not relationship peers), which the rule's *What NOT to flag* section encodes so it never over-promises or fires on trivial one-offs.

## Rule = Test

Per the repo's Rule = Test requirement, the rule ships with its coverage:

- Registered in `graders/auditing-repo/check_yagni_findings_sorted.py` `ALL_RULES` (now 16 rules; sorted-set order ends at step 7).
- New `eval.yaml` task `yagni-untyped-protocols` (reuses the shared `check_yagni_rule.py … LOW 7` grader) with a fixture that mixes an untyped call to flag and an already-typed call that must not be, and the existing `yagni-findings-sorted` task extended to 16 rules.
- Enumerated in the auditor's operative `audit-procedure.md` Phase 9 (new §9.5, cross-artifact Python), and the cost-to-fix ladder→severity legends updated to steps 4–7 → LOW across `_sections.md`, `SKILL.md`, and `audit-procedure.md`.
- `evaluations/*.json` regenerated via `scripts/sync-evals.py`.

## Verification

- Deterministic: grader = 16 rules with step-7 LOW registered; `eval.yaml` parses; `evaluations/*.json` in sync (`sync-evals.py` yields no diff); relative-path links resolve; `grep -rE "protocols generate|--schema-dir|--async" skills/` → zero.
- Reviewed with a high-effort multi-agent code review; findings addressed (including enumerating the rule in Phase 9 and reconciling all three ladder legends).
- **Not yet run:** `skillgrade --smoke` (needs a configured provider) — the behavioural gate on the new eval tasks.

## Draft because

Opened as draft pending the `skillgrade --smoke` run on the new eval tasks. Reviewers can start on the prose/grader now.
