### PR TITLE
fix(reporting-skill-gaps): docs listing, three-version report header, assistant-agnostic evidence discovery

### DIFF
--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -61,6 +61,8 @@ For full lifecycle workflows. The AI generates files, loads them with `infrahubc
 | [Repo Auditor](./skills-reference/auditing-repo.mdx) | Audits a repository against Infrahub best practices |
 | [Data Importer](./skills-reference/importing-data.mdx) | Converts CSV/TSV inputs into Infrahub object YAML and loads onto a fresh branch |
 | [Diagnostics Collector](./skills-reference/collecting-diagnostics.mdx) | Guides `infrahub-collect` to gather a support bundle when Infrahub is misbehaving, and reviews it before hand-off |
+| [Issue Reporter](./skills-reference/reporting-issues.mdx) | Routes a bug or feature request to the right Infrahub-ecosystem repository and prepares a sanitized draft for your review |
+| [Skill Gap Reporter](./skills-reference/reporting-skill-gaps.mdx) | Turns friction with an Infrahub skill into a reviewed issue with a proposed rule change, filed through the Issue Reporter |
 
 A shared reference library (`infrahub-common`) provides GraphQL query syntax, `.infrahub.yml` configuration format, YAML structure conventions, and the Profiles vs Object Templates distinction to all skills.
 

--- a/eval.yaml
+++ b/eval.yaml
@@ -4968,8 +4968,9 @@ tasks:
       A response that drafts a complete report (type feature, a title
       starting with `feat:`, a filled-in body, `searched` naming the
       tracker already checked, a Skills version header read from the
-      implicated skill's own frontmatter, and an Infrahub SDK version
-      header read from the installed package), then hands the payload to
+      implicated skill's own frontmatter, and Infrahub SDK version and
+      Infrahub version headers read from `infrahubctl info`), then hands
+      the payload to
       infrahub-reporting-issues instead of running `gh issue create` or
       claiming an issue was filed itself. It names no target repository:
       routing belongs to the receiver, which resolves it from the type.
@@ -4979,6 +4980,7 @@ tasks:
       - Carries a complete payload (type, title, body, searched)
       - Records the skills-plugin version whose guidance failed
       - Records the infrahub-sdk version the session ran against
+      - Records the Infrahub version the session talked to
       - Names no repository as the filing destination
       - Uses a title starting with `feat:`
     assertions:
@@ -5000,6 +5002,10 @@ tasks:
         check: >-
           Response's header records the infrahub-sdk version the session
           ran against, or `unknown`
+      - name: states-infrahub-version
+        check: >-
+          Response's header records the Infrahub version the session
+          talked to, or `unknown`
       - name: leaves-routing-to-reporter
         check: >-
           Response names no repository as the filing destination, leaving

--- a/eval.yaml
+++ b/eval.yaml
@@ -4967,8 +4967,9 @@ tasks:
     expected_output: >-
       A response that drafts a complete report (type feature, a title
       starting with `feat:`, a filled-in body, `searched` naming the
-      tracker already checked, and a Skills version header read from the
-      implicated skill's own frontmatter), then hands the payload to
+      tracker already checked, a Skills version header read from the
+      implicated skill's own frontmatter, and an Infrahub SDK version
+      header read from the installed package), then hands the payload to
       infrahub-reporting-issues instead of running `gh issue create` or
       claiming an issue was filed itself. It names no target repository:
       routing belongs to the receiver, which resolves it from the type.
@@ -4977,6 +4978,7 @@ tasks:
       - Runs no `gh` write commands itself and claims no issue was filed
       - Carries a complete payload (type, title, body, searched)
       - Records the skills-plugin version whose guidance failed
+      - Records the infrahub-sdk version the session ran against
       - Names no repository as the filing destination
       - Uses a title starting with `feat:`
     assertions:
@@ -4994,6 +4996,10 @@ tasks:
         check: >-
           Response's header records the skills-plugin version whose
           guidance failed, or `unknown`
+      - name: states-sdk-version
+        check: >-
+          Response's header records the infrahub-sdk version the session
+          ran against, or `unknown`
       - name: leaves-routing-to-reporter
         check: >-
           Response names no repository as the filing destination, leaving

--- a/evaluations/infrahub-reporting-skill-gaps.json
+++ b/evaluations/infrahub-reporting-skill-gaps.json
@@ -195,7 +195,7 @@
     {
       "id": 9,
       "prompt": "This friction has now shown up in two separate sessions with\ninfrahub-managing-checks. Both times, a validation check needed to\nimport a GraphQL fragment defined in another check module in the same\nrepository, and both sessions took two failed check runs to find the\ncorrect relative import path. Checking this skill's loaded rules and\nthe shared infrahub-common references turned up nothing that\naddresses sharing a fragment across check files.\n\nThe tracker has already been searched with no match. Triage\nhas already concluded this is a skill defect, and level 2 has already\nconcluded the kind: no rule or reference anywhere covers fragment\nsharing across check modules, so this is a gap the skill's own\nmaterial never claimed.\n\nWork through the rest of the workflow to completion: locate the\nimplicated rule coverage, draft the report, redact anything that\nidentifies the user's infrastructure, and take this as far as this\nskill's own steps go. Do NOT run `gh` commands or contact GitHub\nyourself; write out what you would do instead.\n\nSave your answer to: output.md",
-      "expected_output": "A response that drafts a complete report (type feature, a title starting with `feat:`, a filled-in body, `searched` naming the tracker already checked, a Skills version header read from the implicated skill's own frontmatter, and an Infrahub SDK version header read from the installed package), then hands the payload to infrahub-reporting-issues instead of running `gh issue create` or claiming an issue was filed itself. It names no target repository: routing belongs to the receiver, which resolves it from the type.",
+      "expected_output": "A response that drafts a complete report (type feature, a title starting with `feat:`, a filled-in body, `searched` naming the tracker already checked, a Skills version header read from the implicated skill's own frontmatter, and Infrahub SDK version and Infrahub version headers read from `infrahubctl info`), then hands the payload to infrahub-reporting-issues instead of running `gh issue create` or claiming an issue was filed itself. It names no target repository: routing belongs to the receiver, which resolves it from the type.",
       "files": [],
       "expectations": [
         "Hands off to infrahub-reporting-issues to file, rather than filing directly",
@@ -203,6 +203,7 @@
         "Carries a complete payload (type, title, body, searched)",
         "Records the skills-plugin version whose guidance failed",
         "Records the infrahub-sdk version the session ran against",
+        "Records the Infrahub version the session talked to",
         "Names no repository as the filing destination",
         "Uses a title starting with `feat:`"
       ],
@@ -226,6 +227,10 @@
         {
           "name": "states-sdk-version",
           "check": "Response's header records the infrahub-sdk version the session ran against, or `unknown`"
+        },
+        {
+          "name": "states-infrahub-version",
+          "check": "Response's header records the Infrahub version the session talked to, or `unknown`"
         },
         {
           "name": "leaves-routing-to-reporter",

--- a/evaluations/infrahub-reporting-skill-gaps.json
+++ b/evaluations/infrahub-reporting-skill-gaps.json
@@ -195,13 +195,14 @@
     {
       "id": 9,
       "prompt": "This friction has now shown up in two separate sessions with\ninfrahub-managing-checks. Both times, a validation check needed to\nimport a GraphQL fragment defined in another check module in the same\nrepository, and both sessions took two failed check runs to find the\ncorrect relative import path. Checking this skill's loaded rules and\nthe shared infrahub-common references turned up nothing that\naddresses sharing a fragment across check files.\n\nThe tracker has already been searched with no match. Triage\nhas already concluded this is a skill defect, and level 2 has already\nconcluded the kind: no rule or reference anywhere covers fragment\nsharing across check modules, so this is a gap the skill's own\nmaterial never claimed.\n\nWork through the rest of the workflow to completion: locate the\nimplicated rule coverage, draft the report, redact anything that\nidentifies the user's infrastructure, and take this as far as this\nskill's own steps go. Do NOT run `gh` commands or contact GitHub\nyourself; write out what you would do instead.\n\nSave your answer to: output.md",
-      "expected_output": "A response that drafts a complete report (type feature, a title starting with `feat:`, a filled-in body, `searched` naming the tracker already checked, and a Skills version header read from the implicated skill's own frontmatter), then hands the payload to infrahub-reporting-issues instead of running `gh issue create` or claiming an issue was filed itself. It names no target repository: routing belongs to the receiver, which resolves it from the type.",
+      "expected_output": "A response that drafts a complete report (type feature, a title starting with `feat:`, a filled-in body, `searched` naming the tracker already checked, a Skills version header read from the implicated skill's own frontmatter, and an Infrahub SDK version header read from the installed package), then hands the payload to infrahub-reporting-issues instead of running `gh issue create` or claiming an issue was filed itself. It names no target repository: routing belongs to the receiver, which resolves it from the type.",
       "files": [],
       "expectations": [
         "Hands off to infrahub-reporting-issues to file, rather than filing directly",
         "Runs no `gh` write commands itself and claims no issue was filed",
         "Carries a complete payload (type, title, body, searched)",
         "Records the skills-plugin version whose guidance failed",
+        "Records the infrahub-sdk version the session ran against",
         "Names no repository as the filing destination",
         "Uses a title starting with `feat:`"
       ],
@@ -221,6 +222,10 @@
         {
           "name": "states-skills-version",
           "check": "Response's header records the skills-plugin version whose guidance failed, or `unknown`"
+        },
+        {
+          "name": "states-sdk-version",
+          "check": "Response's header records the infrahub-sdk version the session ran against, or `unknown`"
         },
         {
           "name": "leaves-routing-to-reporter",

--- a/graders/reporting-skill-gaps/check_handoff_to_reporting.py
+++ b/graders/reporting-skill-gaps/check_handoff_to_reporting.py
@@ -13,6 +13,7 @@ CHECKS = [
     "no-direct-filing",
     "payload-is-complete",
     "states-skills-version",
+    "states-sdk-version",
     "leaves-routing-to-reporter",
     "title-uses-kind-prefix",
 ]

--- a/graders/reporting-skill-gaps/check_handoff_to_reporting.py
+++ b/graders/reporting-skill-gaps/check_handoff_to_reporting.py
@@ -14,6 +14,7 @@ CHECKS = [
     "payload-is-complete",
     "states-skills-version",
     "states-sdk-version",
+    "states-infrahub-version",
     "leaves-routing-to-reporter",
     "title-uses-kind-prefix",
 ]

--- a/graders/reporting-skill-gaps/lib.py
+++ b/graders/reporting-skill-gaps/lib.py
@@ -1006,6 +1006,48 @@ def check_states_skills_version(text: str, **_: object) -> CheckResult:
     )
 
 
+# The infrahub-sdk version the session ran against. Matched as its own
+# header line, and `sdk` is required, so the `**Skills version**` line
+# above cannot satisfy this check and prose that happens to mention a
+# version cannot either. A trailing suffix is allowed because pip reports
+# prereleases (`1.14.0b1`, `1.14.0rc1`). `unknown` is accepted: no SDK may
+# be installed at all, and saying so beats a guess.
+_SDK_VERSION_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?\*{0,2}(?:infrahub[ \-]?)?sdk\s+version\*{0,2}\s*[:\-]\s*"
+    r"[`\'\"]?(v?\d+\.\d+(?:\.\d+)?[0-9a-z.\-]*|unknown)",
+    re.IGNORECASE | re.MULTILINE,
+)
+# The template's own unfilled placeholder, the same trap
+# `_UNFILLED_VERSION_RE` guards for on the skills-version line.
+_UNFILLED_SDK_VERSION_RE = re.compile(
+    r"sdk\s+version\*{0,2}\s*[:\-]\s*\[", re.IGNORECASE
+)
+
+
+def check_states_sdk_version(text: str, **_: object) -> CheckResult:
+    """Output's header records the infrahub-sdk version the session ran against.
+
+    Skill rules encode SDK behavior: a CLI flag, a client method, a
+    generated protocol. Without the SDK version a maintainer cannot tell
+    whether the cited rule is wrong or merely older than the SDK that ran,
+    which is the difference between rewriting the guidance and adding a
+    version note to it.
+
+    Accepts `unknown` as a value. The read can genuinely fail, and no SDK
+    may be installed in the session at all; an explicit `unknown` is
+    honest, while a plausible-looking guess is worse than nothing.
+    """
+    if _UNFILLED_SDK_VERSION_RE.search(text):
+        return False, "SDK-version line is still an unfilled template placeholder"
+    match = _SDK_VERSION_RE.search(text)
+    if match:
+        return True, f"records the SDK version ({match.group(1)!r})"
+    return False, (
+        "no SDK-version header line found; a maintainer cannot tell whether "
+        "the cited rule is wrong or older than the SDK that ran"
+    )
+
+
 def check_hands_off_to_reporting_issues(text: str, **_: object) -> CheckResult:
     """Output references infrahub-reporting-issues for the product-defect handoff."""
     if "infrahub-reporting-issues" in text:
@@ -1599,6 +1641,7 @@ CHECKS: dict[str, CheckFn] = {
     "no-direct-filing": check_no_direct_filing,
     "payload-is-complete": check_payload_is_complete,
     "states-skills-version": check_states_skills_version,
+    "states-sdk-version": check_states_sdk_version,
     "leaves-routing-to-reporter": check_leaves_routing_to_reporter,
     "title-uses-kind-prefix": check_title_uses_kind_prefix,
     "cites-rule-file": check_cites_rule_file,

--- a/graders/reporting-skill-gaps/lib.py
+++ b/graders/reporting-skill-gaps/lib.py
@@ -1007,16 +1007,56 @@ def check_states_skills_version(text: str, **_: object) -> CheckResult:
 
 
 # The infrahub-sdk version the session ran against. Matched as its own
-# header line, and `sdk` is required, so the `**Skills version**` line
-# above cannot satisfy this check and prose that happens to mention a
-# version cannot either. A trailing suffix is allowed because pip reports
-# prereleases (`1.14.0b1`, `1.14.0rc1`). `unknown` is accepted: no SDK may
-# be installed at all, and saying so beats a guess.
+# header line, and `sdk` is required, so neither the `**Skills version**`
+# line above nor the `**Infrahub version**` line below can satisfy this
+# check, and prose that happens to mention a version cannot either. A
+# trailing suffix is allowed because prereleases exist (`1.14.0b1`,
+# `1.14.0rc1`). `unknown` is accepted: no SDK may be installed at all,
+# and saying so beats a guess.
 _SDK_VERSION_RE = re.compile(
     r"^\s*(?:[-*]\s*)?\*{0,2}(?:infrahub[ \-]?)?sdk\s+version\*{0,2}\s*[:\-]\s*"
     r"[`\'\"]?(v?\d+\.\d+(?:\.\d+)?[0-9a-z.\-]*|unknown)",
     re.IGNORECASE | re.MULTILINE,
 )
+# The Infrahub version the session talked to, which `infrahubctl info`
+# reports as `Infrahub Version` alongside `SDK Version`. `infrahub` has to
+# be followed directly by `version` (or by `server version`), so the
+# adjacent `**Infrahub SDK version**` line cannot satisfy this check.
+# `n/a` is accepted next to `unknown` because that is the literal value
+# `infrahubctl info` prints when no server is reachable, and a model
+# copying it through is being accurate rather than guessing.
+_INFRAHUB_VERSION_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?\*{0,2}infrahub(?:\s+server)?\s+version\*{0,2}\s*[:\-]\s*"
+    r"[`\'\"]?(v?\d+\.\d+(?:\.\d+)?[0-9a-z.\-]*|unknown|n/a)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_UNFILLED_INFRAHUB_VERSION_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?\*{0,2}infrahub(?:\s+server)?\s+version\*{0,2}\s*[:\-]\s*\[",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def check_states_infrahub_version(text: str, **_: object) -> CheckResult:
+    """Output's header records the Infrahub version the session talked to.
+
+    Rules split by target. One naming a CLI flag or a client method is
+    aimed at an SDK version; one about schema loading, branch behavior, or
+    a check pipeline is aimed at a server version. A report that carries
+    only the SDK version leaves the second kind unanchored.
+
+    Accepts `unknown` and `n/a`. Work done against files alone never
+    reaches a server, and `infrahubctl info` prints `N/A` when none is
+    reachable, so both are honest readings rather than guesses.
+    """
+    if _UNFILLED_INFRAHUB_VERSION_RE.search(text):
+        return False, "Infrahub-version line is still an unfilled template placeholder"
+    match = _INFRAHUB_VERSION_RE.search(text)
+    if match:
+        return True, f"records the Infrahub version ({match.group(1)!r})"
+    return False, (
+        "no Infrahub-version header line found; a maintainer cannot tell "
+        "which server behavior the cited rule was aimed at"
+    )
 # The template's own unfilled placeholder, the same trap
 # `_UNFILLED_VERSION_RE` guards for on the skills-version line.
 _UNFILLED_SDK_VERSION_RE = re.compile(
@@ -1642,6 +1682,7 @@ CHECKS: dict[str, CheckFn] = {
     "payload-is-complete": check_payload_is_complete,
     "states-skills-version": check_states_skills_version,
     "states-sdk-version": check_states_sdk_version,
+    "states-infrahub-version": check_states_infrahub_version,
     "leaves-routing-to-reporter": check_leaves_routing_to_reporter,
     "title-uses-kind-prefix": check_title_uses_kind_prefix,
     "cites-rule-file": check_cites_rule_file,

--- a/skills/infrahub-common/rules/connectivity-server-check.md
+++ b/skills/infrahub-common/rules/connectivity-server-check.md
@@ -87,13 +87,22 @@ below the same way (e.g.,
 infrahubctl info
 ```
 
-Expected output includes the server address and
-version:
+Expected output includes the address, the connection
+status, and both versions:
 
 ```text
-Infrahub server: http://localhost:8000
-Server version: x.y.z
+ Address:            http://localhost:8000
+ Connection Status:  ✅
+ Python Version:     3.12.x
+ SDK Version:        x.y.z
+ Infrahub Version:   x.y.z
+ Deployment ID:      <id>
 ```
+
+`Connection Status` is the signal to read: when it
+fails, `Infrahub Version` and `Deployment ID` come back
+`N/A` while `SDK Version` still reports, since that one
+needs no server.
 
 #### Step 2: Check environment variables
 

--- a/skills/infrahub-reporting-issues/SKILL.md
+++ b/skills/infrahub-reporting-issues/SKILL.md
@@ -255,8 +255,8 @@ Where to find versions:
 
 | Component | Command |
 | --------- | ------- |
-| Infrahub server | `infrahubctl --version`, or check `image:` tag in compose file |
-| Python SDK | `pip show infrahub-sdk` |
+| Infrahub server | `infrahubctl info` (`Infrahub Version` line), or check `image:` tag in compose file |
+| Python SDK | `infrahubctl info` (`SDK Version` line), or `pip show infrahub-sdk` |
 | Ansible collection | `ansible-galaxy collection list opsmill.infrahub` |
 | Nornir plugin | `pip show nornir-infrahub` |
 | Helm chart | `helm list -n <namespace>` |

--- a/skills/infrahub-reporting-issues/rules/environment-info-sanitization.md
+++ b/skills/infrahub-reporting-issues/rules/environment-info-sanitization.md
@@ -114,8 +114,9 @@ the partial value.
 
 ## Common Mistakes
 
-- Pasting `infrahubctl --version` output verbatim
-  when it includes a server URL.
+- Pasting `infrahubctl info` output verbatim. It
+  reports the versions you want alongside the server
+  address and deployment ID, which you do not.
 - Including stack traces without scrubbing file
   paths (they typically contain `/Users/<name>/`).
 - Pasting `pip list` or `pip freeze` output — far

--- a/skills/infrahub-reporting-issues/templates/bug.md
+++ b/skills/infrahub-reporting-issues/templates/bug.md
@@ -21,8 +21,8 @@ you observe? -->
 
 ## Environment
 
-- **Component version**: <!-- e.g., infrahub-sdk 1.5.2 -->
-- **Infrahub server version**: <!-- e.g., 1.4.0 (or "unknown") -->
+- **Component version**: <!-- e.g., infrahub-sdk 1.23.2 -->
+- **Infrahub server version**: <!-- e.g., 1.11.2 (or "unknown") -->
 - **OS / architecture**: <!-- e.g., macOS 14 arm64 -->
 - **Python version** (if applicable): <!-- e.g., 3.12 -->
 

--- a/skills/infrahub-reporting-skill-gaps/SKILL.md
+++ b/skills/infrahub-reporting-skill-gaps/SKILL.md
@@ -153,17 +153,33 @@ infrastructure or organization per
 This is security-critical and applies before the draft
 ever leaves this skill.
 
-The header carries two versions. The skills-plugin
-version whose guidance failed, read from
-`metadata.version` in the implicated skill's own SKILL.md
-frontmatter: without it a maintainer cannot tell whether
-the rule they are looking at is the one that failed. And
-the `infrahub-sdk` version the session ran against, read
-from `pip show infrahub-sdk`: skill rules encode SDK
-behavior, so without it a maintainer cannot tell whether
-the rule is wrong or merely older than the SDK in use.
-Write `unknown` for either if it cannot be read; never
-guess.
+The header carries three versions, and a report is not
+ready without all three:
+
+1. **Skills**, from `metadata.version` in the implicated
+   skill's own SKILL.md frontmatter. Says which revision
+   of the rule failed.
+2. **Infrahub SDK**, from the `SDK Version` line of
+   `infrahubctl info`. Says what a rule naming a CLI
+   flag or client method was aimed at.
+3. **Infrahub**, from the `Infrahub Version` line of
+   the same output. Says what a rule about schema
+   loading, branch behavior, or a check pipeline was
+   aimed at.
+
+Run `infrahubctl info` as
+[../infrahub-common/rules/connectivity-server-check.md](../infrahub-common/rules/connectivity-server-check.md)
+prescribes; the runner prefix matters.
+
+Without them a maintainer cannot tell whether the
+guidance is wrong or merely older than what ran, which
+is the difference between rewriting a rule and adding a
+version note to it. Copy only the version values:
+`infrahubctl info` also prints the server address and
+deployment ID, which
+[rules/evidence-no-customer-data.md](rules/evidence-no-customer-data.md)
+forbids. Write `unknown` for any of the three that
+cannot be read; never guess.
 
 This produces the three handoff fields `type`, `title`,
 and `body`. It does **not** produce a target repository:

--- a/skills/infrahub-reporting-skill-gaps/SKILL.md
+++ b/skills/infrahub-reporting-skill-gaps/SKILL.md
@@ -153,12 +153,17 @@ infrastructure or organization per
 This is security-critical and applies before the draft
 ever leaves this skill.
 
-The header carries the skills-plugin version whose
-guidance failed, read from `metadata.version` in the
-implicated skill's own SKILL.md frontmatter. Without it a
-maintainer cannot tell whether the rule they are looking
-at is the one that failed. Write `unknown` if it cannot be
-read; never guess.
+The header carries two versions. The skills-plugin
+version whose guidance failed, read from
+`metadata.version` in the implicated skill's own SKILL.md
+frontmatter: without it a maintainer cannot tell whether
+the rule they are looking at is the one that failed. And
+the `infrahub-sdk` version the session ran against, read
+from `pip show infrahub-sdk`: skill rules encode SDK
+behavior, so without it a maintainer cannot tell whether
+the rule is wrong or merely older than the SDK in use.
+Write `unknown` for either if it cannot be read; never
+guess.
 
 This produces the three handoff fields `type`, `title`,
 and `body`. It does **not** produce a target repository:

--- a/skills/infrahub-reporting-skill-gaps/reference.md
+++ b/skills/infrahub-reporting-skill-gaps/reference.md
@@ -11,39 +11,56 @@ gives enough evidence to describe the friction.
 | Priority | Source | When to use |
 | -------- | ------ | ----------- |
 | 1 | Current conversation | Always the first source. Most friction reports come from the session already in progress |
-| 2 | `~/.claude/projects/*/*.jsonl` | Optional. Only when the user points at a past session. See Transcript discovery below |
+| 2 | A past session log | Optional. Only when the user points at one. See Transcript discovery below |
 
 There is no third source, and no local record of past
 reports. The shared record is the issue tracker, read
 in step 2; see
 [rules/workflow-tracker-first.md](rules/workflow-tracker-first.md).
 
-The transcript format under `~/.claude/projects/` is
-not a public API. It can change without notice between
-Claude Code releases. If a transcript file cannot be
-parsed, skip it, fall back to the current conversation,
-and say so to the user plainly. Do not guess at a
-schema that may no longer apply, and do not treat a
-missing transcript as a reason to stop.
+Two things are **not** evidence sources. An assistant's
+own memory or context files (`MEMORY.md`, `CLAUDE.md`,
+`AGENTS.md`, and their equivalents) are self-authored
+notes, so citing them proves only that the model wrote
+something down, not that a rule failed. And a local
+draft of an earlier report is not corroboration of
+itself. Evidence comes from the ladder in
+[rules/evidence-detection-ladder.md](rules/evidence-detection-ladder.md),
+and the tracker is what carries a report across
+sessions.
 
 ## Transcript discovery
 
-Transcripts are grouped by working directory, which
-does not correspond to anything meaningful here: one
-repo spread across worktrees or clones produces many
-directories, and a skill's users share none of them.
-So search across all of them rather than deriving one
-path:
+Where session logs live is specific to the assistant
+running this skill, and no format among them is a public
+API. So do not derive a path from an assumed layout.
+Instead, in this order:
 
-```bash
-grep -rl "<term from the friction>" ~/.claude/projects/*/*.jsonl 2>/dev/null | head
-```
+1. Use the current conversation. It needs no discovery
+   and is the source for nearly every report.
+2. If the user points at a past session, ask them for
+   the file or directory unless you already know where
+   your own runtime writes session logs.
+3. If you do know, search across all of that
+   directory's project folders rather than one derived
+   path: a single repo spread over worktrees or clones
+   produces many folders, and a term from the friction
+   is the cheaper key. On Claude Code, for example, the
+   logs are line-delimited JSON under
+   `~/.claude/projects/`:
 
-This is a convenience for finding a session the user
-already remembers. It is never required, and its
-absence never blocks a report.
+   ```bash
+   grep -rl "<term from the friction>" ~/.claude/projects/*/*.jsonl 2>/dev/null | head
+   ```
 
-Friction shows up in a transcript as:
+If a log cannot be found or parsed, skip it, fall back
+to the current conversation, and say so to the user
+plainly. Do not guess at a schema that may no longer
+apply. A missing transcript is never a reason to stop:
+this step is a convenience for finding a session the
+user already remembers.
+
+Friction shows up in a session log as:
 
 - a verifier that failed and later passed on the same
   target: `infrahubctl schema load`, `schema validate`,

--- a/skills/infrahub-reporting-skill-gaps/rules/workflow-bug-vs-feature.md
+++ b/skills/infrahub-reporting-skill-gaps/rules/workflow-bug-vs-feature.md
@@ -29,12 +29,12 @@ the underlying documentation.
 
 ### What this skill can and cannot see
 
-This skill observes a Claude Code session: what the
+This skill observes an assistant session: what the
 model read, ran, and failed at. **It cannot see what a
 human read.** "The user didn't have the docs open" is
 not a signal available here, and this rule never
 pretends otherwise. The discriminator below is built
-entirely out of things visible in the transcript.
+entirely out of things visible in the session.
 
 ### The discriminating question
 

--- a/skills/infrahub-reporting-skill-gaps/templates/skill-friction.md
+++ b/skills/infrahub-reporting-skill-gaps/templates/skill-friction.md
@@ -69,13 +69,30 @@ rather than a checkout, read `version` from
 write `unknown` rather than guessing: a wrong version sends
 a maintainer to the wrong revision of the rule. -->
 **Infrahub SDK version**: [the infrahub-sdk version this session ran against]
-<!-- Run `pip show infrahub-sdk` (or `uv pip show infrahub-sdk`)
-and read the `Version` field. Skill rules encode SDK behavior:
-a CLI flag, a client method, a generated protocol. Without this
-line a maintainer cannot tell whether the rule is wrong or just
-older than the SDK that ran, which is the difference between
-rewriting guidance and adding a version note. Write `unknown`
-when no SDK is installed or the read fails; never guess. -->
+**Infrahub version**: [the version of the Infrahub the session talked to]
+<!-- Both come from one command, `infrahubctl info`, which prints
+`SDK Version` and `Infrahub Version` (the connected server's).
+Run it the way
+../infrahub-common/rules/connectivity-server-check.md
+prescribes: the runner prefix matters, so `uv run infrahubctl
+info` in a uv project. Fall back to `pip show infrahub-sdk` for
+the SDK line when infrahubctl is not installed.
+
+Copy the two version values and nothing else. That output also
+carries the server address and deployment ID, which are exactly
+what rules/evidence-no-customer-data.md forbids.
+
+Rules are aimed at one or the other: a rule naming a CLI flag or a
+client method targets an SDK version, while a rule about schema
+loading, branch behavior, or a check pipeline targets a server
+version. Without both a maintainer cannot tell whether the
+guidance is wrong or merely older than what ran, which is the
+difference between rewriting a rule and adding a version note
+to it.
+
+Write `unknown` for either when the read fails or `infrahubctl
+info` reports `N/A`; work done against files alone is a normal
+reason for the Infrahub line to be `unknown`. Never guess. -->
 **Tracker search**: [the query run against opsmill/infrahub-skills, and its result]
 
 ## What was being attempted

--- a/skills/infrahub-reporting-skill-gaps/templates/skill-friction.md
+++ b/skills/infrahub-reporting-skill-gaps/templates/skill-friction.md
@@ -68,6 +68,14 @@ rather than a checkout, read `version` from
 .claude-plugin/plugin.json instead. If neither is readable,
 write `unknown` rather than guessing: a wrong version sends
 a maintainer to the wrong revision of the rule. -->
+**Infrahub SDK version**: [the infrahub-sdk version this session ran against]
+<!-- Run `pip show infrahub-sdk` (or `uv pip show infrahub-sdk`)
+and read the `Version` field. Skill rules encode SDK behavior:
+a CLI flag, a client method, a generated protocol. Without this
+line a maintainer cannot tell whether the rule is wrong or just
+older than the SDK that ran, which is the difference between
+rewriting guidance and adding a version note. Write `unknown`
+when no SDK is installed or the read fails; never guess. -->
 **Tracker search**: [the query run against opsmill/infrahub-skills, and its result]
 
 ## What was being attempted

--- a/tests/graders/test_reporting_skill_gaps_lib.py
+++ b/tests/graders/test_reporting_skill_gaps_lib.py
@@ -1,0 +1,155 @@
+"""Tests for the version header checks in graders/reporting-skill-gaps/lib.py.
+
+Covers `states-skills-version` and `states-sdk-version` against filled
+headers, unfilled template placeholders, prose that only mentions a
+version, and each other: the two lines sit next to each other in the
+report header, so a regex that reads one as the other would pass a
+report that carries only half the information a maintainer needs.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the module directly — the hyphenated directory is not a valid Python
+# package name, so we use importlib.util to load lib.py by file path.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_LIB_PATH = _REPO_ROOT / "graders" / "reporting-skill-gaps" / "lib.py"
+_spec = importlib.util.spec_from_file_location("skill_gaps_graders_lib", _LIB_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+CHECKS = _mod.CHECKS
+check_states_skills_version = _mod.check_states_skills_version
+check_states_sdk_version = _mod.check_states_sdk_version
+
+_SKILL_DIR = _REPO_ROOT / "skills" / "infrahub-reporting-skill-gaps"
+_TEMPLATE = _SKILL_DIR / "templates" / "skill-friction.md"
+_HANDOFF_GRADER = _REPO_ROOT / "graders" / "reporting-skill-gaps" / "check_handoff_to_reporting.py"
+
+
+FILLED_HEADER = """\
+# feat: infrahub-managing-checks: sharing a GraphQL fragment across check modules
+
+**Skill**: infrahub-managing-checks
+**Type**: feature
+**Confidence**: recurring
+**Skills version**: 1.2.8
+**Infrahub SDK version**: 1.14.0
+**Tracker search**: `repo:opsmill/infrahub-skills fragment import` — no match
+"""
+
+UNFILLED_HEADER = """\
+**Skill**: [skill directory, e.g. infrahub-managing-schemas]
+**Skills version**: [the version of the skills plugin whose guidance failed]
+**Infrahub SDK version**: [the infrahub-sdk version this session ran against]
+"""
+
+
+# ---------------------------------------------------------------------------
+# states-skills-version
+# ---------------------------------------------------------------------------
+
+
+def test_skills_version_accepts_filled_header():
+    passed, detail = check_states_skills_version(FILLED_HEADER)
+    assert passed
+    assert "1.2.8" in detail
+
+
+def test_skills_version_accepts_unknown():
+    passed, _ = check_states_skills_version("**Skills version**: unknown\n")
+    assert passed
+
+
+def test_skills_version_rejects_unfilled_placeholder():
+    passed, detail = check_states_skills_version(UNFILLED_HEADER)
+    assert not passed
+    assert "placeholder" in detail
+
+
+def test_skills_version_rejects_version_only_in_prose():
+    text = "The guidance was wrong; this still worked back in 1.2.7 though.\n"
+    passed, _ = check_states_skills_version(text)
+    assert not passed
+
+
+def test_skills_version_not_satisfied_by_sdk_line():
+    """An SDK-only header must not pass as the skills version."""
+    passed, _ = check_states_skills_version("**Infrahub SDK version**: 1.14.0\n")
+    assert not passed
+
+
+# ---------------------------------------------------------------------------
+# states-sdk-version
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_version_accepts_filled_header():
+    passed, detail = check_states_sdk_version(FILLED_HEADER)
+    assert passed
+    assert "1.14.0" in detail
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "**Infrahub SDK version**: 1.14.0\n",
+        "**SDK version**: v1.14\n",
+        "- SDK version: 1.14.0b1\n",
+        "**infrahub-sdk version**: unknown\n",
+    ],
+)
+def test_sdk_version_accepts_header_variants(line):
+    passed, _ = check_states_sdk_version(line)
+    assert passed
+
+
+def test_sdk_version_rejects_unfilled_placeholder():
+    passed, detail = check_states_sdk_version(UNFILLED_HEADER)
+    assert not passed
+    assert "placeholder" in detail
+
+
+def test_sdk_version_rejects_missing_line():
+    text = FILLED_HEADER.replace("**Infrahub SDK version**: 1.14.0\n", "")
+    passed, detail = check_states_sdk_version(text)
+    assert not passed
+    assert "no SDK-version header line" in detail
+
+
+def test_sdk_version_not_satisfied_by_skills_line():
+    """A skills-version-only header must not pass as the SDK version."""
+    passed, _ = check_states_sdk_version("**Skills version**: 1.2.8\n")
+    assert not passed
+
+
+def test_sdk_version_rejects_version_only_in_prose():
+    text = "The SDK we were on shipped 1.14.0, which is where the flag moved.\n"
+    passed, _ = check_states_sdk_version(text)
+    assert not passed
+
+
+# ---------------------------------------------------------------------------
+# Wiring: registry, template, and eval grader stay in step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["states-skills-version", "states-sdk-version"])
+def test_check_is_registered(name):
+    assert name in CHECKS
+
+
+@pytest.mark.parametrize("line", ["**Skills version**", "**Infrahub SDK version**"])
+def test_template_carries_header_line(line):
+    """The graded field has to exist in the template the skill fills."""
+    assert line in _TEMPLATE.read_text()
+
+
+@pytest.mark.parametrize("name", ["states-skills-version", "states-sdk-version"])
+def test_handoff_grader_runs_check(name):
+    assert name in _HANDOFF_GRADER.read_text()

--- a/tests/graders/test_reporting_skill_gaps_lib.py
+++ b/tests/graders/test_reporting_skill_gaps_lib.py
@@ -1,10 +1,11 @@
 """Tests for the version header checks in graders/reporting-skill-gaps/lib.py.
 
-Covers `states-skills-version` and `states-sdk-version` against filled
-headers, unfilled template placeholders, prose that only mentions a
-version, and each other: the two lines sit next to each other in the
-report header, so a regex that reads one as the other would pass a
-report that carries only half the information a maintainer needs.
+Covers `states-skills-version`, `states-sdk-version`, and
+`states-infrahub-version` against filled headers, unfilled template
+placeholders, prose that only mentions a version, and each other: the
+three lines sit adjacent in the report header and two of them start with
+"Infrahub", so a regex that reads one as another would pass a report
+carrying only part of the information a maintainer needs.
 """
 
 import importlib.util
@@ -26,6 +27,7 @@ _spec.loader.exec_module(_mod)
 CHECKS = _mod.CHECKS
 check_states_skills_version = _mod.check_states_skills_version
 check_states_sdk_version = _mod.check_states_sdk_version
+check_states_infrahub_version = _mod.check_states_infrahub_version
 
 _SKILL_DIR = _REPO_ROOT / "skills" / "infrahub-reporting-skill-gaps"
 _TEMPLATE = _SKILL_DIR / "templates" / "skill-friction.md"
@@ -39,7 +41,8 @@ FILLED_HEADER = """\
 **Type**: feature
 **Confidence**: recurring
 **Skills version**: 1.2.8
-**Infrahub SDK version**: 1.14.0
+**Infrahub SDK version**: 1.23.2
+**Infrahub version**: 1.11.2
 **Tracker search**: `repo:opsmill/infrahub-skills fragment import` — no match
 """
 
@@ -47,6 +50,7 @@ UNFILLED_HEADER = """\
 **Skill**: [skill directory, e.g. infrahub-managing-schemas]
 **Skills version**: [the version of the skills plugin whose guidance failed]
 **Infrahub SDK version**: [the infrahub-sdk version this session ran against]
+**Infrahub version**: [the version of the Infrahub the session talked to]
 """
 
 
@@ -92,7 +96,7 @@ def test_skills_version_not_satisfied_by_sdk_line():
 def test_sdk_version_accepts_filled_header():
     passed, detail = check_states_sdk_version(FILLED_HEADER)
     assert passed
-    assert "1.14.0" in detail
+    assert "1.23.2" in detail
 
 
 @pytest.mark.parametrize(
@@ -116,22 +120,86 @@ def test_sdk_version_rejects_unfilled_placeholder():
 
 
 def test_sdk_version_rejects_missing_line():
-    text = FILLED_HEADER.replace("**Infrahub SDK version**: 1.14.0\n", "")
+    text = FILLED_HEADER.replace("**Infrahub SDK version**: 1.23.2\n", "")
     passed, detail = check_states_sdk_version(text)
     assert not passed
     assert "no SDK-version header line" in detail
 
 
-def test_sdk_version_not_satisfied_by_skills_line():
-    """A skills-version-only header must not pass as the SDK version."""
-    passed, _ = check_states_sdk_version("**Skills version**: 1.2.8\n")
-    assert not passed
-
-
 def test_sdk_version_rejects_version_only_in_prose():
-    text = "The SDK we were on shipped 1.14.0, which is where the flag moved.\n"
+    text = "The SDK we were on shipped 1.23.2, which is where the flag moved.\n"
     passed, _ = check_states_sdk_version(text)
     assert not passed
+
+
+# ---------------------------------------------------------------------------
+# states-infrahub-version
+# ---------------------------------------------------------------------------
+
+
+def test_infrahub_version_accepts_filled_header():
+    passed, detail = check_states_infrahub_version(FILLED_HEADER)
+    assert passed
+    assert "1.11.2" in detail
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "**Infrahub version**: 1.11.2\n",
+        "**Infrahub server version**: 1.11.2\n",
+        "- Infrahub version: unknown\n",
+        # `infrahubctl info` prints N/A when no server is reachable.
+        "**Infrahub version**: N/A\n",
+    ],
+)
+def test_infrahub_version_accepts_header_variants(line):
+    passed, _ = check_states_infrahub_version(line)
+    assert passed
+
+
+def test_infrahub_version_rejects_unfilled_placeholder():
+    passed, detail = check_states_infrahub_version(UNFILLED_HEADER)
+    assert not passed
+    assert "placeholder" in detail
+
+
+def test_infrahub_version_rejects_missing_line():
+    text = FILLED_HEADER.replace("**Infrahub version**: 1.11.2\n", "")
+    passed, detail = check_states_infrahub_version(text)
+    assert not passed
+    assert "no Infrahub-version header line" in detail
+
+
+def test_infrahub_version_rejects_version_only_in_prose():
+    text = "We were running Infrahub 1.11.2 at the time, for what it is worth.\n"
+    passed, _ = check_states_infrahub_version(text)
+    assert not passed
+
+
+# ---------------------------------------------------------------------------
+# The three header lines must not satisfy each other's checks
+# ---------------------------------------------------------------------------
+
+_CHECK_FOR_LINE = {
+    "**Skills version**: 1.2.8\n": check_states_skills_version,
+    "**Infrahub SDK version**: 1.23.2\n": check_states_sdk_version,
+    "**Infrahub version**: 1.11.2\n": check_states_infrahub_version,
+}
+
+
+@pytest.mark.parametrize("line", list(_CHECK_FOR_LINE))
+@pytest.mark.parametrize("other_line", list(_CHECK_FOR_LINE))
+def test_header_lines_do_not_cross_satisfy(line, other_line):
+    """Each line satisfies its own check and no other.
+
+    "Infrahub SDK version" and "Infrahub version" share a prefix, so a
+    loose regex on either would let a report pass while missing a version
+    a maintainer needs.
+    """
+    check = _CHECK_FOR_LINE[other_line]
+    passed, _ = check(line)
+    assert passed is (line == other_line)
 
 
 # ---------------------------------------------------------------------------
@@ -139,17 +207,27 @@ def test_sdk_version_rejects_version_only_in_prose():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("name", ["states-skills-version", "states-sdk-version"])
+_CHECK_NAMES = [
+    "states-skills-version",
+    "states-sdk-version",
+    "states-infrahub-version",
+]
+
+
+@pytest.mark.parametrize("name", _CHECK_NAMES)
 def test_check_is_registered(name):
     assert name in CHECKS
 
 
-@pytest.mark.parametrize("line", ["**Skills version**", "**Infrahub SDK version**"])
+@pytest.mark.parametrize(
+    "line",
+    ["**Skills version**", "**Infrahub SDK version**", "**Infrahub version**"],
+)
 def test_template_carries_header_line(line):
     """The graded field has to exist in the template the skill fills."""
     assert line in _TEMPLATE.read_text()
 
 
-@pytest.mark.parametrize("name", ["states-skills-version", "states-sdk-version"])
+@pytest.mark.parametrize("name", _CHECK_NAMES)
 def test_handoff_grader_runs_check(name):
     assert name in _HANDOFF_GRADER.read_text()


### PR DESCRIPTION
## 1. Gap skill missing from the docs site listing

`docs/docs/readme.mdx`'s "Skills included" table stopped at the
Diagnostics Collector, so the Skill Gap Reporter page was only reachable
from the Issue Reporter page, which was itself unlisted. Added both rows.
The root README already had them.

Not fixed: `infrahub-analyzing-diagnostics` has no reference page at all,
so it still cannot be listed.

## 2. Report header now carries three versions

It carried one — the skills version — which says which revision of a rule
failed but not what that rule was aimed at.

| Field | Source | Anchors |
| --- | --- | --- |
| `**Skills version**` | `metadata.version` in the implicated SKILL.md | Which revision of the rule failed |
| `**Infrahub SDK version**` | `SDK Version` line of `infrahubctl info` | Rules naming a CLI flag or client method |
| `**Infrahub version**` | `Infrahub Version` line of the same output | Rules about schema loading, branches, check pipelines |

Both new fields come from one `infrahubctl info` call and defer to
`infrahub-common/rules/connectivity-server-check.md` for how to run it.
`unknown` and `n/a` are accepted — offline work never reaches a server.
The template says to copy the version values and nothing else, since that
output also prints the server address and deployment ID.

Wiring: `states-sdk-version` and `states-infrahub-version` graders (own
header line required, unfilled placeholder rejected), both in
`check_handoff_to_reporting.py` and the handoff eval task,
`evaluations/*.json` regenerated, and a new 39-test grader test file. The
load-bearing test is a 3x3 parametrize asserting each header line
satisfies its own check and no other — the two `Infrahub` lines share a
prefix.

## 3. `infrahubctl --version` does not exist

Found while sourcing the above, verified against a clean
`infrahub-sdk[ctl]` 1.23.2 install: the flag errors with "No such
option". `infrahubctl info` is the command, printing `SDK Version` and
`Infrahub Version` together. Three places were wrong:

- **`infrahub-common/rules/connectivity-server-check.md`** showed the
  output as `Infrahub server:` / `Server version:`. Neither label exists,
  so grepping for them finds nothing. Every skill inherits this one.
- **`reporting-issues`' version table** pointed at `infrahubctl
  --version`; now names the `infrahubctl info` line to read, `pip show`
  as fallback.
- **Its sanitization rule** warned about `--version` leaking a server
  URL, which a version flag would never print. Moved to `infrahubctl
  info`, which does print the address and deployment ID.

## 4. Evidence discovery no longer Claude-specific

`~/.claude/projects/*/*.jsonl` was hard-coded as evidence source 2. On
any other assistant that path is absent, which reads as "no evidence"
rather than "look elsewhere." Source 2 is now "a past session log," with
discovery ordered by what is knowable: current conversation, then ask the
user, then a log directory you know your runtime writes. The Claude Code
path survives as an example.

**On memory files:** nothing in this repo reads `MEMORY.md` and the gap
skill never did. The reference now says so explicitly — an assistant's
own memory files are self-authored, so citing one proves the model wrote
something down, not that a rule failed. The detection ladder already
ranks self-assessment below a verifier verdict.

## Verification

`pytest tests/` 256 passed · `rumdl check .` clean · `yamllint` only the
pre-existing `eval.yaml` warning · `npm run build` in `docs/` clean ·
`sync-evals.py` in sync · handoff grader against a filled fixture reports
all three versions · infrahubctl behavior confirmed in a throwaway venv,
not from memory.

Not verified: the eval tasks were not run against a live model. CI has no
pytest job, so `tests/graders/` only runs locally — out of scope here,
but it is what would keep these graders from rotting.
