### PR TITLE
chore: sync uv.lock to project version 1.2.8

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "infrahub-skills"
-version = "1.2.7"
+version = "1.2.8"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Split out of #109 at review request — that PR is about making the audit read-only, this one line is not.

`uv.lock` recorded `version = "1.2.7"` while the project is at 1.2.8. Any `uv run` rewrites it, so it keeps showing up as a stray diff in unrelated PRs.

Worth noting separately: `uv.lock` is a version surface the AGENTS.md release checklist does not list.