### PR TITLE
fix(schemas): document mandatory-relationship precondition for uniqueness constraints

### DIFF
--- a/eval.yaml
+++ b/eval.yaml
@@ -389,6 +389,59 @@ tasks:
       - name: human-friendly-id
         check: human_friendly_id defined on each node
 
+  - name: uniqueness-scoped-by-relationship
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-managing-schemas/SKILL.md and follow its workflow and rules.
+
+      Task: Create an Infrahub schema in the 'Virtualization' namespace with a Cluster node
+      (name) and a VirtualMachine node with a numeric 'vmid'. A VM records which cluster it
+      currently runs on — VMs migrate between clusters, so the cluster is a plain reference
+      rather than an owning parent. The vmid must be unique within each cluster, but the same
+      vmid can be reused on a different cluster.
+
+      Save ONLY the final schema YAML to: output.yml
+    graders:
+      - type: deterministic
+        run: python graders/managing-schemas/check_uniqueness_constraints.py
+        weight: 1.0
+    expected_output: >-
+      A schema whose VirtualMachine node scopes uniqueness with
+      uniqueness_constraints combining the bare relationship name and the
+      vmid attribute with its __value suffix, where the cluster
+      relationship is declared cardinality: one and optional: false so the
+      constraint passes server-side validation.
+    expectations:
+      - >-
+        uniqueness_constraints on VirtualMachine combines the bare
+        relationship name (cluster) with vmid__value
+      - >-
+        The cluster relationship has optional: false and cardinality: one,
+        which the server requires for any relationship a uniqueness
+        constraint reaches
+      - >-
+        No uniqueness_constraints entry uses a peer-attribute path such as
+        cluster__name__value
+      - >-
+        Any relationship reached by a human_friendly_id path is likewise
+        mandatory and cardinality: one
+      - "human_friendly_id is defined on each node"
+      - 'Schema starts with version: "1.0"'
+    assertions:
+      - name: schema-version
+        check: "Schema starts with version: '1.0'"
+      - name: uniqueness-rel-mandatory
+        check: >-
+          Every relationship reached by uniqueness_constraints or
+          human_friendly_id has optional: false and cardinality: one, and
+          constraints use bare relationship names
+      - name: matching-identifiers
+        check: Relationship identifier pairs match on both sides
+      - name: full-kind-references
+        check: All peer references use full Namespace+Name kind
+      - name: human-friendly-id
+        check: human_friendly_id defined on each node
+
   - name: inverse-identifier-reuse
     trials: 3
     instruction: |

--- a/eval.yaml
+++ b/eval.yaml
@@ -397,8 +397,9 @@ tasks:
       Task: Create an Infrahub schema in the 'Virtualization' namespace with a Cluster node
       (name) and a VirtualMachine node with a numeric 'vmid'. A VM records which cluster it
       currently runs on — VMs migrate between clusters, so the cluster is a plain reference
-      rather than an owning parent. The vmid must be unique within each cluster, but the same
-      vmid can be reused on a different cluster.
+      rather than an owning parent. Every VM always belongs to exactly one cluster. The vmid
+      must be unique within each cluster, but the same vmid can be reused on a different
+      cluster.
 
       Save ONLY the final schema YAML to: output.yml
     graders:

--- a/evaluations/infrahub-managing-schemas.json
+++ b/evaluations/infrahub-managing-schemas.json
@@ -173,6 +173,42 @@
     },
     {
       "id": 5,
+      "prompt": "Create an Infrahub schema in the 'Virtualization' namespace with a Cluster node\n(name) and a VirtualMachine node with a numeric 'vmid'. A VM records which cluster it\ncurrently runs on \u2014 VMs migrate between clusters, so the cluster is a plain reference\nrather than an owning parent. The vmid must be unique within each cluster, but the same\nvmid can be reused on a different cluster.",
+      "expected_output": "A schema whose VirtualMachine node scopes uniqueness with uniqueness_constraints combining the bare relationship name and the vmid attribute with its __value suffix, where the cluster relationship is declared cardinality: one and optional: false so the constraint passes server-side validation.",
+      "files": [],
+      "expectations": [
+        "uniqueness_constraints on VirtualMachine combines the bare relationship name (cluster) with vmid__value",
+        "The cluster relationship has optional: false and cardinality: one, which the server requires for any relationship a uniqueness constraint reaches",
+        "No uniqueness_constraints entry uses a peer-attribute path such as cluster__name__value",
+        "Any relationship reached by a human_friendly_id path is likewise mandatory and cardinality: one",
+        "human_friendly_id is defined on each node",
+        "Schema starts with version: \"1.0\""
+      ],
+      "assertions": [
+        {
+          "name": "schema-version",
+          "check": "Schema starts with version: '1.0'"
+        },
+        {
+          "name": "uniqueness-rel-mandatory",
+          "check": "Every relationship reached by uniqueness_constraints or human_friendly_id has optional: false and cardinality: one, and constraints use bare relationship names"
+        },
+        {
+          "name": "matching-identifiers",
+          "check": "Relationship identifier pairs match on both sides"
+        },
+        {
+          "name": "full-kind-references",
+          "check": "All peer references use full Namespace+Name kind"
+        },
+        {
+          "name": "human-friendly-id",
+          "check": "human_friendly_id defined on each node"
+        }
+      ]
+    },
+    {
+      "id": 6,
       "prompt": "A schema is already loaded into a running Infrahub instance. The DcimDevice node\ndeclares a forward relationship to its interfaces, and that relationship was first loaded\nWITHOUT an explicit identifier, so Infrahub auto-generated one: dcimdevice__dciminterface.\nThe DcimInterface node currently has NO relationship back to its device, so consumers that\nhold an interface cannot traverse to its device.\n\nExisting schema (do not change the DcimDevice side):\n\n  version: \"1.0\"\n  nodes:\n    - name: Device\n      namespace: Dcim\n      human_friendly_id: [\"name__value\"]\n      attributes:\n        - name: name\n          kind: Text\n      relationships:\n        - name: interfaces\n          peer: DcimInterface\n          kind: Attribute\n          cardinality: many\n          identifier: \"dcimdevice__dciminterface\"\n    - name: Interface\n      namespace: Dcim\n      human_friendly_id: [\"name__value\"]\n      attributes:\n        - name: name\n          kind: Text\n\nAdd the missing inverse `device` relationship on DcimInterface (peer DcimDevice,\ncardinality one) so the link is traversable from both sides.",
       "expected_output": "A schema where the new DcimInterface.device relationship reuses the forward side's existing identifier 'dcimdevice__dciminterface' verbatim, rather than inventing a new one (e.g. 'device__interfaces') and renaming the forward side \u2014 which would fail with not_supported because the identifier is immutable once loaded.",
       "files": [],
@@ -202,7 +238,7 @@
       ]
     },
     {
-      "id": 6,
+      "id": 7,
       "prompt": "Create an Infrahub schema for a BGP autonomous-system catalog. An AutonomousSystem\nnode has an asn (number) and a description. The display name should NOT be entered by\nthe user \u2014 it must be auto-derived from the ASN as 'AS<asn>' (e.g., 'AS65000') using a\nJinja2 computed attribute. The derived name is used as the display label and as part\nof human_friendly_id, so it must always be populated. Use namespace 'Routing'.",
       "expected_output": "A schema where the name attribute uses computed_attribute with kind: Jinja2 and a non-empty jinja2_template, paired with read_only: true (always required) and optional: false (because the value is load-bearing \u2014 used as display_label and in human_friendly_id).",
       "files": [],
@@ -234,7 +270,7 @@
       ]
     },
     {
-      "id": 7,
+      "id": 8,
       "prompt": "Create an Infrahub schema for a load-balancer VIP service. A VIPService has a\nname (Text) and references a frontend IP (IpamIPAddress). The VIPService owns a list\nof HealthCheck objects \u2014 health checks have no meaning on their own and should be\ndeleted when their VIPService is deleted. The frontend IP, however, is shared\ninfrastructure: deleting a VIPService must NOT delete its IP. Use namespace 'ServiceLB'.",
       "expected_output": "A schema where the VIPService \u2192 HealthCheck Component relationship sets on_delete: cascade explicitly (so health checks are removed when the parent VIP is deleted), and the VIPService \u2192 IP relationship either omits on_delete or sets on_delete: no-action (so the shared IP is preserved). Any kind: Parent relationship has optional: false.",
       "files": [],
@@ -275,7 +311,7 @@
       ]
     },
     {
-      "id": 8,
+      "id": 9,
       "prompt": "Create an Infrahub schema for a network-device inventory. Define a generic\nGenericDevice (with shared attributes like hostname and role) and a concrete Device\nnode that inherits from it. The concrete Device should:\n\n  - Be eligible for rendered configuration artifacts (so artifact definitions in\n    .infrahub.yml can attach to it).\n  - Be cloneable from the UI as a starter for new devices (one template per role \u2014\n    leaf, spine, edge \u2014 speeds onboarding).\n\nThe two capabilities are independent features and should be applied to the concrete\nDevice, not to the generic. Use namespace 'Dcim'.",
       "expected_output": "A schema with the GenericDevice generic carrying the shared attributes, and a concrete Device node that both inherits from CoreArtifactTarget AND sets generate_template: true. Neither flag appears on the generic.",
       "files": [],
@@ -309,7 +345,7 @@
       ]
     },
     {
-      "id": 9,
+      "id": 10,
       "prompt": "Add a DcimNetworkDiagram node to my Infrahub schema. Each diagram is a Visio\nfile attached to a LocationSite. Track a title, the author, and the date it was\nlast reviewed. The Visio file itself must be stored inside Infrahub, not as a URL.\nUse namespace 'Dcim'. The LocationSite node already exists \u2014 extend it via the\nschema's relationships rather than redefining it.",
       "expected_output": "A schema in which DcimNetworkDiagram inherits from CoreFileObject (so the Visio file lives in Infrahub object storage with auto file metadata and a GraphQL upload mutation), carries domain attributes (title, author, last_reviewed) but does NOT redeclare the reserved file_name/file_size/file_type/checksum/storage_id attributes, and links back to LocationSite via a cardinality:one relationship.",
       "files": [],
@@ -349,7 +385,7 @@
       ]
     },
     {
-      "id": 10,
+      "id": 11,
       "prompt": "Model a network-device inventory where many devices share the\nsame operational defaults (MTU, status, timezone) that operators want\nto manage in one place and change centrally. Define a generic\nGenericDevice (hostname, role) and a concrete Device node that inherits\nfrom it. Enable the mechanism that lets operators define reusable\ndefault-value sets and assign them to devices. Use namespace 'Dcim'.",
       "expected_output": "A schema whose concrete Device node sets generate_profile: true (never on the GenericDevice generic), inherits from DcimGenericDevice by full kind, and defines human_friendly_id. The shared attributes (mtu, status, timezone) are optional so Profile-supplied values apply.",
       "files": [],
@@ -374,7 +410,7 @@
       ]
     },
     {
-      "id": 11,
+      "id": 12,
       "prompt": "Create an Infrahub schema for a service-handoff intent model. Namespace: 'Service'.\n\nDefine a single node, HandoffIntent, with:\n\n  - intent_id: a Number, the unique identifier for the handoff intent.\n  - state: a Dropdown \u2014 one of draft, active, decommissioned.\n\nPlus two relationships on HandoffIntent:\n\n  - source_device: peer DcimDevice. Constraint: must point to a customer-edge\n    router where the provider hands traffic off. Non-edge devices are rejected at\n    submit by the generator's _validate() step.\n  - handoff_port: peer DcimInterface. The specific port on source_device where\n    the handover happens. The picker walks DcimDevice \u2192 DcimInterface via the\n    peer's human_friendly_id; only ports on the chosen source_device are valid.\n\nThese descriptions are operator-facing \u2014 they are the only docs operators see in the UI\ntooltip. Make sure the schema actually loads (`infrahubctl schema load`) without errors\nin addition to passing `infrahubctl schema check`.",
       "expected_output": "A schema where every string field (`description`, `label`, `identifier`, `deprecation`) stays within Infrahub's server-enforced Pydantic `max_length` caps so the schema loads cleanly. Limits are resolved live per the validation-string-limits rule (public JSON Schema primary, `/api/openapi.json` fallback); this eval does not pin specific numbers. Longer operator-facing context belongs in YAML comments next to the field, not in `description:` itself.",
       "files": [],
@@ -409,7 +445,7 @@
       ]
     },
     {
-      "id": 12,
+      "id": 13,
       "prompt": "Production incident \u2014 we need a new `maintenance_window` optional Dropdown\nattribute on DcimDevice live on our shared, team-wide Infrahub instance in the next 10\nminutes so on-call can start tagging devices. It's just one optional dropdown, totally\nadditive, zero risk. Give me the exact command to apply it to the server right now \u2014 we\ndon't have time to mess with branches and proposed changes.\n\nSave your full plan (the commands plus a brief rationale) to: output.md",
       "expected_output": "Despite the time pressure and the \"additive / zero risk\" framing, the answer should hold the line rather than hand over a bare `schema load` that targets the default branch. It creates or selects a dedicated branch (e.g. `infrahubctl branch create schema-maint-window`) and runs `infrahubctl schema check --branch <branch>` then `infrahubctl schema load --branch <branch>` on that branch, rather than loading directly into the default branch (`main` by convention, but it can be renamed). The rationale should explain that a schema load runs migrations against loaded data immediately, so applying on the default branch gives no preview and no per-step undo, whereas a branch can be previewed, merged via a proposed change after review, or discarded \u2014 and that the branch costs ~60 seconds, which is exactly what an incident needs.",
       "files": [],
@@ -431,7 +467,7 @@
       ]
     },
     {
-      "id": 13,
+      "id": 14,
       "prompt": "Our schema reviews are drowning in noise \u2014 every edit reshuffles keys and the\nreal change gets lost, so CI now rejects any schema file that isn't in our canonical\nkey order. Add a new file for patch-panel inventory: a `DcimPatchPanel` node with a\nunique name, a `rack_unit` position (number), a `status` dropdown (active, spare,\nfaulty), a free-text description, and a relationship to the rack it sits in\n(`LocationRack`, one per panel, mandatory). It has to land already formatted so the\nfirst review diff is clean.",
       "expected_output": "A schema file whose keys are already in the canonical order the skill documents, so a subsequent `infrahubctl schema format` would be a no-op. Top-level keys run `version` then `nodes`. `DcimPatchPanel` leads with `name` then `namespace`, carries `human_friendly_id` and `display_label`, and ends with `attributes` then `relationships` \u2014 no scalar keys trailing after those lists. Within each attribute and relationship, `order_weight` is the final key, with values drawn from the documented ranges (relationships 800-900 or 3000+, core attributes 1000-1999, secondary 2000-2999) rather than a flat constant. The status dropdown's choices are ordered `name`, `label`, then `color`.",
       "files": [],

--- a/evaluations/infrahub-managing-schemas.json
+++ b/evaluations/infrahub-managing-schemas.json
@@ -173,7 +173,7 @@
     },
     {
       "id": 5,
-      "prompt": "Create an Infrahub schema in the 'Virtualization' namespace with a Cluster node\n(name) and a VirtualMachine node with a numeric 'vmid'. A VM records which cluster it\ncurrently runs on \u2014 VMs migrate between clusters, so the cluster is a plain reference\nrather than an owning parent. The vmid must be unique within each cluster, but the same\nvmid can be reused on a different cluster.",
+      "prompt": "Create an Infrahub schema in the 'Virtualization' namespace with a Cluster node\n(name) and a VirtualMachine node with a numeric 'vmid'. A VM records which cluster it\ncurrently runs on \u2014 VMs migrate between clusters, so the cluster is a plain reference\nrather than an owning parent. Every VM always belongs to exactly one cluster. The vmid\nmust be unique within each cluster, but the same vmid can be reused on a different\ncluster.",
       "expected_output": "A schema whose VirtualMachine node scopes uniqueness with uniqueness_constraints combining the bare relationship name and the vmid attribute with its __value suffix, where the cluster relationship is declared cardinality: one and optional: false so the constraint passes server-side validation.",
       "files": [],
       "expectations": [

--- a/graders/managing-schemas/check_uniqueness_constraints.py
+++ b/graders/managing-schemas/check_uniqueness_constraints.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Grader for the uniqueness-constraints eval task.
+
+Verifies the constraint format (``__value`` on attributes, bare names on
+relationships) and the preconditions the server enforces on any relationship a
+constraint reaches: ``optional: false`` and ``cardinality: one``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = [
+    "schema-version",
+    "uniqueness-rel-mandatory",
+    "matching-identifiers",
+    "full-kind-references",
+    "human-friendly-id",
+]
+
+if __name__ == "__main__":
+    output_path = Path("output.yml")
+    result = run_checks(CHECKS, output_path)
+    print(json.dumps(result))

--- a/graders/managing-schemas/check_uniqueness_constraints.py
+++ b/graders/managing-schemas/check_uniqueness_constraints.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """Grader for the uniqueness-constraints eval task.
 
-Verifies the constraint format (``__value`` on attributes, bare names on
-relationships) and the preconditions the server enforces on any relationship a
-constraint reaches: ``optional: false`` and ``cardinality: one``.
+Verifies the preconditions the server enforces on any relationship a
+uniqueness constraint reaches — ``optional: false`` and ``cardinality: one`` —
+and the relationship path shape, which is inverted between the two fields:
+``uniqueness_constraints`` takes the bare name, ``human_friendly_id`` takes a
+peer-attribute path.
+
+Does NOT verify the ``__value`` suffix on plain attribute entries; a bare
+attribute name in a constraint is a separate server error
+(``invalid attribute, it must end with one of the following properties: value``)
+and is not asserted here.
 """
 
 from __future__ import annotations

--- a/graders/managing-schemas/lib.py
+++ b/graders/managing-schemas/lib.py
@@ -1056,6 +1056,82 @@ def check_choice_key_order(schema: dict, **_: Any) -> tuple[bool, str]:
     return True, f"All {seen} dropdown choice(s) are in canonical key order"
 
 
+def _resolve_rel(schema: dict, node: dict, name: str) -> dict | None:
+    """Find relationship ``name`` on ``node`` or on any generic it inherits from."""
+    for rel in _all_rels(node):
+        if rel.get("name") == name:
+            return rel
+    generics = {_full_kind(g): g for g in _all_generics(schema)}
+    for parent_kind in node.get("inherit_from", []) or []:
+        parent = generics.get(parent_kind)
+        if not parent:
+            continue
+        for rel in _all_rels(parent):
+            if rel.get("name") == name:
+                return rel
+    return None
+
+
+def check_uniqueness_rel_mandatory(schema: dict, **_: Any) -> tuple[bool, str]:
+    """Relationships reached by uniqueness_constraints or human_friendly_id must be
+    mandatory and single-valued.
+
+    Server-validated: a relationship named in a constraint must have
+    `optional: false` and `cardinality: one`, and must be referenced by its bare
+    name rather than a peer-attribute path. A human_friendly_id is converted into
+    a uniqueness constraint, so the same requirement reaches its relationships.
+    """
+    all_items = _all_nodes(schema) + _all_generics(schema)
+    bad: list[str] = []
+    found_any = False
+
+    for node in all_items:
+        ref = _full_kind(node)
+        targets: list[tuple[str, str]] = []
+
+        for entry in node.get("uniqueness_constraints") or []:
+            for token in entry or []:
+                if not isinstance(token, str):
+                    continue
+                head = token.split("__", 1)[0]
+                if "__" in token:
+                    # A peer-attribute path is only a violation when the head
+                    # actually names a relationship; otherwise it is an attribute.
+                    if _resolve_rel(schema, node, head) is not None:
+                        bad.append(
+                            f"{ref}.uniqueness_constraints uses peer-attribute path "
+                            f"{token!r}; use the bare relationship name {head!r}"
+                        )
+                    continue
+                targets.append(("uniqueness_constraints", head))
+
+        for token in node.get("human_friendly_id") or []:
+            if not isinstance(token, str):
+                continue
+            head = token.split("__", 1)[0]
+            if _resolve_rel(schema, node, head) is not None:
+                targets.append(("human_friendly_id", head))
+
+        for source, rel_name in targets:
+            rel = _resolve_rel(schema, node, rel_name)
+            if rel is None:
+                # Bare token naming an attribute (or an unresolvable inherited
+                # field) — not this check's concern.
+                continue
+            found_any = True
+            where = f"{ref}.{rel_name} (via {source})"
+            if rel.get("optional", True) is not False:
+                bad.append(f"{where} missing optional: false")
+            if rel.get("cardinality") != "one":
+                bad.append(f"{where} cardinality is {rel.get('cardinality')!r}, expected 'one'")
+
+    if bad:
+        return False, "; ".join(bad)
+    if not found_any:
+        return False, "No relationship reached by uniqueness_constraints or human_friendly_id found"
+    return True, "All relationships used for uniqueness are mandatory and cardinality: one"
+
+
 CHECKS: dict[str, Any] = {
     "attr-min-length": check_attr_min_length,
     "dropdown-for-status": check_dropdown_for_status,
@@ -1074,6 +1150,7 @@ CHECKS: dict[str, Any] = {
     "attribute-kind-relationships": check_attribute_kind_relationships,
     "endpoint-device-relationship": check_endpoint_device_relationship,
     "parent-rel-optional-false": check_parent_rel_optional_false,
+    "uniqueness-rel-mandatory": check_uniqueness_rel_mandatory,
     "parent-rel-single": check_parent_rel_single,
     "computed-jinja2-readonly": check_computed_jinja2_readonly,
     "computed-jinja2-kind": check_computed_jinja2_kind,

--- a/graders/managing-schemas/lib.py
+++ b/graders/managing-schemas/lib.py
@@ -1077,9 +1077,14 @@ def check_uniqueness_rel_mandatory(schema: dict, **_: Any) -> tuple[bool, str]:
     mandatory and single-valued.
 
     Server-validated: a relationship named in a constraint must have
-    `optional: false` and `cardinality: one`, and must be referenced by its bare
-    name rather than a peer-attribute path. A human_friendly_id is converted into
-    a uniqueness constraint, so the same requirement reaches its relationships.
+    `optional: false` and `cardinality: one`. A human_friendly_id is converted
+    into a uniqueness constraint, so the same two requirements reach its
+    relationships.
+
+    The path shape is inverted between the two fields: `uniqueness_constraints`
+    takes the bare relationship name and rejects a peer-attribute path, while
+    `human_friendly_id` requires the peer-attribute path and rejects the bare
+    name. Both directions are asserted here.
     """
     all_items = _all_nodes(schema) + _all_generics(schema)
     bad: list[str] = []
@@ -1110,6 +1115,16 @@ def check_uniqueness_rel_mandatory(schema: dict, **_: Any) -> tuple[bool, str]:
                 continue
             head = token.split("__", 1)[0]
             if _resolve_rel(schema, node, head) is not None:
+                # Path shape is inverted from uniqueness_constraints: an HFID
+                # must traverse to a peer attribute, never name the bare
+                # relationship.
+                if "__" not in token:
+                    bad.append(
+                        f"{ref}.human_friendly_id uses bare relationship name "
+                        f"{token!r}; use a peer-attribute path such as "
+                        f"{token}__<attr>__value"
+                    )
+                    continue
                 targets.append(("human_friendly_id", head))
 
         for source, rel_name in targets:

--- a/graders/managing-schemas/lib.py
+++ b/graders/managing-schemas/lib.py
@@ -1057,7 +1057,12 @@ def check_choice_key_order(schema: dict, **_: Any) -> tuple[bool, str]:
 
 
 def _resolve_rel(schema: dict, node: dict, name: str) -> dict | None:
-    """Find relationship ``name`` on ``node`` or on any generic it inherits from."""
+    """Find relationship ``name`` on ``node`` or on any generic it inherits from.
+
+    The walk over ``inherit_from`` is single-level, which is complete only while
+    Infrahub generics cannot themselves inherit from other generics. If that
+    changes upstream, this needs to become a recursive walk.
+    """
     for rel in _all_rels(node):
         if rel.get("name") == name:
             return rel

--- a/skills/infrahub-managing-schemas/SKILL.md
+++ b/skills/infrahub-managing-schemas/SKILL.md
@@ -55,7 +55,7 @@ use the first argument as the namespace and remaining arguments as node names.
 | HIGH | Hierarchy | `hierarchy-` | Hierarchical generics, parent/children |
 | HIGH | Display | `display-` | human_friendly_id, order_weight, menu placement |
 | MEDIUM | Extensions | `extension-` | Cross-file via extensions block, artifact targets |
-| MEDIUM | Uniqueness | `uniqueness-` | Constraint format, __value suffix |
+| MEDIUM | Uniqueness | `uniqueness-` | Constraint format, __value suffix, mandatory relationships |
 | MEDIUM | Migration | `migration-` | Add/remove attributes, state: absent |
 | MEDIUM | File Formatting | `format-` | Canonical key order; `infrahubctl schema format` (offline) |
 | HIGH | Validation | `validation-` | Load-time string-length caps (description / label / identifier), common error messages, pre-check checklist |

--- a/skills/infrahub-managing-schemas/rules/_sections.md
+++ b/skills/infrahub-managing-schemas/rules/_sections.md
@@ -49,8 +49,11 @@
 
 8. **Uniqueness (uniqueness-)** — MEDIUM. Uniqueness
    constraint format with __value suffix for
-   attributes. Incorrect format causes validation
-   errors.
+   attributes and bare names for relationships, plus
+   the preconditions a referenced relationship must
+   meet (`optional: false`, `cardinality: one`).
+   Incorrect format or an optional relationship causes
+   validation errors.
 
 9. **Migration (migration-)** — MEDIUM. Adding,
    removing, and renaming attributes safely. Using

--- a/skills/infrahub-managing-schemas/rules/uniqueness-constraints.md
+++ b/skills/infrahub-managing-schemas/rules/uniqueness-constraints.md
@@ -60,7 +60,12 @@ below are checked at schema load.
 | ----------- | ------------------- | ----------------- |
 | Mandatory | `optional: false` | `cannot use <name> relationship, relationship must be mandatory` |
 | Single-valued | `cardinality: one` | `cannot use <name> relationship, relationship must be of cardinality one` |
-| Bare name only | no peer-attribute path | `cannot use attributes of related node, only the relationship` |
+| Bare name only (constraints only — see below) | no peer-attribute path | `cannot use attributes of related node, only the relationship` |
+
+Only the first failing condition is reported. An
+optional relationship written as a peer-attribute path
+reports the mandatory error; fix that and the path
+error surfaces on the next load.
 
 The mandatory requirement is the one that surprises
 people: a constraint scoped by a relationship can only
@@ -137,8 +142,18 @@ nodes:
 
 A `human_friendly_id` is also converted into a
 uniqueness constraint behind the scenes, so a
-relationship used in an HFID must meet the same
-preconditions. The confusing part is the error: it is
+relationship reached by an HFID path must be
+`optional: false` and `cardinality: one` too.
+
+**The path shape is inverted between the two**, so do
+not carry the bare-name habit across:
+
+| Field | Relationship written as | Rejects |
+| ----- | ----------------------- | ------- |
+| `uniqueness_constraints` | bare name (`rack`) | a peer-attribute path, with `cannot use attributes of related node, only the relationship` |
+| `human_friendly_id` | peer-attribute path (`rack__name__value`) | a bare name, with `Must use attributes of related node.` |
+
+The confusing part is the mandatory error: it is
 reported against `uniqueness_constraints` even when
 you never wrote one.
 

--- a/skills/infrahub-managing-schemas/rules/uniqueness-constraints.md
+++ b/skills/infrahub-managing-schemas/rules/uniqueness-constraints.md
@@ -1,7 +1,7 @@
 ---
 title: Uniqueness Constraint Format
 impact: MEDIUM
-tags: uniqueness, constraints, validation
+tags: uniqueness, constraints, validation, mandatory, cardinality
 ---
 
 ## Uniqueness Constraint Format
@@ -9,7 +9,9 @@ tags: uniqueness, constraints, validation
 Impact: MEDIUM
 
 Uniqueness constraints reference attributes with the
-`__value` suffix and relationships by bare name.
+`__value` suffix and relationships by bare name. A
+relationship used in a constraint must also be
+mandatory and single-valued.
 
 ### Why it matters
 
@@ -47,6 +49,67 @@ uniqueness_constraints:
 | Attribute | `attribute_name__value` | `name__value` |
 | Relationship | bare name | `rack`, `device_type`, `manufacturer` |
 
+### Relationship Preconditions
+
+Naming a relationship in a constraint is not enough —
+the relationship itself has to be shaped so the
+constraint can be evaluated. All three conditions
+below are checked at schema load.
+
+| Requirement | On the relationship | Error if violated |
+| ----------- | ------------------- | ----------------- |
+| Mandatory | `optional: false` | `cannot use <name> relationship, relationship must be mandatory` |
+| Single-valued | `cardinality: one` | `cannot use <name> relationship, relationship must be of cardinality one` |
+| Bare name only | no peer-attribute path | `cannot use attributes of related node, only the relationship` |
+
+The mandatory requirement is the one that surprises
+people: a constraint scoped by a relationship can only
+be enforced if every object actually has that
+relationship set. If the relationship were optional,
+objects with no peer would have nothing to be unique
+*within*, so Infrahub rejects the schema rather than
+silently skipping those objects.
+
+This bites hardest on `kind: Attribute` relationships,
+which are optional unless you say otherwise. A
+`kind: Parent` relationship is already required to be
+`optional: false` and `cardinality: one`, so it
+satisfies the preconditions for free. See
+[relationship-defaults](./relationship-defaults.md)
+for the default values.
+
+**Incorrect** — `cluster` is optional, so the schema
+does not load:
+
+```yaml
+uniqueness_constraints:
+  - ["cluster", "vmid__value"]
+relationships:
+  - name: cluster
+    peer: VirtualizationCluster
+    kind: Attribute
+    cardinality: one
+    optional: true
+```
+
+**Correct:**
+
+```yaml
+uniqueness_constraints:
+  - ["cluster", "vmid__value"]
+relationships:
+  - name: cluster
+    peer: VirtualizationCluster
+    kind: Attribute
+    cardinality: one
+    optional: false
+```
+
+If making the relationship mandatory is wrong for your
+data model — the peer genuinely may be unset — then
+scoped uniqueness is the wrong tool. Drop the
+constraint and enforce the rule in a check instead.
+
 ### Example: Unique Device Name per Rack
 
 ```yaml
@@ -58,6 +121,45 @@ nodes:
     human_friendly_id:
       - name__value
       - rack__name__value
+    attributes:
+      - name: name
+        kind: Text
+    relationships:
+      - name: rack
+        peer: DcimRack
+        kind: Attribute
+        cardinality: one
+        optional: false           # Required — see Relationship Preconditions
+        identifier: rack__pdu
 ```
+
+### The Same Rule Reaches human_friendly_id
+
+A `human_friendly_id` is also converted into a
+uniqueness constraint behind the scenes, so a
+relationship used in an HFID must meet the same
+preconditions. The confusing part is the error: it is
+reported against `uniqueness_constraints` even when
+you never wrote one.
+
+```yaml
+# No uniqueness_constraints on this node at all, yet
+# schema load fails with:
+#   DcimPdu.uniqueness_constraints: cannot use rack
+#   relationship, relationship must be mandatory. (`rack`)
+human_friendly_id:
+  - name__value
+  - rack__name__value
+relationships:
+  - name: rack
+    peer: DcimRack
+    kind: Attribute
+    cardinality: one
+    optional: true              # <-- the actual cause
+```
+
+If a `uniqueness_constraints` error names a
+relationship you never put in a constraint, look at
+the node's `human_friendly_id`.
 
 Reference: [Infrahub Schema Docs](https://docs.infrahub.app)

--- a/skills/infrahub-managing-schemas/rules/uniqueness-constraints.md
+++ b/skills/infrahub-managing-schemas/rules/uniqueness-constraints.md
@@ -160,7 +160,7 @@ you never wrote one.
 ```yaml
 # No uniqueness_constraints on this node at all, yet
 # schema load fails with:
-#   DcimPdu.uniqueness_constraints: cannot use rack
+#   DcimPDU.uniqueness_constraints: cannot use rack
 #   relationship, relationship must be mandatory. (`rack`)
 human_friendly_id:
   - name__value

--- a/skills/infrahub-managing-schemas/rules/validation-common-errors.md
+++ b/skills/infrahub-managing-schemas/rules/validation-common-errors.md
@@ -13,9 +13,10 @@ messages to the rule files that explain how to fix
 them.
 
 > **Note on `MUST`/`must` in this file and in
-> [relationship-defaults.md](./relationship-defaults.md)
+> [relationship-defaults.md](./relationship-defaults.md),
+> [relationship-component-parent.md](./relationship-component-parent.md)
 > and
-> [relationship-component-parent.md](./relationship-component-parent.md):**
+> [uniqueness-constraints.md](./uniqueness-constraints.md):**
 > any `must` appearing inside a quoted string or
 > backticks is a verbatim Infrahub server error
 > message — kept literal so users can grep their
@@ -122,8 +123,19 @@ the relationship from the constraint. See
 A `uniqueness_constraints` entry used a peer-attribute
 path such as `rack__name__value`. Constraints take the
 bare relationship name (`rack`). Peer-attribute paths
-are valid in `human_friendly_id`, not here. See
+are not merely allowed in `human_friendly_id` — they
+are required there. See
 [uniqueness-constraints](./uniqueness-constraints.md).
+
+### "Must use attributes of related node"
+
+The mirror of the error above, and the one you hit by
+carrying the bare-name habit from constraints into an
+HFID. A `human_friendly_id` entry named a relationship
+directly (`rack`) instead of traversing to one of its
+attributes (`rack__name__value`). See
+[uniqueness-constraints](./uniqueness-constraints.md)
+for the two path shapes side by side.
 
 ### "Unable to load the schema:" with empty body
 

--- a/skills/infrahub-managing-schemas/rules/validation-common-errors.md
+++ b/skills/infrahub-managing-schemas/rules/validation-common-errors.md
@@ -97,6 +97,34 @@ references. See
 Wrong format in constraints. See the
 [uniqueness-constraints](./uniqueness-constraints.md) rule.
 
+### "cannot use \<name\> relationship, relationship must be mandatory"
+
+A relationship named in `uniqueness_constraints` has
+`optional: true` (or no explicit value — relationships
+default to optional). Set `optional: false` on it.
+
+If you never wrote a constraint naming that
+relationship, check the node's `human_friendly_id`: an
+HFID becomes a uniqueness constraint, so the error is
+reported against `uniqueness_constraints` either way.
+See [uniqueness-constraints](./uniqueness-constraints.md).
+
+### "cannot use \<name\> relationship, relationship must be of cardinality one"
+
+A relationship named in `uniqueness_constraints` has
+`cardinality: many` (the default). Scoped uniqueness
+needs a single peer — set `cardinality: one`, or drop
+the relationship from the constraint. See
+[uniqueness-constraints](./uniqueness-constraints.md).
+
+### "cannot use attributes of related node, only the relationship"
+
+A `uniqueness_constraints` entry used a peer-attribute
+path such as `rack__name__value`. Constraints take the
+bare relationship name (`rack`). Peer-attribute paths
+are valid in `human_friendly_id`, not here. See
+[uniqueness-constraints](./uniqueness-constraints.md).
+
 ### "Unable to load the schema:" with empty body
 
 When `infrahubctl schema load` prints
@@ -146,6 +174,10 @@ Before running `infrahubctl schema check`, verify:
 - [ ] All Dropdown attributes have `choices` defined
 - [ ] `human_friendly_id` is set on user-facing nodes
 - [ ] `uniqueness_constraints` use `__value` for attributes
+- [ ] Every relationship named in a
+  `uniqueness_constraints` entry (or reached by a
+  `human_friendly_id` path) has `optional: false` and
+  `cardinality: one`
 - [ ] The `$schema` comment is present for IDE validation
 
 ```bash


### PR DESCRIPTION
Closes #84.

## What was wrong

A relationship named in `uniqueness_constraints` has to satisfy three
conditions, none of which were documented:

| Requirement | Error when violated |
| --- | --- |
| `optional: false` | `cannot use <name> relationship, relationship must be mandatory` |
| `cardinality: one` | `cannot use <name> relationship, relationship must be of cardinality one` |
| bare name, no peer-attribute path | `cannot use attributes of related node, only the relationship` |

The rule's own "Unique Device Name per Rack" example made this worse: it
was a fragment that declared no `rack` relationship at all, so it was not
loadable as written and gave the reader nowhere to see the precondition.

The issue reported the first condition. Checking it against the source
turned up the other two, plus a diagnostic dead end worth its own section:
a `human_friendly_id` is converted into a uniqueness constraint, so an
optional relationship reached by an HFID path fails schema load with a
`uniqueness_constraints:` error even when the node has no explicit
constraint. The error names a field the author never wrote.

## Changes

- **`rules/uniqueness-constraints.md`** — precondition table with the three
  verbatim error strings, a loadable example, the HFID section, and an
  escape hatch: when the peer genuinely may be unset, drop the constraint
  rather than forcing the relationship mandatory.
- **`rules/validation-common-errors.md`** — the three error strings added to
  the lookup table, plus a pre-validation checklist entry.
- **`_sections.md` / `SKILL.md`** — section summary updated to mention the
  relationship preconditions.
- **Eval coverage** (per the Rule = Test requirement) — new
  `uniqueness-rel-mandatory` check in `graders/managing-schemas/lib.py`, a
  `check_uniqueness_constraints.py` task grader, a
  `uniqueness-scoped-by-relationship` eval task, and regenerated
  `evaluations/`.

## Verification

Every error string here is verbatim from the validator, not paraphrased.
Confirmed against Infrahub v1.10.8 by running the schema processor in
memory over hand-built fixtures: the corrected example loads, and each
documented error reproduces from the shape the rule warns about.

The grader agrees with the real validator on all five fixtures — 1.0 on the
loadable one, and below 1.0 with the new assertion named on each of
optional-relationship, cardinality-many, peer-attribute-path, and
HFID-only violations.

