### PR TITLE
docs(dev): harvest review lessons from PRs #85-#117

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,12 +58,23 @@ AI command definitions live in [dev/commands/](dev/commands/).
 Adding a new rule under `skills/<skill>/rules/` must
 ship with its eval coverage in the same change:
 
-1. New check function in `graders/<skill>/lib.py`
-   registered in `CHECKS`.
-2. New task block in `eval.yaml` whose prompt
-   naturally exercises the rule.
-3. Task grader script under `graders/<skill>/`.
-4. `python scripts/sync-evals.py` to regenerate
+1. The rule linked from `SKILL.md` at the workflow
+   step that needs it — `_sections.md` alone is read
+   after the mistake, not before it.
+2. New check function in `graders/<skill>/lib.py`
+   registered in `CHECKS`, parsing the answer
+   (`yaml`, `ast`, `shlex`) rather than
+   substring-matching it.
+3. New task block in `eval.yaml` whose prompt
+   naturally exercises the rule and fails without the
+   skill loaded.
+4. Task grader script under `graders/<skill>/`, run
+   against four fixtures: compliant, compliant
+   phrased differently, violating, and a violating
+   near-miss that satisfies the check's keyword.
+5. Old claims the rule contradicts swept from
+   `skills/`, `graders/`, and `eval.yaml`.
+6. `python scripts/sync-evals.py` to regenerate
    `evaluations/*.json` (commit alongside `eval.yaml`).
 
 Full walkthrough in
@@ -71,6 +82,8 @@ Full walkthrough in
 A rule without a grader is a rule that can rot
 silently — the next refactor of the skill's prose
 loses the constraint with no failing test to flag it.
+A grader that cannot fail is worse: it reports the
+rule as covered forever.
 
 ### Versioning
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,10 @@ ship with its eval coverage in the same change:
    (`yaml`, `ast`, `shlex`) rather than
    substring-matching it.
 3. New task block in `eval.yaml` whose prompt
-   naturally exercises the rule and fails without the
-   skill loaded.
+   naturally exercises the rule and fails with the
+   instruction's `Read the skill at ...` line
+   commented out (procedure in
+   [dev/guides/running-evals.md](dev/guides/running-evals.md#writing-good-eval-prompts)).
 4. Task grader script under `graders/<skill>/`, run
    against four fixtures: compliant, compliant
    phrased differently, violating, and a violating

--- a/dev/guides/adding-a-rule.md
+++ b/dev/guides/adding-a-rule.md
@@ -253,7 +253,9 @@ covered forever.
 If the rule corrects something the repo said before,
 the prose layer is not the only place the old claim
 lives. Grep the whole tree and fix every hit in the
-same change:
+same change — except `evaluations/`, which step 7
+regenerates from `eval.yaml` rather than taking
+hand edits:
 
 ```bash
 grep -rn "<old claim, command, or field>" \

--- a/dev/guides/adding-a-rule.md
+++ b/dev/guides/adding-a-rule.md
@@ -317,7 +317,8 @@ prose. If smoke fails:
 - [ ] `graders/<skill>/check_<task>.py` task grader
   script
 - [ ] Grader run against all four fixtures, including
-  both near-misses
+  the compliant variant and the violating
+  near-miss
 - [ ] Old claims the rule contradicts swept from
   `skills/`, `graders/`, and `eval.yaml`
 - [ ] `python scripts/sync-evals.py` run and the

--- a/dev/guides/adding-a-rule.md
+++ b/dev/guides/adding-a-rule.md
@@ -2,7 +2,7 @@
 
 A rule is a single-concern best practice that lives
 in a skill's `rules/` directory (e.g.,
-`skills/infrahub-managing-schemas/rules/parent-rel-optional-false.md`).
+`skills/infrahub-managing-schemas/rules/relationship-component-parent.md`).
 Adding a rule without a corresponding test means the
 rule lives in the skill's prose only — the AI may
 follow it, may not, and there is no automated signal
@@ -21,9 +21,7 @@ walks through the full path.
   field that the schema validator now rejects when
   absent).
 - Documenting an antipattern in an existing rule that
-  the AI tends to produce — the eval should reproduce
-  the antipattern conditions and the grader should
-  fail on the antipattern shape.
+  the AI tends to produce.
 
 If the rule is purely advisory (taste-based prose
 with no observable structural outcome), it does not
@@ -49,10 +47,37 @@ skills/<skill>/rules/<category>-<concern>.md
 ```
 
 Use the existing category prefixes from the skill's
-`rules/_sections.md`. If the rule introduces a new
-concern that doesn't fit any prefix, update
-`_sections.md` to add the prefix and document its
-scope.
+`rules/_sections.md`. A new prefix has to be
+registered everywhere the skill enumerates its
+categories, not only in `_sections.md`:
+
+- `rules/_sections.md` — the prefix and its scope
+- the `Rule Categories` table in `SKILL.md`
+- any severity or ladder legend the skill keeps
+  (`infrahub-auditing-repo` has one in both
+  `audit-procedure.md` and `SKILL.md`)
+
+A prefix registered in only one of those is a rule
+the skill never emits, while its eval still passes.
+
+#### Make the rule reachable
+
+`_sections.md` is a table of contents, not a load
+trigger — an agent reads it once it already knows
+which category it wants. Link the new rule from
+`SKILL.md` at the workflow step where an agent needs
+it, and say *when* to read it, not just what it
+covers:
+
+```markdown
+Before adding a relationship, read
+[rules/relationship-identifiers.md](./rules/relationship-identifiers.md)
+— both sides must share one identifier.
+```
+
+A rule reachable only from `_sections.md` gets read
+after the mistake, which is the same as not writing
+it down.
 
 ### 2. Add a Grader Check Function
 
@@ -79,47 +104,66 @@ If the rule cuts across multiple skills (rare),
 duplicate the check function in each affected
 `graders/<skill>/lib.py` rather than hoisting to a
 shared module — the skills are deliberately
-independently owned.
+independently owned. Rules that belong to
+`infrahub-common` itself grade from
+`graders/common/`.
+
+#### Parse the answer; never substring-match it
+
+`"x" in text` is the reflexive first draft, and it is
+the commonest way a check goes wrong: it passes an
+answer that merely mentions the trap and fails a
+correct answer that words it differently. Parse the
+artifact instead:
+
+| Artifact | Parse with |
+| -------- | ---------- |
+| Schema / object / menu YAML | `yaml.safe_load`, then walk the structure |
+| Python (checks, generators, transforms) | `ast` — see `graders/managing-generators/lib.py` |
+| Shell commands | `shlex.split`; never split on `[;\|&]`, which fabricates segments inside quotes |
+| Prose reports | locate the section, then match inside it |
+
+Three failure modes follow from matching raw text:
+
+- **Comments and docstrings count as code.** Strip
+  them before asserting, or a `# WRONG:` contrast
+  block in the answer satisfies the check meant to
+  fail it.
+- **Only the first fence gets graded.** Extract every
+  fenced block, and accept an answer whose entire
+  output is fenced.
+- **Adjacency is not structure.** A verb next to a
+  path does not mean the command ran against that
+  path.
 
 ### 3. Add an Eval Task
 
-Add a new task block to the root `eval.yaml`
-following the existing schema. The task prompt should
-be a realistic user request that *would naturally
-exercise the rule* — not a meta-prompt asking the AI
-to "follow the rule." Keep prompts at the
-abstraction level a real user would type.
+Add a task block to the root `eval.yaml`. The block
+schema is documented once, in
+[running-evals.md](./running-evals.md#evalyaml-format).
 
-```yaml
-  - name: my-rule-task
-    trials: 3
-    instruction: |
-      Read the skill at .agents/skills/<skill>/SKILL.md
-      and follow its workflow and rules.
+The prompt is where new tasks go wrong. It has to be
+a realistic user request that *would naturally
+exercise the rule*, and it must not carry the answer:
 
-      Task: <realistic prompt that naturally requires
-      the rule to be applied>
-
-      Save ONLY the final YAML to: output.yml
-    graders:
-      - type: deterministic
-        run: python graders/<skill>/check_my_rule.py
-        weight: 1.0
-    expected_output: >-
-      <one-paragraph description of correct output>
-    expectations:
-      - <human-readable expectation 1>
-      - <human-readable expectation 2>
-    assertions:
-      - name: <assertion-name-from-CHECKS>
-        check: <human-readable description>
-```
+- **No meta-prompts.** Don't ask the AI to "follow
+  the rule", and don't dictate the output schema — a
+  prompt that names the fields it wants back is
+  answerable without the skill.
+- **Prove it discriminates.** Run the task once with
+  the skill unloaded. If the grader still scores 1.0,
+  the task measures the model, not the skill; make
+  the prompt harder, or grade something only the rule
+  produces.
+- **Reproduce the antipattern conditions.** Where the
+  rule has a tempting wrong shape, put the temptation
+  in the prompt instead of hoping the AI stumbles
+  into it.
 
 Set `trials: 3` for new tasks unless the rule is
 particularly noisy (in which case 5 may help). The
-defaults file uses 3 trials; the smoke preset
-overrides to 5 only for tasks that don't set a
-per-task `trials` value.
+defaults block sets 3; the smoke preset overrides to
+5 only for tasks that leave `trials` unset.
 
 ### 4. Add a Task Grader Script
 
@@ -162,27 +206,68 @@ script only when the task needs file-attribution or
 carve-out checks the parameterized grader can't express
 (see `graders/auditing-repo/check_yagni_reuse_marketplace.py`).
 
-### 5. Verify the Grader Locally
+### 5. Verify the Grader Both Ways
 
-Before committing, hand-craft two fixture files —
-one compliant and one violating — and confirm the
-grader returns 1.0 on the compliant case and < 1.0
-on the violating one, with a failure message that
-correctly names the violated assertion.
+A check is wrong in two directions, and the obvious
+compliant/violating pair catches neither. Hand-craft
+**four** fixtures and run the grader on each:
+
+| Fixture | Expected |
+| ------- | -------- |
+| Compliant, written the way the rule shows | 1.0 |
+| Compliant, written differently — other field order, a helper, a synonym | 1.0 |
+| Violating, obviously | < 1.0 |
+| Violating **near-miss** — satisfies the check's keyword while breaking the rule | < 1.0 |
+
+The last of each pair is the one that finds bugs:
+
+- **False fail.** A correct answer phrased differently
+  scores < 1.0. Write out the answer the rule's own
+  example shows and watch whether it passes.
+- **Laundering.** A violating answer scores 1.0
+  because it mentions the right word, imports the
+  right module, or names the right helper somewhere
+  in the file. Ask what the smallest edit is that
+  makes the violating fixture pass — if a comment or
+  a bare string is enough, the check grades
+  vocabulary, not substance.
 
 ```bash
-mkdir -p /tmp/grader-test/{pass,fail}
-# write /tmp/grader-test/pass/output.yml (compliant)
-# write /tmp/grader-test/fail/output.yml (violating)
+mkdir -p /tmp/grader-test/{pass,pass-variant,fail,fail-nearmiss}
+# write output.yml in each
 
-cd /tmp/grader-test/pass && python /path/to/graders/<skill>/check_my_rule.py
-cd /tmp/grader-test/fail && python /path/to/graders/<skill>/check_my_rule.py
+for d in pass pass-variant fail fail-nearmiss; do
+  echo "--- $d"
+  (cd /tmp/grader-test/$d &&
+    python /path/to/graders/<skill>/check_my_rule.py)
+done
 ```
 
-A grader that scores 1.0 on a violating fixture is a
-silently broken assertion — fix it before committing.
+Check the failure message too: it has to name the
+assertion that actually broke. A check that cannot
+fail is worse than no check — it reports the rule as
+covered forever.
 
-### 6. Sync the JSON Evaluations
+### 6. Sweep the Layers the Rule Contradicts
+
+If the rule corrects something the repo said before,
+the prose layer is not the only place the old claim
+lives. Grep the whole tree and fix every hit in the
+same change:
+
+```bash
+grep -rn "<old claim, command, or field>" \
+  skills/ graders/ eval.yaml evaluations/ dev/
+```
+
+The hits that get missed are the ones outside
+`skills/`: a grader still asserting a command the
+rule deletes, an `eval.yaml` expectation restating
+the old causality, an `expectations` rubric that
+rewards it. An impact or severity label bumped in
+the rule has to move in the skill's index too.
+
+### 7. Sync the JSON Evaluations
 
 `evaluations/<skill>.json` files are auto-generated
 from `eval.yaml` for the `/skill-creator` evals
@@ -197,18 +282,15 @@ Commit both `eval.yaml` and the regenerated
 auto-run sync-evals, so a stale JSON will diverge
 from the YAML over time.
 
-### 7. Run a Smoke Pass
+### 8. Run a Smoke Pass
 
 ```bash
 skillgrade --smoke
 ```
 
-The smoke preset uses 5 trials per task by default,
-but tasks that set `trials: 3` (the new
-recommendation) use that. A passing smoke run with
-your new rule means the AI follows the rule
-reliably under the skill's current prose. If smoke
-fails:
+A passing smoke run with your new rule means the AI
+follows the rule reliably under the skill's current
+prose. If smoke fails:
 
 - Re-read the rule file. If the *why* is buried, the
   AI may not internalize it.
@@ -222,16 +304,22 @@ fails:
 ## Required Files Checklist
 
 - [ ] `skills/<skill>/rules/<category>-<concern>.md`
-- [ ] (if new prefix)
-  `skills/<skill>/rules/_sections.md` updated
+- [ ] Rule linked from `SKILL.md` at the workflow
+  step that needs it
+- [ ] (if new prefix) `rules/_sections.md`, the
+  `SKILL.md` `Rule Categories` table, and any ladder
+  legend all updated
 - [ ] New check function added to
   `graders/<skill>/lib.py` and registered in
-  `CHECKS`
-- [ ] New task block added to `eval.yaml`
+  `CHECKS`, parsing rather than substring-matching
+- [ ] New task block added to `eval.yaml`, verified
+  to fail without the skill loaded
 - [ ] `graders/<skill>/check_<task>.py` task grader
   script
-- [ ] Grader verified against compliant + violating
-  fixtures locally
+- [ ] Grader run against all four fixtures, including
+  both near-misses
+- [ ] Old claims the rule contradicts swept from
+  `skills/`, `graders/`, and `eval.yaml`
 - [ ] `python scripts/sync-evals.py` run and the
   regenerated `evaluations/*.json` committed
 - [ ] `skillgrade --smoke` passes (or smoke failures

--- a/dev/guides/adding-a-rule.md
+++ b/dev/guides/adding-a-rule.md
@@ -150,11 +150,13 @@ exercise the rule*, and it must not carry the answer:
   the rule", and don't dictate the output schema — a
   prompt that names the fields it wants back is
   answerable without the skill.
-- **Prove it discriminates.** Run the task once with
-  the skill unloaded. If the grader still scores 1.0,
-  the task measures the model, not the skill; make
-  the prompt harder, or grade something only the rule
-  produces.
+- **Prove it discriminates.** Comment out the
+  instruction's `Read the skill at ...` line and run
+  `skillgrade --eval=<task-name> --trials=1`
+  ([procedure](./running-evals.md#writing-good-eval-prompts)).
+  If the grader still scores 1.0, the task measures
+  the model, not the skill; make the prompt harder,
+  or grade something only the rule produces.
 - **Reproduce the antipattern conditions.** Where the
   rule has a tempting wrong shape, put the temptation
   in the prompt instead of hoping the AI stumbles
@@ -162,8 +164,8 @@ exercise the rule*, and it must not carry the answer:
 
 Set `trials: 3` for new tasks unless the rule is
 particularly noisy (in which case 5 may help). The
-defaults block sets 3; the smoke preset overrides to
-5 only for tasks that leave `trials` unset.
+`defaults` block in `eval.yaml` already sets 3, so a
+new task only needs the key to differ from it.
 
 ### 4. Add a Task Grader Script
 
@@ -315,7 +317,8 @@ prose. If smoke fails:
   `graders/<skill>/lib.py` and registered in
   `CHECKS`, parsing rather than substring-matching
 - [ ] New task block added to `eval.yaml`, verified
-  to fail without the skill loaded
+  to fail with the skill's `Read the skill at ...`
+  line commented out
 - [ ] `graders/<skill>/check_<task>.py` task grader
   script
 - [ ] Grader run against all four fixtures, including

--- a/dev/guides/running-evals.md
+++ b/dev/guides/running-evals.md
@@ -82,60 +82,84 @@ skillgrade preview browser
 
 ## eval.yaml Format
 
-The root `eval.yaml` defines all tasks to run:
+A `defaults` block sets the agent, provider, trials,
+timeout, and threshold; `tasks` is a flat list of
+task blocks that override those per task. Each task
+names the skill to load in its own `instruction`,
+which is how tasks for different skills coexist in
+one file:
 
 ```yaml
-skill_name: infrahub-my-skill  # matches SKILL.md frontmatter name
-
 tasks:
-  - id: basic-scenario
-    prompt: >-
-      A realistic user request with specific names,
-      namespaces, and field types.
-    expected_output: >-
-      Human-readable description of what correct
-      output looks like.
-    grader: graders/my-skill/basic-scenario.sh  # path to deterministic grader
+  - name: my-rule-task
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/<skill>/SKILL.md
+      and follow its workflow and rules.
 
-  - id: advanced-scenario
-    prompt: >-
-      A more complex request with relationships
-      and cross-references.
+      Task: <realistic prompt that naturally requires
+      the rule to be applied>
+
+      Save ONLY the final YAML to: output.yml
+    graders:
+      - type: deterministic
+        run: python graders/<skill>/check_my_rule.py
+        weight: 1.0
     expected_output: >-
-      Expected output description.
-    grader: graders/my-skill/advanced-scenario.sh
+      <one-paragraph description of correct output>
+    expectations:
+      - <human-readable expectation 1>
+    assertions:
+      - name: <assertion-name-from-CHECKS>
+        check: <human-readable description>
 ```
+
+`graders` is what skillgrade scores, by weight.
+`expected_output`, `expectations`, and `assertions`
+document the task for whoever reads the results —
+keep them accurate, but don't expect them to fail a
+run on their own.
 
 ## Writing Grader Scripts
 
-Graders live in `graders/<skill-name>/` and
-are deterministic shell scripts that inspect the
-model's output and emit a JSON result.
+Graders live in `graders/<skill>/` and are
+deterministic Python scripts. A task grader reads the
+artifact the instruction told the AI to save (usually
+`output.yml` in the working directory), calls
+`run_checks` from its skill's `lib.py`, and prints
+the skillgrade JSON result to stdout:
 
-A grader receives the model output on stdin and must
-print a JSON object to stdout:
+```python
+#!/usr/bin/env python3
+"""Grader for the my-rule-task eval."""
 
-```bash
-#!/usr/bin/env bash
-# graders/my-skill/basic-scenario.sh
-output=$(cat)
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
 
-# Check for required patterns
-if echo "$output" | grep -q 'kind: Dropdown'; then
-  echo '{"pass": true, "reason": "Status uses Dropdown kind"}'
-else
-  echo '{"pass": false, "reason": "Status does not use Dropdown kind"}'
-fi
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lib import run_checks  # noqa: E402
+
+CHECKS = ["schema-version", "<assertion-name>"]
+
+if __name__ == "__main__":
+    print(json.dumps(run_checks(CHECKS, Path("output.yml"))))
 ```
 
-**Keep graders deterministic.** They should not call
-external services or depend on timing. Parse the
-output text and check for the presence or absence of
-specific patterns.
+The individual assertions live in
+`graders/<skill>/lib.py` under a `CHECKS` registry.
+Writing one — including how to parse rather than
+substring-match the answer, and the four fixtures
+that prove it works — is covered in
+[adding-a-rule.md](./adding-a-rule.md#2-add-a-grader-check-function).
 
-**Use descriptive file names.** The grader filename
-appears in results (`dropdown-for-status.sh` is more
-readable than `check1.sh`).
+**Keep graders deterministic.** No LLM grading, no
+network calls, no dependence on timing.
+
+**Name the script after what it asserts.** The
+filename appears in results, so
+`check_dropdown_for_status.py` beats `check1.py`.
 
 ## Writing Good Eval Prompts
 
@@ -160,21 +184,19 @@ field names, missing bidirectional identifiers), write
 eval prompts that would expose these mistakes without
 the skill's guidance.
 
-## Writing Good Assertions
+**Don't put the answer in the question.** A prompt
+that dictates the output schema, names the fields it
+wants back, or tells the AI to "follow the rule" is
+answerable without the skill. Keep the prompt at the
+abstraction level a real user would type and let the
+skill supply the shape.
 
-**Make them objectively verifiable.** "Output looks
-nice" is not an assertion. "Status uses kind: Dropdown
-with choice objects" is.
-
-**Use descriptive names.** The grader filename appears
-in results. Someone scanning results should understand
-what `dropdown-for-status.sh` checks without reading
-the full script.
-
-**Focus on what the skill uniquely provides.** If a
-model would get something right even without the
-skill, testing it isn't very informative. Test the
-things the skill's rules specifically address.
+**Prove the task discriminates.** Run it once with
+the skill unloaded. If the grader still scores 1.0,
+the task measures the model rather than the skill —
+that is a broken task, not a passing one. Make the
+prompt harder, or grade something only the skill's
+rules produce.
 
 ## Iteration Loop
 
@@ -186,24 +208,15 @@ things the skill's rules specifically address.
 ## Existing Evals
 
 All tasks live in the single root `eval.yaml`; graders
-live under `graders/<skill>/`. Counts below reflect the
-tasks currently defined (group by the `skills/<skill>/SKILL.md`
-each task reads).
+live under `graders/<skill>/`. Rather than restating
+the per-skill counts here, where they go stale
+silently, read them off the file:
 
-| Skill | Tasks |
-| ----- | ----- |
-| infrahub-managing-schemas | 13 |
-| infrahub-managing-menus | 3 |
-| infrahub-managing-checks | 3 |
-| infrahub-managing-generators | 6 |
-| infrahub-managing-transforms | 3 |
-| infrahub-managing-objects | 3 |
-| infrahub-reporting-issues | 3 |
-| infrahub-auditing-repo | 16 |
-| infrahub-collecting-diagnostics | 3 |
-| infrahub-analyzing-diagnostics | 10 |
-| infrahub-importing-data | 25 |
+```bash
+grep -oE '\.agents/skills/infrahub-[a-z-]+' eval.yaml |
+  sort | uniq -c | sort -rn
+```
 
-`infrahub-analyzing-data` has no eval tasks yet —
-adding them is a good contribution. It has rules but
-no grader directory.
+A skill absent from that output has rules but no
+eval coverage, which makes it the highest-value place
+to add a task.

--- a/dev/guides/running-evals.md
+++ b/dev/guides/running-evals.md
@@ -115,10 +115,18 @@ tasks:
 ```
 
 `graders` is what skillgrade scores, by weight.
-`expected_output`, `expectations`, and `assertions`
-document the task for whoever reads the results —
-keep them accurate, but don't expect them to fail a
-run on their own.
+Under skillgrade, `expected_output`, `expectations`,
+and `assertions` document the task for whoever reads
+the results and do not fail a run on their own.
+
+They are not inert, though: `scripts/sync-evals.py`
+copies all three into `evaluations/<skill>.json`, and
+whether the `/skill-creator` runner scores them is
+outside this repo. Write them as if they were
+graded: objectively verifiable and specific ("Status
+uses `kind: Dropdown`", not "the schema is well
+designed"), and about what the skill uniquely
+provides.
 
 ## Writing Grader Scripts
 
@@ -191,12 +199,24 @@ answerable without the skill. Keep the prompt at the
 abstraction level a real user would type and let the
 skill supply the shape.
 
-**Prove the task discriminates.** Run it once with
-the skill unloaded. If the grader still scores 1.0,
-the task measures the model rather than the skill —
-that is a broken task, not a passing one. Make the
-prompt harder, or grade something only the skill's
-rules produce.
+**Prove the task discriminates.** Every task's
+`instruction` opens with a `Read the skill at
+.agents/skills/<skill>/SKILL.md` line, and that line
+is the only thing that loads the skill. To run the
+task without it, comment the line out and run that
+task alone:
+
+```bash
+skillgrade --eval=<task-name> --trials=1
+# then restore the line
+```
+
+Leave the rest of the instruction untouched, since
+the task body is what you are testing. If the grader
+still scores 1.0, the task measures the model rather
+than the skill; that is a broken task, not a passing
+one. Make the prompt harder, or grade something only
+the skill's rules produce.
 
 ## Iteration Loop
 

--- a/dev/knowledges/architecture.md
+++ b/dev/knowledges/architecture.md
@@ -29,7 +29,7 @@ Plugin (plugin.json)
 │           schema files
 │
 ├── Skills (skills/)
-│   ├── infrahub-managing-schemas/
+│   ├── infrahub-<verb>-<noun>/   ← one per skill
 │   │   ├── SKILL.md          ← Entry point
 │   │   ├── rules/            ← Modular rules
 │   │   │   ├── _sections.md  ← Category index
@@ -38,31 +38,24 @@ Plugin (plugin.json)
 │   │   ├── reference.md      ← Property/format tables
 │   │   └── validation.md     ← Validation guidance
 │   │
-│   ├── infrahub-managing-objects/
-│   ├── infrahub-managing-checks/
-│   ├── infrahub-managing-generators/
-│   ├── infrahub-managing-transforms/
-│   ├── infrahub-managing-menus/
-│   ├── infrahub-analyzing-data/
-│   ├── infrahub-auditing-repo/
-│   │
 │   └── infrahub-common/      ← Cross-cutting refs
 │       ├── graphql-queries.md
 │       ├── infrahub-yml-reference.md
 │       ├── marketplace-reference.md
 │       └── rules/            ← Shared rules
 │
-├── eval.yaml                             ← skillgrade config (all skills)
+├── eval.yaml                 ← skillgrade config (all skills)
 │
-└── graders/                              ← Deterministic grader scripts
-    ├── managing-schemas/                  ← one directory per skill
-    ├── managing-menus/
-    ├── managing-checks/
-    ├── managing-objects/
-    ├── managing-generators/
-    ├── managing-transforms/
-    └── reporting-issues/
+└── graders/                  ← Deterministic grader scripts
+    └── <skill>/              ← one directory per skill,
+                                named without the
+                                `infrahub-` prefix
 ```
+
+The skill list itself lives in one place — the
+Quick Reference table in
+[AGENTS.md](../../AGENTS.md) — so it isn't repeated
+here.
 
 ## Progressive Disclosure Model
 
@@ -163,6 +156,14 @@ Cross-cutting concerns live in `skills/infrahub-common/` to
 avoid duplication. When multiple skills need GraphQL
 query guidance or `.infrahub.yml` format reference,
 they point to the same shared files.
+
+The shared files are also the most expensive place to
+write. Every skill that loads `infrahub-common` pays
+for all of it, so a rule that only two skills need
+belongs in those two skills, not here. Before adding
+to a shared file, check whether the concern is
+genuinely cross-cutting or just convenient to put in
+one place.
 
 ### Automatic Detection via Hooks
 

--- a/dev/knowledges/skill-writing-guide.md
+++ b/dev/knowledges/skill-writing-guide.md
@@ -108,22 +108,49 @@ Every rule file should answer:
 2. **Why does it matter?** — The reasoning (failures,
    confusing behavior, data loss)
 3. **How to apply it** — The specific check or pattern
-4. **Examples** — Compliant and non-compliant, side
-   by side
+4. **Examples** — Compliant and non-compliant, in
+   two separate fenced blocks. One fence holding
+   both makes a single document the AI reads as one
+   artifact, so the WRONG half gets copied along
+   with the RIGHT half.
 5. **Common mistakes** — What typically goes wrong
    (this is gold for AI models)
 
 ### Category prefixes
 
-Rules are named with category prefixes from
-`_sections.md` for organization:
+Rules are named with a category prefix from
+`_sections.md` (`naming-conventions.md`,
+`relationship-identifiers.md`,
+`display-order-weight.md`), so rules are findable by
+domain and new ones need no renaming. Registering a
+new prefix touches more than `_sections.md` — see
+[adding-a-rule.md](../guides/adding-a-rule.md#1-write-the-rule).
 
-- `naming-conventions.md`
-- `relationship-identifiers.md`
-- `display-order-weight.md`
+### One fact, one home
 
-This makes it easy to find rules by domain and to add
-new ones without renaming.
+State a list, a claim, or a command in exactly one
+file and point at it from everywhere else. The
+failure is not the duplication itself, it is that the
+copies drift: a read-only command allowlist written
+into four files ends up with three different
+memberships, and nobody can tell which is current.
+
+This binds graders too. A grader that hard-codes a
+command tree, a kind list, or a set of valid flags
+holds a second copy of the skill's prose, and the two
+diverge the first time the prose changes. Derive it
+from one place, or assert the shape rather than the
+membership.
+
+### Say only what you verified
+
+Write the claim you actually tested, at the strength
+you tested it. "Verified against Infrahub 1.11.0"
+means the check ran on 1.11.0 — if it ran on
+something else, or on nothing, drop the line. An
+unverified provenance claim is worse than no claim,
+because the next author trusts it instead of
+re-checking.
 
 ## Examples File
 
@@ -150,6 +177,26 @@ abstract instructions.
 - Examples that work around bugs or legacy behavior
   (document the current best practice)
 
+### Every snippet must stand on its own
+
+An example is copied, not read. Each one has to name
+only kinds, attributes, fields, and packages that
+exist in what it shows — a snippet referring to an
+attribute the schema above it never defines cannot be
+run, and the quoted error it promises will never
+appear. Before shipping a snippet, load or execute it
+against the artifact it sits next to.
+
+### Read the example back against the rule
+
+The commonest defect in a corrected rule is an
+example that demonstrates something other than the
+sentence introducing it — often the inverse, because
+the rule's lead was rewritten and the example wasn't.
+After editing either half, read the lead sentence and
+the example together and check the example would fail
+for the reason the lead gives.
+
 ## Common Pitfalls
 
 ### Overfitting to specific examples
@@ -166,10 +213,3 @@ Piling on rigid constraints ("MUST use X", "NEVER do
 Y", "ALWAYS check Z") makes the skill brittle and
 hard to maintain. Use explanation and reasoning
 instead — the AI will generalize better.
-
-### Neglecting the description
-
-A perfect SKILL.md body is useless if the description
-doesn't trigger. After writing or updating a skill,
-check whether the description covers the realistic
-ways users ask for this task.


### PR DESCRIPTION
## What this is

The review threads on PRs #85, #89 and #109-#117 produced roughly 120 findings across 2-4 rounds each. Most of them trace back to a handful of repeated causes, and every one of those lessons lived in a thread and died there. This PR routes the durable ones into `dev/`.

Produced with the **`harvesting-review` skill from the `opsmill/infrahub` repository** (`.agents/skills/harvesting-review/`), run against this repo: mine the review threads, abstract each comment to the rule behind it, verify it against the actual code, check whether it is already codified, then route it to the most specific existing home. Every lesson below was re-verified against `main` and the real `eval.yaml`/`graders/` tree rather than taken from the comments at face value.

## Existing coverage strengthened

These rules were already written. A reviewer still had to raise them, which makes the coverage the problem, not the contributor.

| Lesson | Was at | Why it did not land |
| --- | --- | --- |
| Grader verification is one-directional in practice | `adding-a-rule.md:165-183` | "Compliant" and "violating" invite the *obvious* pair. Both real failure classes only surface on a near-miss. ~25 findings across 10 of 11 PRs. |
| Eval tasks must discriminate | `running-evals.md:174-177` | Stated as a principle with no procedure, and nothing banned the meta-shaped prompt that carries its own answer. |
| Category-prefix registration | `adding-a-rule.md:51-55` | Named `_sections.md` only; the wiring is three places. |
| Examples "side by side" | `skill-writing-guide.md:111-112` | Did not say *two fences*, so a WRONG/RIGHT pair shipped as one YAML document. |

## New rules

- **Graders parse; they never substring-match.** `yaml.safe_load` / `ast` / `shlex`, plus the three failure modes that follow from raw text (comments count as code, only the first fence gets graded, adjacency is not structure). The practice already existed in three `lib.py` files and in `dev/specs/`, but never in the guide.
- **A rule must be reachable from `SKILL.md`** at the workflow step that needs it. `_sections.md` is a table of contents, read after the mistake. 8 of 11 PRs hit this; 60+ rule files on `main` are not named anywhere in their own `SKILL.md`.
- **One fact, one home** — including graders that hard-code a command tree and become a second, drifting copy of the skill's prose.
- **Correcting a claim means sweeping every layer**, `graders/` and `eval.yaml` included, not just the prose.
- **Snippets must stand on their own** — no kind, attribute, or package the snippet does not define.
- **Say only what you verified** — no "verified against Infrahub X.Y.Z" line unless the check ran on X.Y.Z.
- **A rule in `infrahub-common` costs every skill** that loads it.

The always-loaded layer (`AGENTS.md` → Rule = Test) now names reachability, parsing, discrimination, the four fixtures, and the sweep, so the guide gets pulled in before the mistake instead of after.

## Rot repaired while at the lines

The harvest skill prunes as it goes, so these were fixed in the same pass rather than listed for later:

- `running-evals.md` documented an `eval.yaml` schema with **zero** occurrences in the file — `- id:`/`prompt:`/`grader:` against the real `name:`/`instruction:`/`graders:` (102 blocks) — and bash graders reading stdin, when all **110** graders are Python reading `output.yml`.
- `adding-a-rule.md` cited `rules/parent-rel-optional-false.md`, which does not exist (it is `relationship-component-parent.md`), stated the `trials` rule twice, and carried a third copy of the `eval.yaml` schema that disagreed with the other two.
- `architecture.md` listed 8 of 14 skills and 7 of 13 grader directories.
- The hand-maintained per-skill eval-count table was already wrong (auditing-repo 16 vs 17, `reporting-skill-gaps` missing with 13 tasks). Replaced with the command that prints it.
- Dropped the "analyzing-data has no eval tasks yet" note: true today, but a defect snapshot nothing revisits.

## Line counts

Net +155 across five files, with real deletions rather than pure accretion.

| File | Before | After |
| --- | --- | --- |
| `dev/guides/adding-a-rule.md` | 238 | 326 |
| `dev/guides/running-evals.md` | 209 | 222 |
| `dev/knowledges/skill-writing-guide.md` | 175 | 215 |
| `dev/knowledges/architecture.md` | 185 | 186 |
| `AGENTS.md` | 81 | 94 |

`adding-a-rule.md` is the one that grew meaningfully (+88). Its two largest additions are the parse-don't-match section and the four-fixture verification, which are the two highest-frequency causes in the whole review corpus.

## Verification

- `uv run rumdl check .` — clean, 267 files (this is the CI markdown gate).
- The documented eval-count command was run and its output checked against `eval.yaml`.
- Every cross-doc anchor added here resolves to a real heading.
- Every path and file count cited above was checked against the tree.

## Notes, not addressed here

- `scripts/run_evals.py` is the legacy custom runner that `running-evals.md` says skillgrade replaced. Still in the tree; deleting it is a separate call.
- `uv.lock` pins `infrahub-skills 1.2.7` while `pyproject.toml` says `1.2.8`. Pre-existing drift, left alone.
- PRs #109-#117 are still open, so their content is not on `main`. The lessons here are about process and land in `dev/`, so they do not conflict with those branches.
