### PR TITLE
feat(managing-checks): add relationship-traversal validation rule

### DIFF
--- a/dev/guides/running-evals.md
+++ b/dev/guides/running-evals.md
@@ -194,7 +194,7 @@ each task reads).
 | ----- | ----- |
 | infrahub-managing-schemas | 13 |
 | infrahub-managing-menus | 3 |
-| infrahub-managing-checks | 2 |
+| infrahub-managing-checks | 3 |
 | infrahub-managing-generators | 6 |
 | infrahub-managing-transforms | 3 |
 | infrahub-managing-objects | 3 |

--- a/eval.yaml
+++ b/eval.yaml
@@ -1054,13 +1054,12 @@ tasks:
     instruction: |
       Read the skill at .agents/skills/infrahub-managing-checks/SKILL.md and follow its workflow and rules.
 
-      Task: Write a global check that enforces install ordering. A
-      DcimModule must not be `installed` while its containing chassis is
-      not yet in service. The module reaches its chassis through the
-      relationship chain installed_in (a bay) -> container (the chassis).
-      Flag any DcimModule whose status is `installed` when the container's
-      status is neither `installed` nor `maintenance`. The class is
-      DcimInstallOrderingCheck and the query is named dcim_install_ordering.
+      Task: Write a global check that stops an interface being brought into
+      service ahead of the device it belongs to. Flag any InfraInterface
+      whose status is `active` when the device it belongs to has a status
+      other than `active` or `provisioning`. If an interface's device
+      cannot be determined, treat that as a violation too. The class is
+      InterfaceReadinessCheck and the query is named interface_readiness.
 
       Produce two files:
       - the GraphQL query, saved to: output.gql
@@ -1070,44 +1069,48 @@ tasks:
         run: python graders/managing-checks/check_relationship_traversal.py
         weight: 1.0
     expected_output: >-
-      A GraphQL query that selects DcimModule filtered by
-      status__value: "installed" and traverses installed_in -> container
-      to fetch the chassis `status { value }`, plus a Python
-      InfrahubCheck whose validate() unwraps that nested path (guarding
-      each null hop with `or {}`), reports the ordering violation with
-      log_error, and flags a module with no resolvable container rather
-      than skipping it.
+      A GraphQL query that selects InfraInterface filtered to the active
+      ones and traverses to the owning device to fetch that device's
+      `status { value }` in the same query, plus a Python InfrahubCheck
+      whose validate() unwraps the nested path (guarding each hop against
+      null), reports the readiness violation with log_error, and flags an
+      interface whose device cannot be resolved rather than skipping it.
     expectations:
       - >-
-        The query fetches the container's status inside the query via
-        relationship traversal (installed_in -> container -> status),
-        not just the module's own fields — a check runs one query with
-        no lazy fetch
+        The query fetches the owning device's status inside the query via
+        relationship traversal, not just the interface's own fields — a
+        check runs one query with no lazy fetch
       - >-
-        validate() reads the nested container status and calls
-        log_error when it is not installed or maintenance
+        The device status is selected inside the device's own node
+        selection set, not merely somewhere after the nested block
       - >-
-        The nested unwrap guards each hop against null (`or {}` /
-        `is None`) so a dangling relationship does not crash or pass
-        silently
+        validate() reads the nested device status and calls log_error
+        when it is not active or provisioning
       - >-
-        A module whose container cannot be resolved is flagged, not
-        skipped
+        Each relationship hop is guarded against null (`or {}`) so a
+        dangling relationship does not crash
+      - >-
+        An interface whose device cannot be resolved is flagged with
+        log_error, not skipped with a bare continue/return
     assertions:
       - name: child-status-filter
-        check: Query filters DcimModule by status__value "installed"
+        check: Query filters the interface set by an attribute value
       - name: traverses-related-node
-        check: Query nests into the related container node
+        check: Query nests into the related device node
       - name: fetches-related-attribute-value
         check: >-
-          The nested container node selects status value so the parent
-          state is available to validate()
+          The device's own (innermost) node selection set selects a
+          status value, so the parent state is actually fetched
       - name: uses-infrahubcheck
         check: Python defines an InfrahubCheck bound to the query
       - name: surfaces-violation
         check: validate() reports the violation with log_error
       - name: null-safe-traversal
-        check: The nested relationship walk guards against a null hop
+        check: Each relationship hop is guarded against a null value
+      - name: flags-unresolvable-parent
+        check: >-
+          An unresolvable device is flagged with log_error, not skipped
+          with a bare continue/return
 
   # --- Generators: relationship reference encoding --- #
   - name: generator-relationship-hfid-encoding

--- a/eval.yaml
+++ b/eval.yaml
@@ -1049,6 +1049,66 @@ tasks:
           Targeted check_definitions entry declares both targets and
           parameters
 
+  - name: relationship-traversal-check
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-managing-checks/SKILL.md and follow its workflow and rules.
+
+      Task: Write a global check that enforces install ordering. A
+      DcimModule must not be `installed` while its containing chassis is
+      not yet in service. The module reaches its chassis through the
+      relationship chain installed_in (a bay) -> container (the chassis).
+      Flag any DcimModule whose status is `installed` when the container's
+      status is neither `installed` nor `maintenance`. The class is
+      DcimInstallOrderingCheck and the query is named dcim_install_ordering.
+
+      Produce two files:
+      - the GraphQL query, saved to: output.gql
+      - the Python check class, saved to: output.py
+    graders:
+      - type: deterministic
+        run: python graders/managing-checks/check_relationship_traversal.py
+        weight: 1.0
+    expected_output: >-
+      A GraphQL query that selects DcimModule filtered by
+      status__value: "installed" and traverses installed_in -> container
+      to fetch the chassis `status { value }`, plus a Python
+      InfrahubCheck whose validate() unwraps that nested path (guarding
+      each null hop with `or {}`), reports the ordering violation with
+      log_error, and flags a module with no resolvable container rather
+      than skipping it.
+    expectations:
+      - >-
+        The query fetches the container's status inside the query via
+        relationship traversal (installed_in -> container -> status),
+        not just the module's own fields — a check runs one query with
+        no lazy fetch
+      - >-
+        validate() reads the nested container status and calls
+        log_error when it is not installed or maintenance
+      - >-
+        The nested unwrap guards each hop against null (`or {}` /
+        `is None`) so a dangling relationship does not crash or pass
+        silently
+      - >-
+        A module whose container cannot be resolved is flagged, not
+        skipped
+    assertions:
+      - name: child-status-filter
+        check: Query filters DcimModule by status__value "installed"
+      - name: traverses-related-node
+        check: Query nests into the related container node
+      - name: fetches-related-attribute-value
+        check: >-
+          The nested container node selects status value so the parent
+          state is available to validate()
+      - name: uses-infrahubcheck
+        check: Python defines an InfrahubCheck bound to the query
+      - name: surfaces-violation
+        check: validate() reports the violation with log_error
+      - name: null-safe-traversal
+        check: The nested relationship walk guards against a null hop
+
   # --- Generators: relationship reference encoding --- #
   - name: generator-relationship-hfid-encoding
     trials: 3

--- a/eval.yaml
+++ b/eval.yaml
@@ -1106,7 +1106,7 @@ tasks:
       - name: surfaces-violation
         check: validate() reports the violation with log_error
       - name: null-safe-traversal
-        check: Each relationship hop is guarded against a null value
+        check: The relationship walk uses a null-guard idiom (`or {}` / `.get(k, {})`)
       - name: flags-unresolvable-parent
         check: >-
           An unresolvable device is flagged with log_error, not skipped

--- a/evaluations/infrahub-managing-checks.json
+++ b/evaluations/infrahub-managing-checks.json
@@ -72,6 +72,44 @@
           "check": "Targeted check_definitions entry declares both targets and parameters"
         }
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Write a global check that enforces install ordering. A\nDcimModule must not be `installed` while its containing chassis is\nnot yet in service. The module reaches its chassis through the\nrelationship chain installed_in (a bay) -> container (the chassis).\nFlag any DcimModule whose status is `installed` when the container's\nstatus is neither `installed` nor `maintenance`. The class is\nDcimInstallOrderingCheck and the query is named dcim_install_ordering.\n\nProduce two files:\n- the GraphQL query, saved to: output.gql\n- the Python check class, saved to: output.py",
+      "expected_output": "A GraphQL query that selects DcimModule filtered by status__value: \"installed\" and traverses installed_in -> container to fetch the chassis `status { value }`, plus a Python InfrahubCheck whose validate() unwraps that nested path (guarding each null hop with `or {}`), reports the ordering violation with log_error, and flags a module with no resolvable container rather than skipping it.",
+      "files": [],
+      "expectations": [
+        "The query fetches the container's status inside the query via relationship traversal (installed_in -> container -> status), not just the module's own fields \u2014 a check runs one query with no lazy fetch",
+        "validate() reads the nested container status and calls log_error when it is not installed or maintenance",
+        "The nested unwrap guards each hop against null (`or {}` / `is None`) so a dangling relationship does not crash or pass silently",
+        "A module whose container cannot be resolved is flagged, not skipped"
+      ],
+      "assertions": [
+        {
+          "name": "child-status-filter",
+          "check": "Query filters DcimModule by status__value \"installed\""
+        },
+        {
+          "name": "traverses-related-node",
+          "check": "Query nests into the related container node"
+        },
+        {
+          "name": "fetches-related-attribute-value",
+          "check": "The nested container node selects status value so the parent state is available to validate()"
+        },
+        {
+          "name": "uses-infrahubcheck",
+          "check": "Python defines an InfrahubCheck bound to the query"
+        },
+        {
+          "name": "surfaces-violation",
+          "check": "validate() reports the violation with log_error"
+        },
+        {
+          "name": "null-safe-traversal",
+          "check": "The nested relationship walk guards against a null hop"
+        }
+      ]
     }
   ]
 }

--- a/evaluations/infrahub-managing-checks.json
+++ b/evaluations/infrahub-managing-checks.json
@@ -75,27 +75,28 @@
     },
     {
       "id": 3,
-      "prompt": "Write a global check that enforces install ordering. A\nDcimModule must not be `installed` while its containing chassis is\nnot yet in service. The module reaches its chassis through the\nrelationship chain installed_in (a bay) -> container (the chassis).\nFlag any DcimModule whose status is `installed` when the container's\nstatus is neither `installed` nor `maintenance`. The class is\nDcimInstallOrderingCheck and the query is named dcim_install_ordering.\n\nProduce two files:\n- the GraphQL query, saved to: output.gql\n- the Python check class, saved to: output.py",
-      "expected_output": "A GraphQL query that selects DcimModule filtered by status__value: \"installed\" and traverses installed_in -> container to fetch the chassis `status { value }`, plus a Python InfrahubCheck whose validate() unwraps that nested path (guarding each null hop with `or {}`), reports the ordering violation with log_error, and flags a module with no resolvable container rather than skipping it.",
+      "prompt": "Write a global check that stops an interface being brought into\nservice ahead of the device it belongs to. Flag any InfraInterface\nwhose status is `active` when the device it belongs to has a status\nother than `active` or `provisioning`. If an interface's device\ncannot be determined, treat that as a violation too. The class is\nInterfaceReadinessCheck and the query is named interface_readiness.\n\nProduce two files:\n- the GraphQL query, saved to: output.gql\n- the Python check class, saved to: output.py",
+      "expected_output": "A GraphQL query that selects InfraInterface filtered to the active ones and traverses to the owning device to fetch that device's `status { value }` in the same query, plus a Python InfrahubCheck whose validate() unwraps the nested path (guarding each hop against null), reports the readiness violation with log_error, and flags an interface whose device cannot be resolved rather than skipping it.",
       "files": [],
       "expectations": [
-        "The query fetches the container's status inside the query via relationship traversal (installed_in -> container -> status), not just the module's own fields \u2014 a check runs one query with no lazy fetch",
-        "validate() reads the nested container status and calls log_error when it is not installed or maintenance",
-        "The nested unwrap guards each hop against null (`or {}` / `is None`) so a dangling relationship does not crash or pass silently",
-        "A module whose container cannot be resolved is flagged, not skipped"
+        "The query fetches the owning device's status inside the query via relationship traversal, not just the interface's own fields \u2014 a check runs one query with no lazy fetch",
+        "The device status is selected inside the device's own node selection set, not merely somewhere after the nested block",
+        "validate() reads the nested device status and calls log_error when it is not active or provisioning",
+        "Each relationship hop is guarded against null (`or {}`) so a dangling relationship does not crash",
+        "An interface whose device cannot be resolved is flagged with log_error, not skipped with a bare continue/return"
       ],
       "assertions": [
         {
           "name": "child-status-filter",
-          "check": "Query filters DcimModule by status__value \"installed\""
+          "check": "Query filters the interface set by an attribute value"
         },
         {
           "name": "traverses-related-node",
-          "check": "Query nests into the related container node"
+          "check": "Query nests into the related device node"
         },
         {
           "name": "fetches-related-attribute-value",
-          "check": "The nested container node selects status value so the parent state is available to validate()"
+          "check": "The device's own (innermost) node selection set selects a status value, so the parent state is actually fetched"
         },
         {
           "name": "uses-infrahubcheck",
@@ -107,7 +108,11 @@
         },
         {
           "name": "null-safe-traversal",
-          "check": "The nested relationship walk guards against a null hop"
+          "check": "Each relationship hop is guarded against a null value"
+        },
+        {
+          "name": "flags-unresolvable-parent",
+          "check": "An unresolvable device is flagged with log_error, not skipped with a bare continue/return"
         }
       ]
     }

--- a/evaluations/infrahub-managing-checks.json
+++ b/evaluations/infrahub-managing-checks.json
@@ -108,7 +108,7 @@
         },
         {
           "name": "null-safe-traversal",
-          "check": "Each relationship hop is guarded against a null value"
+          "check": "The relationship walk uses a null-guard idiom (`or {}` / `.get(k, {})`)"
         },
         {
           "name": "flags-unresolvable-parent",

--- a/graders/managing-checks/check_relationship_traversal.py
+++ b/graders/managing-checks/check_relationship_traversal.py
@@ -1,24 +1,36 @@
 #!/usr/bin/env python3
 """Grader for the relationship-traversal-check eval task.
 
-Unlike the registration graders in this directory, this task grades the
-*query and Python logic* of a check that validates a node against a
-related node's state, so it reads the produced `output.gql` and
-`output.py` directly rather than an `.infrahub.yml` via run_checks.
+This task grades the produced GraphQL query and Python check (not an
+`.infrahub.yml`), so it reads `output.gql` / `output.py` and delegates to
+`run_text_checks` in lib.py — the text-based counterpart to `run_checks`.
 
-The load-bearing, deterministic fact is the query shape: a check runs
-one query with no lazy fetch, so the parent's comparison attribute must
-be pulled by traversing the relationship inside the query. The naive
-failure mode — selecting only the child — is exactly what these query
-assertions catch. The validate() assertions confirm the violation is
-surfaced and the nested unwrap is null-safe.
+The load-bearing assertions are on the query: a check runs one query with no
+lazy fetch, so the related node's comparison attribute must be pulled inside
+the query, in the innermost related node's own selection set. The Python
+assertions confirm the violation is surfaced and, critically, that an
+unresolvable related node is flagged rather than skipped.
 """
 
 from __future__ import annotations
 
 import json
-import re
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_text_checks  # noqa: E402
+
+CHECKS = [
+    "child-status-filter",
+    "traverses-related-node",
+    "fetches-related-attribute-value",
+    "uses-infrahubcheck",
+    "surfaces-violation",
+    "null-safe-traversal",
+    "flags-unresolvable-parent",
+]
 
 
 def _read(name: str) -> str:
@@ -28,88 +40,6 @@ def _read(name: str) -> str:
         return ""
 
 
-def check_child_status_filter(gql: str, py: str) -> tuple[bool, str]:
-    """The query filters the child set by an attribute value (e.g. status__value:)."""
-    if re.search(r"\w+__value\s*:", gql):
-        return True, "Query filters children by an attribute value"
-    return False, "Query has no `<attr>__value:` filter selecting the constrained children"
-
-
-def check_traverses_related_node(gql: str, py: str) -> tuple[bool, str]:
-    """The query nests into a related node (>= 2 `node {` blocks)."""
-    opens = len(re.findall(r"node\s*{", gql))
-    if opens >= 2:
-        return True, f"Query nests into a related node ({opens} `node {{` blocks)"
-    return False, "Query does not traverse a relationship into a nested `node {` block"
-
-
-def check_fetches_related_attribute_value(gql: str, py: str) -> tuple[bool, str]:
-    """An attribute `value` is selected inside a nested relationship, not just at the top."""
-    node_opens = [m.start() for m in re.finditer(r"node\s*{", gql)]
-    if len(node_opens) < 2:
-        return False, "No nested node block to hold the related attribute"
-    after_second = gql[node_opens[1]:]
-    if re.search(r"\bvalue\b", after_second):
-        return True, "Related node selects an attribute value (parent state is fetched)"
-    return False, "Nested related node does not select any attribute `value` to compare against"
-
-
-def check_uses_infrahubcheck(gql: str, py: str) -> tuple[bool, str]:
-    """Python defines an InfrahubCheck subclass bound to a query."""
-    if "InfrahubCheck" in py and re.search(r"query\s*=", py):
-        return True, "Defines an InfrahubCheck with a `query =` binding"
-    return False, "No InfrahubCheck subclass with a `query =` attribute"
-
-
-def check_surfaces_violation(gql: str, py: str) -> tuple[bool, str]:
-    """validate() surfaces the mismatch via log_error (blocks the merge)."""
-    if re.search(r"log_error\s*\(", py):
-        return True, "Reports the violation with log_error"
-    return False, "validate() never calls log_error, so no violation is surfaced"
-
-
-def check_null_safe_traversal(gql: str, py: str) -> tuple[bool, str]:
-    """The nested unwrap guards against a null relationship."""
-    if "or {}" in py or re.search(r"is\s+None", py):
-        return True, "Guards the relationship walk against a null hop"
-    return False, "No null guard (`or {}` / `is None`) on the nested relationship walk"
-
-
-CHECKS = [
-    ("child-status-filter", check_child_status_filter),
-    ("traverses-related-node", check_traverses_related_node),
-    ("fetches-related-attribute-value", check_fetches_related_attribute_value),
-    ("uses-infrahubcheck", check_uses_infrahubcheck),
-    ("surfaces-violation", check_surfaces_violation),
-    ("null-safe-traversal", check_null_safe_traversal),
-]
-
-
-def main() -> None:
-    gql = _read("output.gql")
-    py = _read("output.py")
-
-    entries = []
-    passed = 0
-    for name, fn in CHECKS:
-        try:
-            ok, msg = fn(gql, py)
-        except Exception as exc:  # pragma: no cover
-            ok, msg = False, f"Error running check: {exc}"
-        if ok:
-            passed += 1
-        entries.append({"name": name, "passed": ok, "message": msg})
-
-    total = len(CHECKS)
-    score = round(passed / total, 4) if total else 0.0
-    failed = [e["name"] for e in entries if not e["passed"]]
-    details = (
-        f"All {total} checks passed."
-        if not failed
-        else f"{passed}/{total} checks passed. Failed: {', '.join(failed)}"
-    )
-    print(json.dumps({"score": score, "details": details, "checks": entries}))
-
-
 if __name__ == "__main__":
-    main()
+    sources = {"gql": _read("output.gql"), "py": _read("output.py")}
+    print(json.dumps(run_text_checks(CHECKS, sources)))

--- a/graders/managing-checks/check_relationship_traversal.py
+++ b/graders/managing-checks/check_relationship_traversal.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Grader for the relationship-traversal-check eval task.
+
+Unlike the registration graders in this directory, this task grades the
+*query and Python logic* of a check that validates a node against a
+related node's state, so it reads the produced `output.gql` and
+`output.py` directly rather than an `.infrahub.yml` via run_checks.
+
+The load-bearing, deterministic fact is the query shape: a check runs
+one query with no lazy fetch, so the parent's comparison attribute must
+be pulled by traversing the relationship inside the query. The naive
+failure mode — selecting only the child — is exactly what these query
+assertions catch. The validate() assertions confirm the violation is
+surfaced and the nested unwrap is null-safe.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def _read(name: str) -> str:
+    try:
+        return Path(name).read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return ""
+
+
+def check_child_status_filter(gql: str, py: str) -> tuple[bool, str]:
+    """The query filters the child set by an attribute value (e.g. status__value:)."""
+    if re.search(r"\w+__value\s*:", gql):
+        return True, "Query filters children by an attribute value"
+    return False, "Query has no `<attr>__value:` filter selecting the constrained children"
+
+
+def check_traverses_related_node(gql: str, py: str) -> tuple[bool, str]:
+    """The query nests into a related node (>= 2 `node {` blocks)."""
+    opens = len(re.findall(r"node\s*{", gql))
+    if opens >= 2:
+        return True, f"Query nests into a related node ({opens} `node {{` blocks)"
+    return False, "Query does not traverse a relationship into a nested `node {` block"
+
+
+def check_fetches_related_attribute_value(gql: str, py: str) -> tuple[bool, str]:
+    """An attribute `value` is selected inside a nested relationship, not just at the top."""
+    node_opens = [m.start() for m in re.finditer(r"node\s*{", gql)]
+    if len(node_opens) < 2:
+        return False, "No nested node block to hold the related attribute"
+    after_second = gql[node_opens[1]:]
+    if re.search(r"\bvalue\b", after_second):
+        return True, "Related node selects an attribute value (parent state is fetched)"
+    return False, "Nested related node does not select any attribute `value` to compare against"
+
+
+def check_uses_infrahubcheck(gql: str, py: str) -> tuple[bool, str]:
+    """Python defines an InfrahubCheck subclass bound to a query."""
+    if "InfrahubCheck" in py and re.search(r"query\s*=", py):
+        return True, "Defines an InfrahubCheck with a `query =` binding"
+    return False, "No InfrahubCheck subclass with a `query =` attribute"
+
+
+def check_surfaces_violation(gql: str, py: str) -> tuple[bool, str]:
+    """validate() surfaces the mismatch via log_error (blocks the merge)."""
+    if re.search(r"log_error\s*\(", py):
+        return True, "Reports the violation with log_error"
+    return False, "validate() never calls log_error, so no violation is surfaced"
+
+
+def check_null_safe_traversal(gql: str, py: str) -> tuple[bool, str]:
+    """The nested unwrap guards against a null relationship."""
+    if "or {}" in py or re.search(r"is\s+None", py):
+        return True, "Guards the relationship walk against a null hop"
+    return False, "No null guard (`or {}` / `is None`) on the nested relationship walk"
+
+
+CHECKS = [
+    ("child-status-filter", check_child_status_filter),
+    ("traverses-related-node", check_traverses_related_node),
+    ("fetches-related-attribute-value", check_fetches_related_attribute_value),
+    ("uses-infrahubcheck", check_uses_infrahubcheck),
+    ("surfaces-violation", check_surfaces_violation),
+    ("null-safe-traversal", check_null_safe_traversal),
+]
+
+
+def main() -> None:
+    gql = _read("output.gql")
+    py = _read("output.py")
+
+    entries = []
+    passed = 0
+    for name, fn in CHECKS:
+        try:
+            ok, msg = fn(gql, py)
+        except Exception as exc:  # pragma: no cover
+            ok, msg = False, f"Error running check: {exc}"
+        if ok:
+            passed += 1
+        entries.append({"name": name, "passed": ok, "message": msg})
+
+    total = len(CHECKS)
+    score = round(passed / total, 4) if total else 0.0
+    failed = [e["name"] for e in entries if not e["passed"]]
+    details = (
+        f"All {total} checks passed."
+        if not failed
+        else f"{passed}/{total} checks passed. Failed: {', '.join(failed)}"
+    )
+    print(json.dumps({"score": score, "details": details, "checks": entries}))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/managing-checks/lib.py
+++ b/graders/managing-checks/lib.py
@@ -10,6 +10,7 @@ field on `check_definitions`) lives.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -192,6 +193,173 @@ def run_checks(check_names: list[str], output_path: Path) -> dict:
         fn = CHECKS[name]
         try:
             ok, msg = fn(config)
+        except Exception as exc:  # pragma: no cover
+            ok, msg = False, f"Error running check: {exc}"
+        if ok:
+            passed_count += 1
+        entries.append({"name": name, "passed": ok, "message": msg})
+
+    total = len(check_names)
+    score = round(passed_count / total, 4) if total > 0 else 0.0
+    failed = [e["name"] for e in entries if not e["passed"]]
+    if failed:
+        details = f"{passed_count}/{total} checks passed. Failed: {', '.join(failed)}"
+    else:
+        details = f"All {total} checks passed."
+    return {"score": score, "details": details, "checks": entries}
+
+
+# ---------------------------------------------------------------------------
+# Text-based checks
+# ---------------------------------------------------------------------------
+#
+# Some rules grade the produced artifacts (a `.gql` query and a Python check
+# class), not the `.infrahub.yml` registration. Those checks take the raw
+# file text rather than a parsed config, so they live in TEXT_CHECKS and run
+# through run_text_checks. Each has the same (bool, str) contract as the
+# config checks above.
+
+
+def _last_node_block(gql: str) -> str | None:
+    """Return the balanced `{...}` body of the last `node {` in the query.
+
+    The innermost `node {` is the related node reached by traversal; its
+    selection set is where the comparison attribute must appear. Returns
+    None when there is no relationship traversal (fewer than two `node {`).
+    """
+    matches = list(re.finditer(r"node\s*{", gql))
+    if len(matches) < 2:
+        return None
+    start = matches[-1].end() - 1  # index of the opening brace
+    depth = 0
+    for i in range(start, len(gql)):
+        ch = gql[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return gql[start + 1 : i]
+    return gql[start + 1 :]  # unbalanced; grade against the remainder
+
+
+def _none_guard_blocks(py: str) -> list[str]:
+    """Return the body of each `if <parent> is None:` / `if not <parent>:` block.
+
+    Restricted to None / empty-truthiness guards so a `status not in ALLOWED`
+    comparison is not mistaken for an unresolvable-parent guard.
+    """
+    lines = py.split("\n")
+    is_none = re.compile(r"^(\s*)if\s+.+\bis\s+None\s*:\s*$")
+    is_falsy = re.compile(r"^(\s*)if\s+not\s+[\w.\(\)\[\]\"']+\s*:\s*$")
+    blocks: list[str] = []
+    for i, line in enumerate(lines):
+        m = is_none.match(line) or is_falsy.match(line)
+        if not m:
+            continue
+        indent = len(m.group(1))
+        body: list[str] = []
+        for nxt in lines[i + 1 :]:
+            if not nxt.strip():
+                continue
+            if len(nxt) - len(nxt.lstrip()) <= indent:
+                break
+            body.append(nxt)
+        blocks.append("\n".join(body))
+    return blocks
+
+
+def text_child_status_filter(gql: str, py: str) -> tuple[bool, str]:
+    """The query filters the child set by an attribute value (e.g. status__value:)."""
+    if re.search(r"\w+__value\s*:", gql):
+        return True, "Query filters children by an attribute value"
+    return False, "Query has no `<attr>__value:` filter selecting the constrained children"
+
+
+def text_traverses_related_node(gql: str, py: str) -> tuple[bool, str]:
+    """The query nests into a related node (>= 2 `node {` blocks)."""
+    opens = len(re.findall(r"node\s*{", gql))
+    if opens >= 2:
+        return True, f"Query traverses into a related node ({opens} `node {{` blocks)"
+    return False, "Query does not traverse a relationship into a nested `node {` block"
+
+
+def text_fetches_related_attribute_value(gql: str, py: str) -> tuple[bool, str]:
+    """The comparison attribute is selected inside the innermost related node.
+
+    Guards finding 1: selecting the child's own `name { value }` after the
+    nested block must not satisfy this — the value has to sit in the related
+    node's own selection set.
+    """
+    block = _last_node_block(gql)
+    if block is None:
+        return False, "No nested related node to hold the comparison attribute"
+    if re.search(r"\bvalue\b", block):
+        return True, "Innermost related node selects an attribute value (parent state is fetched)"
+    return False, "Innermost related node selects no attribute `value`; parent state is not fetched"
+
+
+def text_uses_infrahubcheck(gql: str, py: str) -> tuple[bool, str]:
+    """Python defines an InfrahubCheck subclass bound to a query."""
+    if "InfrahubCheck" in py and re.search(r"query\s*=", py):
+        return True, "Defines an InfrahubCheck with a `query =` binding"
+    return False, "No InfrahubCheck subclass with a `query =` attribute"
+
+
+def text_surfaces_violation(gql: str, py: str) -> tuple[bool, str]:
+    """validate() surfaces a mismatch via log_error (blocks the merge)."""
+    if re.search(r"log_error\s*\(", py):
+        return True, "Reports a violation with log_error"
+    return False, "validate() never calls log_error, so no violation is surfaced"
+
+
+def text_null_safe_traversal(gql: str, py: str) -> tuple[bool, str]:
+    """Each relationship hop is guarded against null (`or {}` / `.get(k, {})`)."""
+    if "or {}" in py or re.search(r"\.get\([^)]*,\s*{}\)", py):
+        return True, "Guards each relationship hop against null (`or {}` / `.get(k, {})`)"
+    return False, "No per-hop null guard (`or {}` / `.get(k, {})`) on the relationship walk"
+
+
+def text_flags_unresolvable_parent(gql: str, py: str) -> tuple[bool, str]:
+    """An unresolvable related node is flagged, not silently skipped.
+
+    Guards finding 2: `if parent is None: continue` (a skip) must fail; the
+    branch has to call log_error. Absence of any such guard also fails,
+    since the rule requires handling the unresolvable case explicitly.
+    """
+    blocks = _none_guard_blocks(py)
+    if not blocks:
+        return False, "No guard for an unresolvable related node (the rule requires flagging it)"
+    if any("log_error" in b for b in blocks):
+        return True, "Flags an unresolvable related node with log_error instead of skipping"
+    return False, "The unresolvable-parent branch skips (continue/return) without log_error"
+
+
+TEXT_CHECKS: dict[str, Any] = {
+    "child-status-filter": text_child_status_filter,
+    "traverses-related-node": text_traverses_related_node,
+    "fetches-related-attribute-value": text_fetches_related_attribute_value,
+    "uses-infrahubcheck": text_uses_infrahubcheck,
+    "surfaces-violation": text_surfaces_violation,
+    "null-safe-traversal": text_null_safe_traversal,
+    "flags-unresolvable-parent": text_flags_unresolvable_parent,
+}
+
+
+def run_text_checks(check_names: list[str], sources: dict[str, str]) -> dict:
+    """Run named TEXT_CHECKS against produced source files and return skillgrade JSON.
+
+    `sources` maps a label (e.g. "gql", "py") to that file's raw text.
+    """
+    gql = sources.get("gql", "")
+    py = sources.get("py", "")
+
+    entries: list[dict] = []
+    passed_count = 0
+    for name in check_names:
+        fn = TEXT_CHECKS[name]
+        try:
+            ok, msg = fn(gql, py)
         except Exception as exc:  # pragma: no cover
             ok, msg = False, f"Error running check: {exc}"
         if ok:

--- a/graders/managing-checks/lib.py
+++ b/graders/managing-checks/lib.py
@@ -10,7 +10,9 @@ field on `check_definitions`) lives.
 
 from __future__ import annotations
 
+import ast
 import re
+import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -220,53 +222,57 @@ def run_checks(check_names: list[str], output_path: Path) -> dict:
 # config checks above.
 
 
-def _last_node_block(gql: str) -> str | None:
-    """Return the balanced `{...}` body of the last `node {` in the query.
+def _traversed_node_blocks(gql: str) -> list[str]:
+    """Selection set of every `node {` after the first (the filtered child's own).
 
-    The innermost `node {` is the related node reached by traversal; its
-    selection set is where the comparison attribute must appear. Returns
-    None when there is no relationship traversal (fewer than two `node {`).
+    Excluding the first `node {` keeps the child's own `name { value }` from
+    satisfying the fetch assertion, while returning *every* traversed block
+    (not only the textually last one) so a correct answer whose comparison
+    traversal is followed by a sibling selection still counts.
     """
     matches = list(re.finditer(r"node\s*{", gql))
-    if len(matches) < 2:
-        return None
-    start = matches[-1].end() - 1  # index of the opening brace
-    depth = 0
-    for i in range(start, len(gql)):
-        ch = gql[i]
-        if ch == "{":
-            depth += 1
-        elif ch == "}":
-            depth -= 1
-            if depth == 0:
-                return gql[start + 1 : i]
-    return gql[start + 1 :]  # unbalanced; grade against the remainder
-
-
-def _none_guard_blocks(py: str) -> list[str]:
-    """Return the body of each `if <parent> is None:` / `if not <parent>:` block.
-
-    Restricted to None / empty-truthiness guards so a `status not in ALLOWED`
-    comparison is not mistaken for an unresolvable-parent guard.
-    """
-    lines = py.split("\n")
-    is_none = re.compile(r"^(\s*)if\s+.+\bis\s+None\s*:\s*$")
-    is_falsy = re.compile(r"^(\s*)if\s+not\s+[\w.\(\)\[\]\"']+\s*:\s*$")
     blocks: list[str] = []
-    for i, line in enumerate(lines):
-        m = is_none.match(line) or is_falsy.match(line)
-        if not m:
-            continue
-        indent = len(m.group(1))
-        body: list[str] = []
-        for nxt in lines[i + 1 :]:
-            if not nxt.strip():
-                continue
-            if len(nxt) - len(nxt.lstrip()) <= indent:
-                break
-            body.append(nxt)
-        blocks.append("\n".join(body))
+    for m in matches[1:]:
+        start = m.end() - 1  # index of the opening brace
+        depth = 0
+        for i in range(start, len(gql)):
+            ch = gql[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(gql[start + 1 : i])
+                    break
+        else:
+            blocks.append(gql[start + 1 :])  # unbalanced; grade against the remainder
     return blocks
+
+
+def _skips_unresolvable_without_log(py: str) -> bool | None:
+    """Does any `if` branch skip (continue/return) without logging first?
+
+    Semantic, idiom-agnostic detection of the anti-pattern the rule forbids
+    (`if dev is None: continue`), instead of matching guard syntax. Returns
+    None when the source cannot be parsed, so the caller can fall back.
+    """
+    try:
+        tree = ast.parse(textwrap.dedent(py))
+    except SyntaxError:
+        return None
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        skips = any(isinstance(s, (ast.Continue, ast.Return)) for s in ast.walk(node))
+        logged = any(
+            isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Attribute)
+            and c.func.attr == "log_error"
+            for c in ast.walk(node)
+        )
+        if skips and not logged:
+            return True
+    return False
 
 
 def text_child_status_filter(gql: str, py: str) -> tuple[bool, str]:
@@ -284,19 +290,24 @@ def text_traverses_related_node(gql: str, py: str) -> tuple[bool, str]:
     return False, "Query does not traverse a relationship into a nested `node {` block"
 
 
-def text_fetches_related_attribute_value(gql: str, py: str) -> tuple[bool, str]:
-    """The comparison attribute is selected inside the innermost related node.
+def text_fetches_related_attribute_value(
+    gql: str, py: str, attr: str = "status"
+) -> tuple[bool, str]:
+    """The *named* comparison attribute is selected inside a traversed related node.
 
-    Guards finding 1: selecting the child's own `name { value }` after the
-    nested block must not satisfy this — the value has to sit in the related
-    node's own selection set.
+    The assertion carries the rule's thesis — the comparison attribute has to
+    be pulled in the same query — so it matches the attribute by name (default
+    `status`). Fetching some other attribute (e.g. the parent's `name`) on the
+    traversed node no longer passes, and the child's own attributes are
+    excluded because the child's `node {` is skipped.
     """
-    block = _last_node_block(gql)
-    if block is None:
-        return False, "No nested related node to hold the comparison attribute"
-    if re.search(r"\bvalue\b", block):
-        return True, "Innermost related node selects an attribute value (parent state is fetched)"
-    return False, "Innermost related node selects no attribute `value`; parent state is not fetched"
+    blocks = _traversed_node_blocks(gql)
+    if not blocks:
+        return False, "Query does not traverse into a related node"
+    pattern = re.compile(rf"\b{re.escape(attr)}\s*\{{\s*value\b")
+    if any(pattern.search(b) for b in blocks):
+        return True, f"A traversed related node selects `{attr} {{ value }}` (parent state is fetched)"
+    return False, f"No traversed related node selects `{attr} {{ value }}`; the comparison attribute is not fetched"
 
 
 def text_uses_infrahubcheck(gql: str, py: str) -> tuple[bool, str]:
@@ -314,25 +325,33 @@ def text_surfaces_violation(gql: str, py: str) -> tuple[bool, str]:
 
 
 def text_null_safe_traversal(gql: str, py: str) -> tuple[bool, str]:
-    """Each relationship hop is guarded against null (`or {}` / `.get(k, {})`)."""
+    """The relationship walk uses a null-guard idiom (`or {}` / `.get(k, {})`).
+
+    Checks the idiom is present, not that every hop is covered (that would need
+    to count hops against guards); the message says what it verifies.
+    """
     if "or {}" in py or re.search(r"\.get\([^)]*,\s*{}\)", py):
-        return True, "Guards each relationship hop against null (`or {}` / `.get(k, {})`)"
-    return False, "No per-hop null guard (`or {}` / `.get(k, {})`) on the relationship walk"
+        return True, "Relationship walk uses a null guard (`or {}` / `.get(k, {})`)"
+    return False, "No null guard (`or {}` / `.get(k, {})`) on the relationship walk"
 
 
 def text_flags_unresolvable_parent(gql: str, py: str) -> tuple[bool, str]:
     """An unresolvable related node is flagged, not silently skipped.
 
-    Guards finding 2: `if parent is None: continue` (a skip) must fail; the
-    branch has to call log_error. Absence of any such guard also fails,
-    since the rule requires handling the unresolvable case explicitly.
+    Guards finding 2 semantically: any `if` branch that skips (continue/return)
+    without a log_error is the anti-pattern (`if dev is None: continue`),
+    regardless of how the condition is written. Passing also requires a
+    log_error somewhere, so the unresolvable case is actually surfaced.
     """
-    blocks = _none_guard_blocks(py)
-    if not blocks:
-        return False, "No guard for an unresolvable related node (the rule requires flagging it)"
-    if any("log_error" in b for b in blocks):
-        return True, "Flags an unresolvable related node with log_error instead of skipping"
-    return False, "The unresolvable-parent branch skips (continue/return) without log_error"
+    skips = _skips_unresolvable_without_log(py)
+    if skips is None:  # unparseable — fall back to the classic textual anti-pattern
+        classic = re.search(r"(is\s+None|if\s+not\s+[\w.\[\]()]+)\s*:\s*\n\s*(continue|return)\b", py)
+        skips = bool(classic)
+    if skips:
+        return False, "An unresolvable-relationship branch skips (continue/return) without log_error"
+    if not re.search(r"log_error\s*\(", py):
+        return False, "No log_error on the unresolvable-relationship path"
+    return True, "Flags an unresolvable related node instead of skipping it"
 
 
 TEXT_CHECKS: dict[str, Any] = {
@@ -346,10 +365,14 @@ TEXT_CHECKS: dict[str, Any] = {
 }
 
 
-def run_text_checks(check_names: list[str], sources: dict[str, str]) -> dict:
+def run_text_checks(
+    check_names: list[str], sources: dict[str, str], attr: str = "status"
+) -> dict:
     """Run named TEXT_CHECKS against produced source files and return skillgrade JSON.
 
-    `sources` maps a label (e.g. "gql", "py") to that file's raw text.
+    `sources` maps a label (e.g. "gql", "py") to that file's raw text. `attr` is
+    the comparison attribute the query must fetch on the related node, passed to
+    the fetch check so it stays generic per task rather than hardcoded.
     """
     gql = sources.get("gql", "")
     py = sources.get("py", "")
@@ -359,7 +382,10 @@ def run_text_checks(check_names: list[str], sources: dict[str, str]) -> dict:
     for name in check_names:
         fn = TEXT_CHECKS[name]
         try:
-            ok, msg = fn(gql, py)
+            if name == "fetches-related-attribute-value":
+                ok, msg = fn(gql, py, attr)
+            else:
+                ok, msg = fn(gql, py)
         except Exception as exc:  # pragma: no cover
             ok, msg = False, f"Error running check: {exc}"
         if ok:

--- a/skills/infrahub-managing-checks/SKILL.md
+++ b/skills/infrahub-managing-checks/SKILL.md
@@ -57,7 +57,7 @@ Existing queries:
 | CRITICAL | Python Class | `python-` | InfrahubCheck base class, validate(), log_error/log_info |
 | HIGH | API Reference | `api-` | Class attributes, instance properties, methods, lifecycle |
 | HIGH | Registration | `registration-` | .infrahub.yml config, query name matching, parameters |
-| MEDIUM | Patterns | `patterns-` | Error collection, shared utilities, scoped validation |
+| MEDIUM | Patterns | `patterns-` | Error collection, shared utilities, scoped validation, relationship-traversal validation |
 | HIGH | Testing | `testing-` | Resources Testing Framework (YAML-driven tests), infrahubctl check commands |
 
 <!-- markdownlint-enable MD013 -->
@@ -72,6 +72,7 @@ are actually schema-side gaps:
 | --------------- | ------------------------------------- | --- |
 | Reads an attribute via GraphQL | Expose it on the schema node with the same name (`name__value`-shaped paths) | [../infrahub-managing-schemas/rules/attribute-defaults-and-types.md](../infrahub-managing-schemas/rules/attribute-defaults-and-types.md) |
 | Walks a relationship to validate related objects | Have both sides of the relationship defined with matching identifiers; otherwise the traversal returns nothing | [../infrahub-managing-schemas/rules/relationship-identifiers.md](../infrahub-managing-schemas/rules/relationship-identifiers.md) |
+| Validates a node against a related node's state (child vs parent lifecycle, peer consistency) | Fetch the related node's comparison attribute in the query by traversing the relationship; a check runs one query with no lazy fetch | [rules/patterns-relationship-traversal.md](./rules/patterns-relationship-traversal.md) |
 | Is targeted (per-object) | Register a `CoreStandardGroup` as `targets:` in `.infrahub.yml` and map `parameters:` to bind GraphQL variables | [rules/registration-config.md](./rules/registration-config.md) |
 | Needs the GraphQL response keyed to typed nodes | Select `id` and `__typename` in the query — the SDK relies on both | [../infrahub-common/graphql-queries.md](../infrahub-common/graphql-queries.md) |
 | Should never block a merge but only annotate | Use `self.log_info()` instead of `log_error()`; `log_warning()` does not exist | [rules/python-validate.md](./rules/python-validate.md) |

--- a/skills/infrahub-managing-checks/SKILL.md
+++ b/skills/infrahub-managing-checks/SKILL.md
@@ -154,7 +154,12 @@ Follow these steps when creating a check:
 2. **Write the GraphQL query** — Create a `.gql` file
    that fetches the data to validate. Read
    [../infrahub-common/graphql-queries.md](../infrahub-common/graphql-queries.md)
-   for query patterns.
+   for query patterns. If the rule compares a node
+   against a related node's state (child vs parent
+   lifecycle, peer consistency), the query must fetch
+   that related attribute by traversing the relationship
+   now — a check runs one query with no later fetch. See
+   [rules/patterns-relationship-traversal.md](./rules/patterns-relationship-traversal.md).
 3. **Implement the Python class** — Inherit from
    `InfrahubCheck`, implement `validate()`. Read
    [rules/python-validate.md](./rules/python-validate.md)

--- a/skills/infrahub-managing-checks/rules/_sections.md
+++ b/skills/infrahub-managing-checks/rules/_sections.md
@@ -23,6 +23,8 @@
 
 5. **Patterns (patterns-)** -- MEDIUM. Error collection
    before logging, shared utility functions (common.py),
-   scoped validation for performance on large datasets.
+   scoped validation for performance on large datasets,
+   relationship-traversal validation (comparing a node
+   against a related node's fetched state).
 
 6. **Testing (testing-)** -- HIGH. Resources Testing Framework (YAML-driven pytest tests: smoke, unit, integration), infrahubctl check commands. Always create tests alongside new checks.

--- a/skills/infrahub-managing-checks/rules/patterns-relationship-traversal.md
+++ b/skills/infrahub-managing-checks/rules/patterns-relationship-traversal.md
@@ -1,0 +1,125 @@
+---
+title: Relationship-Traversal Validation
+impact: MEDIUM
+tags: patterns, relationship, traversal, parent, cross-object, lifecycle
+---
+
+## Relationship-Traversal Validation
+
+Impact: MEDIUM
+
+To validate a node against a *related* node's state
+(a child against its parent's lifecycle, a peer
+against another peer), fetch the related node's
+comparison attribute inside the GraphQL query via
+relationship traversal, then read that nested value in
+`validate()`. Treat an unresolvable related node as a
+violation, not a silent skip.
+
+### Why it matters
+
+A check runs its `self.query` exactly once and receives
+the single result as `data`; there is no lazy fetch
+inside `validate()`. An attribute you did not select in
+the query is simply absent from `data`, so a check that
+selects only the child cannot see the parent's state at
+all. The naive fix — issue one extra query per node
+from inside `validate()` — is not available in the check
+execution model and would be O(n) round trips even if it
+were. The comparison attribute has to be pulled in the
+same query by walking the relationship.
+
+Both sides of the relationship must be defined with
+matching identifiers, or the traversal returns nothing
+(see
+[../../infrahub-managing-schemas/rules/relationship-identifiers.md](../../infrahub-managing-schemas/rules/relationship-identifiers.md)).
+
+### Fetch the related node's attribute in the query
+
+Filter the child set, then traverse into the related
+node and select the attribute you will compare against
+(here, a container's `status`):
+
+```graphql
+query InstallOrdering {
+  DcimModule(status__value: "installed") {
+    edges {
+      node {
+        id
+        name { value }
+        installed_in {
+          node {
+            container {
+              node { id name { value } status { value } }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The nested `container { node { status { value } } }`
+is the whole point: without it, `validate()` has no
+parent status to test.
+
+### Read the nested value and flag the mismatch
+
+Unwrap defensively — a relationship can be null — and
+surface an unresolvable parent as its own error rather
+than skipping it, so a broken link cannot pass silently:
+
+```python
+ALLOWED_CONTAINER_STATUS = {"installed", "maintenance"}
+
+
+class DcimInstallOrderingCheck(InfrahubCheck):
+    query = "dcim_install_ordering"
+
+    def validate(self, data: dict) -> None:
+        for edge in data["DcimModule"]["edges"]:
+            node = edge["node"]
+            bay = (node.get("installed_in") or {}).get("node")
+            container = ((bay or {}).get("container") or {}).get("node")
+            name = node["name"]["value"]
+            if container is None:
+                self.log_error(
+                    message=f"{name} is 'installed' but has no resolvable container",
+                    object_id=node["id"],
+                    object_type="DcimModule",
+                )
+                continue
+            status = (container.get("status") or {}).get("value")
+            if status not in ALLOWED_CONTAINER_STATUS:
+                self.log_error(
+                    message=(
+                        f"{name} is 'installed' but its container "
+                        f"{container['name']['value']} is '{status}'"
+                    ),
+                    object_id=node["id"],
+                    object_type="DcimModule",
+                )
+```
+
+### Exempt the root of the chain
+
+The top of a containment hierarchy has no parent (a
+chassis is installed into nothing), so exempt it rather
+than flagging it as "no resolvable container". Scope the
+query to the kinds that *have* a parent, or branch on
+kind in `validate()`.
+
+### Common mistakes
+
+- Querying only the child and discovering in `validate()`
+  that the parent's status was never fetched.
+- Skipping a node whose relationship is null instead of
+  flagging it — a dangling link then merges unnoticed.
+- Assuming every nested `node` is present; each hop
+  (`installed_in`, `container`) can be null and needs an
+  `or {}` guard before the next `.get`.
+
+Reference: [patterns-common.md](./patterns-common.md)
+for error-collection and performance bucketing, and
+[examples.md](../examples.md) for complete checks.

--- a/skills/infrahub-managing-checks/rules/patterns-relationship-traversal.md
+++ b/skills/infrahub-managing-checks/rules/patterns-relationship-traversal.md
@@ -18,16 +18,15 @@ violation, not a silent skip.
 
 ### Why it matters
 
-A check runs its `self.query` exactly once and receives
-the single result as `data`; there is no lazy fetch
-inside `validate()`. An attribute you did not select in
-the query is simply absent from `data`, so a check that
-selects only the child cannot see the parent's state at
-all. The naive fix — issue one extra query per node
-from inside `validate()` — is not available in the check
-execution model and would be O(n) round trips even if it
-were. The comparison attribute has to be pulled in the
-same query by walking the relationship.
+A check runs its `self.query` once and validates the
+single result in `data`. An attribute you did not select
+in the query is simply absent from `data`, so a check
+that selects only the child cannot see the parent's state
+from `data` at all. You *can* issue a follow-up read per
+node with `self.client`, but that is O(n) round trips
+that blow the check timeout on any real dataset. Pull the
+comparison attribute in the same query by walking the
+relationship instead.
 
 Both sides of the relationship must be defined with
 matching identifiers, or the traversal returns nothing


### PR DESCRIPTION
## What

Adds a `patterns-` rule to `infrahub-managing-checks`: **relationship-traversal validation** — how to write a check that validates a node against a *related* node's state (child vs parent lifecycle, peer consistency).

## Why

A check runs its query once and gets a single `data` payload; there is no lazy fetch inside `validate()`. So when the rule spans two related objects (e.g. "a `DcimModule` must not be `installed` while its containing chassis is not"), the related node's comparison attribute has to be pulled in the *same* query by traversing the relationship. The common failure mode is a query that selects only the child and then has no parent state to test. The skill covered error-collection and performance bucketing, but not this pattern.

The rule teaches:
- fetch the related node's attribute in the query via relationship traversal;
- unwrap the nested path null-safely (`or {}` per hop);
- surface an unresolvable related node as a violation, not a silent skip;
- exempt the root of a containment chain (it has no parent).

Grounded in a real check from a field PoC (an install-ordering guard that caught a pre-existing data inconsistency), and checked against the SDK `InfrahubCheck` API (`query`, `validate(self, data)`, `log_error(...)`).

## Rule = Test

- New rule `skills/infrahub-managing-checks/rules/patterns-relationship-traversal.md`; indexed in `_sections.md` and the SKILL.md decision table.
- New `relationship-traversal-check` task in `eval.yaml` (managing-checks 2 -> 3 tasks).
- Deterministic grader `graders/managing-checks/check_relationship_traversal.py` over the produced `.gql` / `.py`. Verified on fixtures: compliant scores 1.0, a child-only query + weak logic scores 0.33 and names the missing traversal.
- `evaluations/infrahub-managing-checks.json` regenerated via `scripts/sync-evals.py`; `dev/guides/running-evals.md` count updated.
