### PR TITLE
chore(evals): make eval.yaml loadable so skillgrade can run

### DIFF
--- a/eval.yaml
+++ b/eval.yaml
@@ -6188,33 +6188,6 @@ tasks:
           A Markdown report names the NetBox component lists that did not
           convert
 
-# ---------------------------------------------------------------------------
-# Ungraded task definitions — NOT run by skillgrade
-# ---------------------------------------------------------------------------
-#
-# skillgrade requires every entry under `tasks:` to carry at least one grader
-# and refuses to load the whole file if any entry does not, so these seven
-# blocked `skillgrade` from running ANY task in this repo, for any skill.
-# They are parked here, verbatim, to make the file loadable again.
-#
-# Moving them costs no coverage that existed. CI never ran them either: the
-# discover step in .github/workflows/skill-evals.yml derives a task's skill
-# from `graders[0].run`, so a grader-less task is skipped when the matrix is
-# built.
-#
-# Why they have no graders: each asks for prose — an interview plan, a column
-# profile, an error translation, a command sequence — and six of the seven
-# explicitly instruct the model NOT to emit YAML, so there is no artifact on
-# disk for a deterministic grader to read. Writing one anyway would mean
-# substring-matching the transcript, which dev/knowledges/skill-writing-guide.md
-# rules out and which yields a check that cannot fail.
-#
-# To reinstate one: give it an artifact to write (without dictating the schema
-# in the prompt), add a check function to graders/importing-data/lib.py, add
-# its task grader, and move the block back under `tasks:`.
-
-ungraded_tasks:
-
   - name: csv-import-up-front-interview
     trials: 3
     instruction: |
@@ -6237,6 +6210,13 @@ ungraded_tasks:
       file naming, branch name, and lineage opt-in. Do not start writing
       until I confirm. Echo back the full plan before any file is created.
       Save planned output under `./output_dir/`.
+
+      Save the batched questions and the echoed plan to
+      `./output_dir/answer.md`. Write no object YAML in this task.
+    graders:
+      - type: deterministic
+        run: python graders/importing-data/check_up_front_interview.py
+        weight: 1.0
     expected_output: >-
       A single batched set of multi-choice questions covering every
       ambiguity (tier_label has no schema home; Status is a dropdown
@@ -6269,6 +6249,13 @@ ungraded_tasks:
 
       Schema is fixed. Emit only the per-file profile summary — do not
       write any object YAML in this task.
+
+      Save the profile to `./output_dir/profile.yml`, one entry per
+      column. Write no object YAML in this task.
+    graders:
+      - type: deterministic
+        run: python graders/importing-data/check_profile_sample.py
+        weight: 1.0
     expected_output: >-
       A per-column profile of inventory.csv naming distinct-value counts
       (4 names, 2 roles, 2 statuses, 2 manufacturers, 2 port counts, 3
@@ -6297,6 +6284,12 @@ ungraded_tasks:
       validate error into a clear instruction that tells me which CSV
       cell to fix, and explicitly tells me NOT to edit the emitted YAML
       directly.
+
+      Save the instruction you would give me to `./output_dir/answer.md`.
+    graders:
+      - type: deterministic
+        run: python graders/importing-data/check_validate_error_mapping.py
+        weight: 1.0
     expected_output: >-
       A traceback that names inventory.csv row 12 column "Status", explains
       that "Active" is the display label (the schema choice name is
@@ -6326,6 +6319,13 @@ ungraded_tasks:
 
       Schema defines `OrganizationManufacturer` with Text attributes
       `name`, `description`, `country`, and `human_friendly_id: [name__value]`.
+
+      Save the self-check description to `./output_dir/answer.md`,
+      alongside the emitted YAML.
+    graders:
+      - type: deterministic
+        run: python graders/importing-data/check_self_check_rules.py
+        weight: 1.0
     expected_output: >-
       The emitted YAML for OrganizationManufacturer under ./output_dir/,
       plus a description of the local self-check that walks each emitted
@@ -6351,6 +6351,12 @@ ungraded_tasks:
       using a default branch name like `csv-import-YYYYMMDD-HHMM`. Do
       NOT actually execute them — just produce the command sequence
       with one-line explanations.
+
+      Save the command sequence to `./output_dir/answer.md`.
+    graders:
+      - type: deterministic
+        run: python graders/importing-data/check_create_branch_first.py
+        weight: 1.0
     expected_output: >-
       The command sequence in order: (1) infrahubctl info to verify
       connectivity, (2) infrahubctl branch create <name>, (3) infrahubctl
@@ -6377,6 +6383,12 @@ ungraded_tasks:
       and explain when to fall back to the next source. The schema is
       read-only throughout — do not propose any schema edit. Do not
       emit any YAML in this task — describe the introspection only.
+
+      Save the introspection description to `./output_dir/answer.md`.
+    graders:
+      - type: deterministic
+        run: python graders/importing-data/check_introspect_first.py
+        weight: 1.0
     expected_output: >-
       A description of the four-source priority chain (MCP first,
       infrahubctl schema export, /api/schema REST, local schemas/*.yml
@@ -6402,6 +6414,12 @@ ungraded_tasks:
       profiling, and what happens to non-CSV/TSV files in a directory.
       Do not emit any YAML in this task — describe the input
       normalization only.
+
+      Save the normalization description to `./output_dir/answer.md`.
+    graders:
+      - type: deterministic
+        run: python graders/importing-data/check_file_folder_list_input.py
+        weight: 1.0
     expected_output: >-
       A description of the input normalization step: single file passes
       through, directory is recursively scanned for *.csv and *.tsv

--- a/eval.yaml
+++ b/eval.yaml
@@ -3579,205 +3579,12 @@ tasks:
 
   # --- Expectations-only tasks for process / conversation rules --- #
 
-  - name: csv-import-up-front-interview
-    trials: 3
-    instruction: |
-      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
 
-      Task: I have `devices.csv` with these columns and rows:
 
-          name,role,status,tier_label
-          spine-01,spine,Active,gold
-          spine-02,spine,Maintenance,gold
-          leaf-01,leaf,Active,silver
 
-      The schema declares `DcimDevice` with attributes `name` (Text),
-      `role` (Text), `status` (Dropdown: active/maintenance/retired). The
-      schema has NO `tier_label` attribute on DcimDevice. DcimDevice has
-      `human_friendly_id: [name__value]`. The schema is fixed.
 
-      Before emitting any file, surface every decision you need from me in
-      ONE batch — unmapped columns, dropdown-label translation, target
-      file naming, branch name, and lineage opt-in. Do not start writing
-      until I confirm. Echo back the full plan before any file is created.
-      Save planned output under `./output_dir/`.
-    expected_output: >-
-      A single batched set of multi-choice questions covering every
-      ambiguity (tier_label has no schema home; Status is a dropdown
-      label; branch name; lineage opt-in) plus a confirm-and-lock summary
-      of the proposed plan. No file is written until the user confirms.
-    expectations:
-      - Every ambiguity is surfaced in one batched round, not one-by-one
-      - The unmapped tier_label column is called out explicitly
-      - Status values (Active/Maintenance) are flagged as dropdown labels
-      - A branch name is proposed (e.g., csv-import-YYYYMMDD-HHMM)
-      - Lineage opt-in is offered with an explanation of source vs. owner+is_protected
-      - The plan is echoed back before any file is written
 
-  - name: csv-import-profile-sample
-    trials: 3
-    instruction: |
-      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
 
-      Task: Before mapping `inventory.csv` (which I will provide
-      content-wise inline below), profile it: report distinct-value counts,
-      sample values, length ranges, numeric-only fractions, date-pattern
-      matches, and any sequence patterns. Use the profile to drive the
-      mapping plan.
-
-          name,role,status,manufacturer_name,port_count,commissioned_at
-          spine-01,spine,Active,Arista,32,2024-03-15
-          spine-02,spine,Active,Arista,32,2024-03-15
-          leaf-01,leaf,Maintenance,Cisco,48,2023-09-01
-          leaf-02,leaf,Active,Cisco,48,2024-01-10
-
-      Schema is fixed. Emit only the per-file profile summary — do not
-      write any object YAML in this task.
-    expected_output: >-
-      A per-column profile of inventory.csv naming distinct-value counts
-      (4 names, 2 roles, 2 statuses, 2 manufacturers, 2 port counts, 3
-      dates), sample values, length ranges, the 100% numeric port_count
-      column, and the YYYY-MM-DD commissioned_at column as DateTime.
-    expectations:
-      - The profile names per-column distinct-value counts
-      - role and status are flagged as low-cardinality (dropdown candidates)
-      - port_count is flagged as 100% numeric
-      - commissioned_at is flagged as a YYYY-MM-DD DateTime pattern
-      - manufacturer_name is flagged as a reference candidate (low cardinality)
-
-  - name: csv-import-validate-error-mapping
-    trials: 3
-    instruction: |
-      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
-
-      Task: After running `infrahubctl object validate ./output_dir/ --branch csv-import-20260622-1430`,
-      the server returned:
-
-          output_dir/04_devices.yml row 7 attribute 'status':
-            'Active' is not a valid choice for status
-
-      The skill produced the YAML from `inventory.csv` row 12. The skill
-      knows the per-row mapping back to the source. Translate the
-      validate error into a clear instruction that tells me which CSV
-      cell to fix, and explicitly tells me NOT to edit the emitted YAML
-      directly.
-    expected_output: >-
-      A traceback that names inventory.csv row 12 column "Status", explains
-      that "Active" is the display label (the schema choice name is
-      `active`), and lists fix options including re-running with the
-      dropdown-label-to-name rule applied. The response must instruct the
-      user not to edit the emitted YAML by hand.
-    expectations:
-      - The error is traced back to inventory.csv row 12 column "Status"
-      - The "Active" vs "active" label/name distinction is explained
-      - Fix options include editing the CSV and re-running the skill
-      - The user is told NOT to edit the emitted YAML directly
-
-  - name: csv-import-self-check-against-managing-objects
-    trials: 3
-    instruction: |
-      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
-
-      Task: After emitting Infrahub object YAML to ./output_dir/ (do this
-      step first for the simple manufacturers CSV below), describe the
-      local self-check you would run BEFORE creating any branch. Name the
-      specific managing-objects rules you check the emission against and
-      what each one catches.
-
-          # manufacturers.csv
-          name,description,country
-          Dell,Server and storage vendor,US
-
-      Schema defines `OrganizationManufacturer` with Text attributes
-      `name`, `description`, `country`, and `human_friendly_id: [name__value]`.
-    expected_output: >-
-      The emitted YAML for OrganizationManufacturer under ./output_dir/,
-      plus a description of the local self-check that walks each emitted
-      file against managing-objects rules (format-structure,
-      value-attributes, value-relationships, children-components,
-      range-expansion, organization-load-order). No infrahubctl command
-      is run in this task — the self-check is local-only.
-    expectations:
-      - At least one YAML file is emitted to ./output_dir/
-      - The self-check is described as running BEFORE infrahubctl branch create
-      - The self-check is local-only (no server, no branch)
-      - Specific managing-objects rule files are named
-      - Each named rule is matched to the shape it verifies
-
-  - name: csv-import-create-branch-first
-    trials: 3
-    instruction: |
-      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
-
-      Task: Walk me through the validate-and-load sequence after the
-      local self-check passes for a hypothetical ./output_dir/. Include
-      the exact infrahubctl commands in the order they should be run,
-      using a default branch name like `csv-import-YYYYMMDD-HHMM`. Do
-      NOT actually execute them — just produce the command sequence
-      with one-line explanations.
-    expected_output: >-
-      The command sequence in order: (1) infrahubctl info to verify
-      connectivity, (2) infrahubctl branch create <name>, (3) infrahubctl
-      object validate ./output_dir/ --branch <name>, (4) infrahubctl
-      object load ./output_dir/ --branch <name>. Plus a note about
-      `infrahubctl branch delete <name>` on partial failure. The default
-      branch is never the target.
-    expectations:
-      - The sequence creates a branch BEFORE validate or load
-      - infrahubctl info is mentioned as a connectivity check
-      - The branch is created via infrahubctl branch create
-      - validate and load both pass --branch <name>
-      - The default branch is explicitly excluded as a target
-      - branch delete is named as the cleanup on partial failure
-
-  - name: csv-import-introspect-first
-    trials: 3
-    instruction: |
-      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
-
-      Task: Before mapping `devices.csv` to the schema, describe how you
-      would discover the schema. List the priority chain (MCP →
-      infrahubctl schema export → /api/schema REST → local schemas/*.yml)
-      and explain when to fall back to the next source. The schema is
-      read-only throughout — do not propose any schema edit. Do not
-      emit any YAML in this task — describe the introspection only.
-    expected_output: >-
-      A description of the four-source priority chain (MCP first,
-      infrahubctl schema export, /api/schema REST, local schemas/*.yml
-      last), with the trade-off of each source (freshness vs.
-      availability) and an explicit "schema is read-only — escalate to
-      managing-schemas if a column has no home."
-    expectations:
-      - The priority chain lists MCP first
-      - infrahubctl schema export is listed as the next fallback after MCP
-      - /api/schema REST is named as the third option
-      - Local schemas/*.yml is named as the last resort with a freshness caveat
-      - The response explicitly says no schema edit will be proposed
-      - Escalation to managing-schemas is named for the unmappable-column case
-
-  - name: csv-import-file-folder-list-input
-    trials: 3
-    instruction: |
-      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
-
-      Task: I will hand you any of three input shapes — a single CSV
-      file, a directory of CSVs, or an explicit list of paths. Describe
-      how the skill normalizes each shape into a flat file list before
-      profiling, and what happens to non-CSV/TSV files in a directory.
-      Do not emit any YAML in this task — describe the input
-      normalization only.
-    expected_output: >-
-      A description of the input normalization step: single file passes
-      through, directory is recursively scanned for *.csv and *.tsv
-      (case-insensitive), list of paths is expanded the same way.
-      Non-CSV/TSV files in a directory are ignored or surface a
-      fail-closed report depending on the rule.
-    expectations:
-      - Single file is accepted directly
-      - Directory is recursively scanned for .csv and .tsv files
-      - Mixed input lists are normalized to a flat file set
-      - Case-insensitive extension matching is mentioned
-      - The response references the fail-closed posture for unsupported file types
 
   - name: csv-import-fail-closed
     trials: 3
@@ -6388,3 +6195,230 @@ tasks:
         check: >-
           A Markdown report names the NetBox component lists that did not
           convert
+
+# ---------------------------------------------------------------------------
+# Ungraded task definitions — NOT run by skillgrade
+# ---------------------------------------------------------------------------
+#
+# skillgrade requires every entry under `tasks:` to carry at least one grader
+# and refuses to load the whole file if any entry does not, so these seven
+# blocked `skillgrade` from running ANY task in this repo, for any skill.
+# They are parked here, verbatim, to make the file loadable again.
+#
+# Moving them costs no coverage that existed. CI never ran them either: the
+# discover step in .github/workflows/skill-evals.yml derives a task's skill
+# from `graders[0].run`, so a grader-less task is skipped when the matrix is
+# built.
+#
+# Why they have no graders: each asks for prose — an interview plan, a column
+# profile, an error translation, a command sequence — and six of the seven
+# explicitly instruct the model NOT to emit YAML, so there is no artifact on
+# disk for a deterministic grader to read. Writing one anyway would mean
+# substring-matching the transcript, which dev/knowledges/skill-writing-guide.md
+# rules out and which yields a check that cannot fail.
+#
+# To reinstate one: give it an artifact to write (without dictating the schema
+# in the prompt), add a check function to graders/importing-data/lib.py, add
+# its task grader, and move the block back under `tasks:`.
+
+ungraded_tasks:
+
+  - name: csv-import-up-front-interview
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
+
+      Task: I have `devices.csv` with these columns and rows:
+
+          name,role,status,tier_label
+          spine-01,spine,Active,gold
+          spine-02,spine,Maintenance,gold
+          leaf-01,leaf,Active,silver
+
+      The schema declares `DcimDevice` with attributes `name` (Text),
+      `role` (Text), `status` (Dropdown: active/maintenance/retired). The
+      schema has NO `tier_label` attribute on DcimDevice. DcimDevice has
+      `human_friendly_id: [name__value]`. The schema is fixed.
+
+      Before emitting any file, surface every decision you need from me in
+      ONE batch — unmapped columns, dropdown-label translation, target
+      file naming, branch name, and lineage opt-in. Do not start writing
+      until I confirm. Echo back the full plan before any file is created.
+      Save planned output under `./output_dir/`.
+    expected_output: >-
+      A single batched set of multi-choice questions covering every
+      ambiguity (tier_label has no schema home; Status is a dropdown
+      label; branch name; lineage opt-in) plus a confirm-and-lock summary
+      of the proposed plan. No file is written until the user confirms.
+    expectations:
+      - Every ambiguity is surfaced in one batched round, not one-by-one
+      - The unmapped tier_label column is called out explicitly
+      - Status values (Active/Maintenance) are flagged as dropdown labels
+      - A branch name is proposed (e.g., csv-import-YYYYMMDD-HHMM)
+      - Lineage opt-in is offered with an explanation of source vs. owner+is_protected
+      - The plan is echoed back before any file is written
+
+  - name: csv-import-profile-sample
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
+
+      Task: Before mapping `inventory.csv` (which I will provide
+      content-wise inline below), profile it: report distinct-value counts,
+      sample values, length ranges, numeric-only fractions, date-pattern
+      matches, and any sequence patterns. Use the profile to drive the
+      mapping plan.
+
+          name,role,status,manufacturer_name,port_count,commissioned_at
+          spine-01,spine,Active,Arista,32,2024-03-15
+          spine-02,spine,Active,Arista,32,2024-03-15
+          leaf-01,leaf,Maintenance,Cisco,48,2023-09-01
+          leaf-02,leaf,Active,Cisco,48,2024-01-10
+
+      Schema is fixed. Emit only the per-file profile summary — do not
+      write any object YAML in this task.
+    expected_output: >-
+      A per-column profile of inventory.csv naming distinct-value counts
+      (4 names, 2 roles, 2 statuses, 2 manufacturers, 2 port counts, 3
+      dates), sample values, length ranges, the 100% numeric port_count
+      column, and the YYYY-MM-DD commissioned_at column as DateTime.
+    expectations:
+      - The profile names per-column distinct-value counts
+      - role and status are flagged as low-cardinality (dropdown candidates)
+      - port_count is flagged as 100% numeric
+      - commissioned_at is flagged as a YYYY-MM-DD DateTime pattern
+      - manufacturer_name is flagged as a reference candidate (low cardinality)
+
+  - name: csv-import-validate-error-mapping
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
+
+      Task: After running `infrahubctl object validate ./output_dir/ --branch csv-import-20260622-1430`,
+      the server returned:
+
+          output_dir/04_devices.yml row 7 attribute 'status':
+            'Active' is not a valid choice for status
+
+      The skill produced the YAML from `inventory.csv` row 12. The skill
+      knows the per-row mapping back to the source. Translate the
+      validate error into a clear instruction that tells me which CSV
+      cell to fix, and explicitly tells me NOT to edit the emitted YAML
+      directly.
+    expected_output: >-
+      A traceback that names inventory.csv row 12 column "Status", explains
+      that "Active" is the display label (the schema choice name is
+      `active`), and lists fix options including re-running with the
+      dropdown-label-to-name rule applied. The response must instruct the
+      user not to edit the emitted YAML by hand.
+    expectations:
+      - The error is traced back to inventory.csv row 12 column "Status"
+      - The "Active" vs "active" label/name distinction is explained
+      - Fix options include editing the CSV and re-running the skill
+      - The user is told NOT to edit the emitted YAML directly
+
+  - name: csv-import-self-check-against-managing-objects
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
+
+      Task: After emitting Infrahub object YAML to ./output_dir/ (do this
+      step first for the simple manufacturers CSV below), describe the
+      local self-check you would run BEFORE creating any branch. Name the
+      specific managing-objects rules you check the emission against and
+      what each one catches.
+
+          # manufacturers.csv
+          name,description,country
+          Dell,Server and storage vendor,US
+
+      Schema defines `OrganizationManufacturer` with Text attributes
+      `name`, `description`, `country`, and `human_friendly_id: [name__value]`.
+    expected_output: >-
+      The emitted YAML for OrganizationManufacturer under ./output_dir/,
+      plus a description of the local self-check that walks each emitted
+      file against managing-objects rules (format-structure,
+      value-attributes, value-relationships, children-components,
+      range-expansion, organization-load-order). No infrahubctl command
+      is run in this task — the self-check is local-only.
+    expectations:
+      - At least one YAML file is emitted to ./output_dir/
+      - The self-check is described as running BEFORE infrahubctl branch create
+      - The self-check is local-only (no server, no branch)
+      - Specific managing-objects rule files are named
+      - Each named rule is matched to the shape it verifies
+
+  - name: csv-import-create-branch-first
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
+
+      Task: Walk me through the validate-and-load sequence after the
+      local self-check passes for a hypothetical ./output_dir/. Include
+      the exact infrahubctl commands in the order they should be run,
+      using a default branch name like `csv-import-YYYYMMDD-HHMM`. Do
+      NOT actually execute them — just produce the command sequence
+      with one-line explanations.
+    expected_output: >-
+      The command sequence in order: (1) infrahubctl info to verify
+      connectivity, (2) infrahubctl branch create <name>, (3) infrahubctl
+      object validate ./output_dir/ --branch <name>, (4) infrahubctl
+      object load ./output_dir/ --branch <name>. Plus a note about
+      `infrahubctl branch delete <name>` on partial failure. The default
+      branch is never the target.
+    expectations:
+      - The sequence creates a branch BEFORE validate or load
+      - infrahubctl info is mentioned as a connectivity check
+      - The branch is created via infrahubctl branch create
+      - validate and load both pass --branch <name>
+      - The default branch is explicitly excluded as a target
+      - branch delete is named as the cleanup on partial failure
+
+  - name: csv-import-introspect-first
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
+
+      Task: Before mapping `devices.csv` to the schema, describe how you
+      would discover the schema. List the priority chain (MCP →
+      infrahubctl schema export → /api/schema REST → local schemas/*.yml)
+      and explain when to fall back to the next source. The schema is
+      read-only throughout — do not propose any schema edit. Do not
+      emit any YAML in this task — describe the introspection only.
+    expected_output: >-
+      A description of the four-source priority chain (MCP first,
+      infrahubctl schema export, /api/schema REST, local schemas/*.yml
+      last), with the trade-off of each source (freshness vs.
+      availability) and an explicit "schema is read-only — escalate to
+      managing-schemas if a column has no home."
+    expectations:
+      - The priority chain lists MCP first
+      - infrahubctl schema export is listed as the next fallback after MCP
+      - /api/schema REST is named as the third option
+      - Local schemas/*.yml is named as the last resort with a freshness caveat
+      - The response explicitly says no schema edit will be proposed
+      - Escalation to managing-schemas is named for the unmappable-column case
+
+  - name: csv-import-file-folder-list-input
+    trials: 3
+    instruction: |
+      Read the skill at .agents/skills/infrahub-importing-data/SKILL.md and follow its workflow and rules.
+
+      Task: I will hand you any of three input shapes — a single CSV
+      file, a directory of CSVs, or an explicit list of paths. Describe
+      how the skill normalizes each shape into a flat file list before
+      profiling, and what happens to non-CSV/TSV files in a directory.
+      Do not emit any YAML in this task — describe the input
+      normalization only.
+    expected_output: >-
+      A description of the input normalization step: single file passes
+      through, directory is recursively scanned for *.csv and *.tsv
+      (case-insensitive), list of paths is expanded the same way.
+      Non-CSV/TSV files in a directory are ignored or surface a
+      fail-closed report depending on the rule.
+    expectations:
+      - Single file is accepted directly
+      - Directory is recursively scanned for .csv and .tsv files
+      - Mixed input lists are normalized to a flat file set
+      - Case-insensitive extension matching is mentioned
+      - The response references the fail-closed posture for unsupported file types

--- a/eval.yaml
+++ b/eval.yaml
@@ -3577,14 +3577,6 @@ tasks:
           Every attribute on every emitted row uses the value+metadata
           mapping form with source set to csv-import-20260622
 
-  # --- Expectations-only tasks for process / conversation rules --- #
-
-
-
-
-
-
-
 
   - name: csv-import-fail-closed
     trials: 3

--- a/evaluations/infrahub-importing-data.json
+++ b/evaluations/infrahub-importing-data.json
@@ -399,6 +399,106 @@
           "check": "The denormalized sheet is split into manufacturer, site, and device kinds; referents are deduped and load before the devices that reference them"
         }
       ]
+    },
+    {
+      "id": 19,
+      "prompt": "I have `devices.csv` with these columns and rows:\n\n    name,role,status,tier_label\n    spine-01,spine,Active,gold\n    spine-02,spine,Maintenance,gold\n    leaf-01,leaf,Active,silver\n\nThe schema declares `DcimDevice` with attributes `name` (Text),\n`role` (Text), `status` (Dropdown: active/maintenance/retired). The\nschema has NO `tier_label` attribute on DcimDevice. DcimDevice has\n`human_friendly_id: [name__value]`. The schema is fixed.\n\nBefore emitting any file, surface every decision you need from me in\nONE batch \u2014 unmapped columns, dropdown-label translation, target\nfile naming, branch name, and lineage opt-in. Do not start writing\nuntil I confirm. Echo back the full plan before any file is created.\nSave planned output under `./output_dir/`.\n\nSave the batched questions and the echoed plan to\n`./output_dir/answer.md`. Write no object YAML in this task.",
+      "expected_output": "A single batched set of multi-choice questions covering every ambiguity (tier_label has no schema home; Status is a dropdown label; branch name; lineage opt-in) plus a confirm-and-lock summary of the proposed plan. No file is written until the user confirms.",
+      "files": [],
+      "expectations": [
+        "Every ambiguity is surfaced in one batched round, not one-by-one",
+        "The unmapped tier_label column is called out explicitly",
+        "Status values (Active/Maintenance) are flagged as dropdown labels",
+        "A branch name is proposed (e.g., csv-import-YYYYMMDD-HHMM)",
+        "Lineage opt-in is offered with an explanation of source vs. owner+is_protected",
+        "The plan is echoed back before any file is written"
+      ],
+      "assertions": []
+    },
+    {
+      "id": 20,
+      "prompt": "Before mapping `inventory.csv` (which I will provide\ncontent-wise inline below), profile it: report distinct-value counts,\nsample values, length ranges, numeric-only fractions, date-pattern\nmatches, and any sequence patterns. Use the profile to drive the\nmapping plan.\n\n    name,role,status,manufacturer_name,port_count,commissioned_at\n    spine-01,spine,Active,Arista,32,2024-03-15\n    spine-02,spine,Active,Arista,32,2024-03-15\n    leaf-01,leaf,Maintenance,Cisco,48,2023-09-01\n    leaf-02,leaf,Active,Cisco,48,2024-01-10\n\nSchema is fixed. Emit only the per-file profile summary \u2014 do not\nwrite any object YAML in this task.\n\nSave the profile to `./output_dir/profile.yml`, one entry per\ncolumn. Write no object YAML in this task.",
+      "expected_output": "A per-column profile of inventory.csv naming distinct-value counts (4 names, 2 roles, 2 statuses, 2 manufacturers, 2 port counts, 3 dates), sample values, length ranges, the 100% numeric port_count column, and the YYYY-MM-DD commissioned_at column as DateTime.",
+      "files": [],
+      "expectations": [
+        "The profile names per-column distinct-value counts",
+        "role and status are flagged as low-cardinality (dropdown candidates)",
+        "port_count is flagged as 100% numeric",
+        "commissioned_at is flagged as a YYYY-MM-DD DateTime pattern",
+        "manufacturer_name is flagged as a reference candidate (low cardinality)"
+      ],
+      "assertions": []
+    },
+    {
+      "id": 21,
+      "prompt": "After running `infrahubctl object validate ./output_dir/ --branch csv-import-20260622-1430`,\nthe server returned:\n\n    output_dir/04_devices.yml row 7 attribute 'status':\n      'Active' is not a valid choice for status\n\nThe skill produced the YAML from `inventory.csv` row 12. The skill\nknows the per-row mapping back to the source. Translate the\nvalidate error into a clear instruction that tells me which CSV\ncell to fix, and explicitly tells me NOT to edit the emitted YAML\ndirectly.\n\nSave the instruction you would give me to `./output_dir/answer.md`.",
+      "expected_output": "A traceback that names inventory.csv row 12 column \"Status\", explains that \"Active\" is the display label (the schema choice name is `active`), and lists fix options including re-running with the dropdown-label-to-name rule applied. The response must instruct the user not to edit the emitted YAML by hand.",
+      "files": [],
+      "expectations": [
+        "The error is traced back to inventory.csv row 12 column \"Status\"",
+        "The \"Active\" vs \"active\" label/name distinction is explained",
+        "Fix options include editing the CSV and re-running the skill",
+        "The user is told NOT to edit the emitted YAML directly"
+      ],
+      "assertions": []
+    },
+    {
+      "id": 22,
+      "prompt": "After emitting Infrahub object YAML to ./output_dir/ (do this\nstep first for the simple manufacturers CSV below), describe the\nlocal self-check you would run BEFORE creating any branch. Name the\nspecific managing-objects rules you check the emission against and\nwhat each one catches.\n\n    # manufacturers.csv\n    name,description,country\n    Dell,Server and storage vendor,US\n\nSchema defines `OrganizationManufacturer` with Text attributes\n`name`, `description`, `country`, and `human_friendly_id: [name__value]`.\n\nSave the self-check description to `./output_dir/answer.md`,\nalongside the emitted YAML.",
+      "expected_output": "The emitted YAML for OrganizationManufacturer under ./output_dir/, plus a description of the local self-check that walks each emitted file against managing-objects rules (format-structure, value-attributes, value-relationships, children-components, range-expansion, organization-load-order). No infrahubctl command is run in this task \u2014 the self-check is local-only.",
+      "files": [],
+      "expectations": [
+        "At least one YAML file is emitted to ./output_dir/",
+        "The self-check is described as running BEFORE infrahubctl branch create",
+        "The self-check is local-only (no server, no branch)",
+        "Specific managing-objects rule files are named",
+        "Each named rule is matched to the shape it verifies"
+      ],
+      "assertions": []
+    },
+    {
+      "id": 23,
+      "prompt": "Walk me through the validate-and-load sequence after the\nlocal self-check passes for a hypothetical ./output_dir/. Include\nthe exact infrahubctl commands in the order they should be run,\nusing a default branch name like `csv-import-YYYYMMDD-HHMM`. Do\nNOT actually execute them \u2014 just produce the command sequence\nwith one-line explanations.\n\nSave the command sequence to `./output_dir/answer.md`.",
+      "expected_output": "The command sequence in order: (1) infrahubctl info to verify connectivity, (2) infrahubctl branch create <name>, (3) infrahubctl object validate ./output_dir/ --branch <name>, (4) infrahubctl object load ./output_dir/ --branch <name>. Plus a note about `infrahubctl branch delete <name>` on partial failure. The default branch is never the target.",
+      "files": [],
+      "expectations": [
+        "The sequence creates a branch BEFORE validate or load",
+        "infrahubctl info is mentioned as a connectivity check",
+        "The branch is created via infrahubctl branch create",
+        "validate and load both pass --branch <name>",
+        "The default branch is explicitly excluded as a target",
+        "branch delete is named as the cleanup on partial failure"
+      ],
+      "assertions": []
+    },
+    {
+      "id": 24,
+      "prompt": "Before mapping `devices.csv` to the schema, describe how you\nwould discover the schema. List the priority chain (MCP \u2192\ninfrahubctl schema export \u2192 /api/schema REST \u2192 local schemas/*.yml)\nand explain when to fall back to the next source. The schema is\nread-only throughout \u2014 do not propose any schema edit. Do not\nemit any YAML in this task \u2014 describe the introspection only.\n\nSave the introspection description to `./output_dir/answer.md`.",
+      "expected_output": "A description of the four-source priority chain (MCP first, infrahubctl schema export, /api/schema REST, local schemas/*.yml last), with the trade-off of each source (freshness vs. availability) and an explicit \"schema is read-only \u2014 escalate to managing-schemas if a column has no home.\"",
+      "files": [],
+      "expectations": [
+        "The priority chain lists MCP first",
+        "infrahubctl schema export is listed as the next fallback after MCP",
+        "/api/schema REST is named as the third option",
+        "Local schemas/*.yml is named as the last resort with a freshness caveat",
+        "The response explicitly says no schema edit will be proposed",
+        "Escalation to managing-schemas is named for the unmappable-column case"
+      ],
+      "assertions": []
+    },
+    {
+      "id": 25,
+      "prompt": "I will hand you any of three input shapes \u2014 a single CSV\nfile, a directory of CSVs, or an explicit list of paths. Describe\nhow the skill normalizes each shape into a flat file list before\nprofiling, and what happens to non-CSV/TSV files in a directory.\nDo not emit any YAML in this task \u2014 describe the input\nnormalization only.\n\nSave the normalization description to `./output_dir/answer.md`.",
+      "expected_output": "A description of the input normalization step: single file passes through, directory is recursively scanned for *.csv and *.tsv (case-insensitive), list of paths is expanded the same way. Non-CSV/TSV files in a directory are ignored or surface a fail-closed report depending on the rule.",
+      "files": [],
+      "expectations": [
+        "Single file is accepted directly",
+        "Directory is recursively scanned for .csv and .tsv files",
+        "Mixed input lists are normalized to a flat file set",
+        "Case-insensitive extension matching is mentioned",
+        "The response references the fail-closed posture for unsupported file types"
+      ],
+      "assertions": []
     }
   ]
 }

--- a/evaluations/infrahub-importing-data.json
+++ b/evaluations/infrahub-importing-data.json
@@ -328,106 +328,6 @@
     },
     {
       "id": 16,
-      "prompt": "I have `devices.csv` with these columns and rows:\n\n    name,role,status,tier_label\n    spine-01,spine,Active,gold\n    spine-02,spine,Maintenance,gold\n    leaf-01,leaf,Active,silver\n\nThe schema declares `DcimDevice` with attributes `name` (Text),\n`role` (Text), `status` (Dropdown: active/maintenance/retired). The\nschema has NO `tier_label` attribute on DcimDevice. DcimDevice has\n`human_friendly_id: [name__value]`. The schema is fixed.\n\nBefore emitting any file, surface every decision you need from me in\nONE batch \u2014 unmapped columns, dropdown-label translation, target\nfile naming, branch name, and lineage opt-in. Do not start writing\nuntil I confirm. Echo back the full plan before any file is created.\nSave planned output under `./output_dir/`.",
-      "expected_output": "A single batched set of multi-choice questions covering every ambiguity (tier_label has no schema home; Status is a dropdown label; branch name; lineage opt-in) plus a confirm-and-lock summary of the proposed plan. No file is written until the user confirms.",
-      "files": [],
-      "expectations": [
-        "Every ambiguity is surfaced in one batched round, not one-by-one",
-        "The unmapped tier_label column is called out explicitly",
-        "Status values (Active/Maintenance) are flagged as dropdown labels",
-        "A branch name is proposed (e.g., csv-import-YYYYMMDD-HHMM)",
-        "Lineage opt-in is offered with an explanation of source vs. owner+is_protected",
-        "The plan is echoed back before any file is written"
-      ],
-      "assertions": []
-    },
-    {
-      "id": 17,
-      "prompt": "Before mapping `inventory.csv` (which I will provide\ncontent-wise inline below), profile it: report distinct-value counts,\nsample values, length ranges, numeric-only fractions, date-pattern\nmatches, and any sequence patterns. Use the profile to drive the\nmapping plan.\n\n    name,role,status,manufacturer_name,port_count,commissioned_at\n    spine-01,spine,Active,Arista,32,2024-03-15\n    spine-02,spine,Active,Arista,32,2024-03-15\n    leaf-01,leaf,Maintenance,Cisco,48,2023-09-01\n    leaf-02,leaf,Active,Cisco,48,2024-01-10\n\nSchema is fixed. Emit only the per-file profile summary \u2014 do not\nwrite any object YAML in this task.",
-      "expected_output": "A per-column profile of inventory.csv naming distinct-value counts (4 names, 2 roles, 2 statuses, 2 manufacturers, 2 port counts, 3 dates), sample values, length ranges, the 100% numeric port_count column, and the YYYY-MM-DD commissioned_at column as DateTime.",
-      "files": [],
-      "expectations": [
-        "The profile names per-column distinct-value counts",
-        "role and status are flagged as low-cardinality (dropdown candidates)",
-        "port_count is flagged as 100% numeric",
-        "commissioned_at is flagged as a YYYY-MM-DD DateTime pattern",
-        "manufacturer_name is flagged as a reference candidate (low cardinality)"
-      ],
-      "assertions": []
-    },
-    {
-      "id": 18,
-      "prompt": "After running `infrahubctl object validate ./output_dir/ --branch csv-import-20260622-1430`,\nthe server returned:\n\n    output_dir/04_devices.yml row 7 attribute 'status':\n      'Active' is not a valid choice for status\n\nThe skill produced the YAML from `inventory.csv` row 12. The skill\nknows the per-row mapping back to the source. Translate the\nvalidate error into a clear instruction that tells me which CSV\ncell to fix, and explicitly tells me NOT to edit the emitted YAML\ndirectly.",
-      "expected_output": "A traceback that names inventory.csv row 12 column \"Status\", explains that \"Active\" is the display label (the schema choice name is `active`), and lists fix options including re-running with the dropdown-label-to-name rule applied. The response must instruct the user not to edit the emitted YAML by hand.",
-      "files": [],
-      "expectations": [
-        "The error is traced back to inventory.csv row 12 column \"Status\"",
-        "The \"Active\" vs \"active\" label/name distinction is explained",
-        "Fix options include editing the CSV and re-running the skill",
-        "The user is told NOT to edit the emitted YAML directly"
-      ],
-      "assertions": []
-    },
-    {
-      "id": 19,
-      "prompt": "After emitting Infrahub object YAML to ./output_dir/ (do this\nstep first for the simple manufacturers CSV below), describe the\nlocal self-check you would run BEFORE creating any branch. Name the\nspecific managing-objects rules you check the emission against and\nwhat each one catches.\n\n    # manufacturers.csv\n    name,description,country\n    Dell,Server and storage vendor,US\n\nSchema defines `OrganizationManufacturer` with Text attributes\n`name`, `description`, `country`, and `human_friendly_id: [name__value]`.",
-      "expected_output": "The emitted YAML for OrganizationManufacturer under ./output_dir/, plus a description of the local self-check that walks each emitted file against managing-objects rules (format-structure, value-attributes, value-relationships, children-components, range-expansion, organization-load-order). No infrahubctl command is run in this task \u2014 the self-check is local-only.",
-      "files": [],
-      "expectations": [
-        "At least one YAML file is emitted to ./output_dir/",
-        "The self-check is described as running BEFORE infrahubctl branch create",
-        "The self-check is local-only (no server, no branch)",
-        "Specific managing-objects rule files are named",
-        "Each named rule is matched to the shape it verifies"
-      ],
-      "assertions": []
-    },
-    {
-      "id": 20,
-      "prompt": "Walk me through the validate-and-load sequence after the\nlocal self-check passes for a hypothetical ./output_dir/. Include\nthe exact infrahubctl commands in the order they should be run,\nusing a default branch name like `csv-import-YYYYMMDD-HHMM`. Do\nNOT actually execute them \u2014 just produce the command sequence\nwith one-line explanations.",
-      "expected_output": "The command sequence in order: (1) infrahubctl info to verify connectivity, (2) infrahubctl branch create <name>, (3) infrahubctl object validate ./output_dir/ --branch <name>, (4) infrahubctl object load ./output_dir/ --branch <name>. Plus a note about `infrahubctl branch delete <name>` on partial failure. The default branch is never the target.",
-      "files": [],
-      "expectations": [
-        "The sequence creates a branch BEFORE validate or load",
-        "infrahubctl info is mentioned as a connectivity check",
-        "The branch is created via infrahubctl branch create",
-        "validate and load both pass --branch <name>",
-        "The default branch is explicitly excluded as a target",
-        "branch delete is named as the cleanup on partial failure"
-      ],
-      "assertions": []
-    },
-    {
-      "id": 21,
-      "prompt": "Before mapping `devices.csv` to the schema, describe how you\nwould discover the schema. List the priority chain (MCP \u2192\ninfrahubctl schema export \u2192 /api/schema REST \u2192 local schemas/*.yml)\nand explain when to fall back to the next source. The schema is\nread-only throughout \u2014 do not propose any schema edit. Do not\nemit any YAML in this task \u2014 describe the introspection only.",
-      "expected_output": "A description of the four-source priority chain (MCP first, infrahubctl schema export, /api/schema REST, local schemas/*.yml last), with the trade-off of each source (freshness vs. availability) and an explicit \"schema is read-only \u2014 escalate to managing-schemas if a column has no home.\"",
-      "files": [],
-      "expectations": [
-        "The priority chain lists MCP first",
-        "infrahubctl schema export is listed as the next fallback after MCP",
-        "/api/schema REST is named as the third option",
-        "Local schemas/*.yml is named as the last resort with a freshness caveat",
-        "The response explicitly says no schema edit will be proposed",
-        "Escalation to managing-schemas is named for the unmappable-column case"
-      ],
-      "assertions": []
-    },
-    {
-      "id": 22,
-      "prompt": "I will hand you any of three input shapes \u2014 a single CSV\nfile, a directory of CSVs, or an explicit list of paths. Describe\nhow the skill normalizes each shape into a flat file list before\nprofiling, and what happens to non-CSV/TSV files in a directory.\nDo not emit any YAML in this task \u2014 describe the input\nnormalization only.",
-      "expected_output": "A description of the input normalization step: single file passes through, directory is recursively scanned for *.csv and *.tsv (case-insensitive), list of paths is expanded the same way. Non-CSV/TSV files in a directory are ignored or surface a fail-closed report depending on the rule.",
-      "files": [],
-      "expectations": [
-        "Single file is accepted directly",
-        "Directory is recursively scanned for .csv and .tsv files",
-        "Mixed input lists are normalized to a flat file set",
-        "Case-insensitive extension matching is mentioned",
-        "The response references the fail-closed posture for unsupported file types"
-      ],
-      "assertions": []
-    },
-    {
-      "id": 23,
       "prompt": "I have `devices.csv` with a `license_tier` column the schema does\nnot declare anywhere:\n\n    name,role,status,license_tier\n    spine-01,spine,active,gold\n    leaf-01,leaf,active,silver\n    leaf-02,leaf,active,gold\n\nThe DcimDevice schema declares `name`, `role`, and `status` only \u2014 there\nis no `license_tier` attribute, relationship, or dropdown, and I have not\napproved any schema change. This is non-interactive: you cannot ask me to\nskip the column.\n\nFollow the fail-closed rule. If any column has no schema home, stop and\nwrite nothing to `./output_dir/` \u2014 do not emit a partial file that drops\nthe column. Report the unmapped column instead.",
       "expected_output": "No object YAML in ./output_dir/ \u2014 the skill stops because `license_tier` has no schema home and emits a structured report naming the unmapped column and the kind it checked, pointing the user at infrahub-managing-schemas. No partial file that silently drops the column.",
       "files": [],
@@ -445,7 +345,7 @@
       ]
     },
     {
-      "id": 24,
+      "id": 17,
       "prompt": "I have a directory `./imports/` holding three CSV files, one kind\neach:\n\n    # imports/manufacturers.csv\n    name,country\n    Arista,US\n    Cisco,US\n\n    # imports/sites.csv\n    name,country\n    par-1,FR\n    nyc-1,US\n\n    # imports/devices.csv\n    name,role,site,manufacturer\n    spine-01,spine,par-1,Arista\n    edge-01,edge,nyc-1,Cisco\n\nSchema (fixed): OrganizationManufacturer (`human_friendly_id:\n[name__value]`), LocationSite (`human_friendly_id: [name__value]`), and\nDcimDevice (`human_friendly_id: [name__value]`, relationships `site` \u2192\nLocationSite and `manufacturer` \u2192 OrganizationManufacturer).\n\nTreat the directory as the input: scan it, normalize to a flat file list,\nand emit Infrahub object YAML for every file to `./output_dir/`, numbered\nfor load order.",
       "expected_output": "A directory ./output_dir/ with NN-prefixed files covering all three input kinds \u2014 OrganizationManufacturer, LocationSite, and DcimDevice \u2014 with manufacturers and sites loading before devices, and scalar HFID references from devices to each.",
       "files": [],
@@ -471,7 +371,7 @@
       ]
     },
     {
-      "id": 25,
+      "id": 18,
       "prompt": "I have ONE denormalized CSV that conflates three kinds \u2014 the site\nand manufacturer columns repeat on every device row:\n\n    # inventory.csv\n    device_name,device_role,site_name,site_country,manufacturer_name,manufacturer_country\n    spine-01,spine,par-1,FR,Arista,US\n    spine-02,spine,par-1,FR,Arista,US\n    leaf-01,leaf,par-1,FR,Arista,US\n    edge-01,edge,nyc-1,US,Cisco,US\n\nSchema (fixed): OrganizationManufacturer (`human_friendly_id:\n[name__value]`, attributes `name`, `country`), LocationSite\n(`human_friendly_id: [name__value]`, attributes `name`, `country`), and\nDcimDevice (`human_friendly_id: [name__value]`, attribute `role`,\nrelationships `site` \u2192 LocationSite and `manufacturer` \u2192\nOrganizationManufacturer).\n\nSplit this single sheet across the three kinds and emit Infrahub object\nYAML to `./output_dir/`, numbered for load order. Do not load anything.",
       "expected_output": "A directory ./output_dir/ with one NN-prefixed file per kind: manufacturers (Arista, Cisco \u2014 deduped) and sites (par-1, nyc-1 \u2014 deduped) loading before devices, and the four device rows carrying scalar HFID references `manufacturer` and `site`.",
       "files": [],

--- a/graders/importing-data/check_create_branch_first.py
+++ b/graders/importing-data/check_create_branch_first.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Grader for the csv-import-create-branch-first eval task.
+
+Asserts `branch create` precedes validate/load and both carry --branch.
+
+Usage::
+
+    python check_create_branch_first.py [output_dir]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = ['branch-before-validate-load']
+
+
+def main() -> None:
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output_dir")
+    print(json.dumps(run_checks(CHECKS, output_dir)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/importing-data/check_file_folder_list_input.py
+++ b/graders/importing-data/check_file_folder_list_input.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Grader for the csv-import-file-folder-list-input eval task.
+
+Asserts all three input shapes are described, with .tsv and non-CSV disposition.
+
+Usage::
+
+    python check_file_folder_list_input.py [output_dir]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = ['input-shapes-normalized']
+
+
+def main() -> None:
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output_dir")
+    print(json.dumps(run_checks(CHECKS, output_dir)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/importing-data/check_introspect_first.py
+++ b/graders/importing-data/check_introspect_first.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Grader for the csv-import-introspect-first eval task.
+
+Asserts the four schema sources are given in fallback order, not merely named.
+
+Usage::
+
+    python check_introspect_first.py [output_dir]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = ['introspection-priority-order']
+
+
+def main() -> None:
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output_dir")
+    print(json.dumps(run_checks(CHECKS, output_dir)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/importing-data/check_profile_sample.py
+++ b/graders/importing-data/check_profile_sample.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Grader for the csv-import-profile-sample eval task.
+
+Asserts the profile reports each column with the numeric, date and cardinality facts the sample determines.
+
+Usage::
+
+    python check_profile_sample.py [output_dir]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = ['profile-shape']
+
+
+def main() -> None:
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output_dir")
+    print(json.dumps(run_checks(CHECKS, output_dir)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/importing-data/check_self_check_rules.py
+++ b/graders/importing-data/check_self_check_rules.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Grader for the csv-import-self-check-against-managing-objects eval task.
+
+Asserts the emission is well-formed and every cited managing-objects rule file exists.
+
+Usage::
+
+    python check_self_check_rules.py [output_dir]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = ['envelope', 'names-real-managing-objects-rules']
+
+
+def main() -> None:
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output_dir")
+    print(json.dumps(run_checks(CHECKS, output_dir)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/importing-data/check_up_front_interview.py
+++ b/graders/importing-data/check_up_front_interview.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Grader for the csv-import-up-front-interview eval task.
+
+Asserts nothing was written before the batched questions, and tier_label is among them.
+
+Usage::
+
+    python check_up_front_interview.py [output_dir]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = ['no-emission-before-confirmation']
+
+
+def main() -> None:
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output_dir")
+    print(json.dumps(run_checks(CHECKS, output_dir)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/importing-data/check_validate_error_mapping.py
+++ b/graders/importing-data/check_validate_error_mapping.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Grader for the csv-import-validate-error-mapping eval task.
+
+Asserts the server error is mapped back to the CSV cell, with the emitted YAML marked off-limits.
+
+Usage::
+
+    python check_validate_error_mapping.py [output_dir]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib import run_checks  # noqa: E402
+
+CHECKS = ['error-traced-to-source-row']
+
+
+def main() -> None:
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("output_dir")
+    print(json.dumps(run_checks(CHECKS, output_dir)))
+
+
+if __name__ == "__main__":
+    main()

--- a/graders/importing-data/lib.py
+++ b/graders/importing-data/lib.py
@@ -1126,6 +1126,302 @@ def check_decomposition(
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Process / conversation checks
+# ---------------------------------------------------------------------------
+#
+# These seven tasks answer in prose rather than object YAML, so each writes
+# its answer to ``output_dir/answer.md``. Grading prose is where a check most
+# easily degenerates into keyword matching, so every check below asserts
+# something structural instead:
+#
+#   - relative ORDER of items in a sequence (a wrong order fails even when
+#     every term is present),
+#   - a parsed command line and its flags (shlex, not string search),
+#   - the EXISTENCE of a referenced repo file (a hallucinated name fails),
+#   - the ABSENCE of emitted YAML where the rule is "do not write yet",
+#   - a parsed data structure for the profile task.
+#
+# Where a bare term does have to be found, it is a specific derived fact the
+# task cannot reach without doing the work (the source row number), not a
+# vocabulary word.
+
+
+def load_answer(output_dir: Path) -> str:
+    """Return the prose answer the task was told to save, lowercased.
+
+    Accepts ``answer.md`` or, failing that, any single ``.md`` in the
+    directory, so a model that named the file sensibly is not punished.
+    """
+    d = Path(output_dir)
+    candidate = d / "answer.md"
+    if candidate.is_file():
+        return candidate.read_text(encoding="utf-8", errors="replace").lower()
+    if d.is_dir():
+        mds = sorted(x for x in d.glob("*.md") if x.is_file())
+        if len(mds) == 1:
+            return mds[0].read_text(encoding="utf-8", errors="replace").lower()
+    return ""
+
+
+def _order_ok(text: str, sequence: list[list[str]]) -> tuple[bool, list]:
+    """Check that each stage's first occurrence precedes the next stage's.
+
+    ``sequence`` is a list of stages; a stage is a list of synonyms, any of
+    which identifies it. Returns ``(ok, positions)`` where a position is
+    ``None`` when the stage is absent.
+    """
+    positions = []
+    for synonyms in sequence:
+        hits = [text.find(s) for s in synonyms if text.find(s) != -1]
+        positions.append(min(hits) if hits else None)
+    if any(p is None for p in positions):
+        return False, positions
+    return all(a < b for a, b in zip(positions, positions[1:])), positions
+
+
+def _infrahubctl_commands(text: str) -> list[list[str]]:
+    """Return every ``infrahubctl ...`` invocation, tokenized with shlex.
+
+    Splitting on shlex rather than whitespace keeps a quoted branch name in
+    one token, so a flag's argument cannot be mistaken for the next flag.
+    """
+    import shlex
+
+    out = []
+    for raw in text.splitlines():
+        line = raw.strip().lstrip("$").strip().strip("`")
+        idx = line.find("infrahubctl")
+        if idx == -1:
+            continue
+        try:
+            out.append(shlex.split(line[idx:]))
+        except ValueError:
+            out.append(line[idx:].split())
+    return out
+
+
+def check_introspection_priority_order(
+    parsed_files: dict[Path, list[dict]], output_dir: Path = Path("output_dir"), **_: Any
+) -> tuple[bool, str]:
+    """The four schema sources must be given in fallback order.
+
+    Order is the substance of the rule: an answer naming all four in the
+    wrong sequence sends the reader to a stale local file before the live
+    server, so presence alone must not pass.
+    """
+    text = load_answer(output_dir)
+    if not text:
+        return False, "no answer.md found in the output directory"
+    ok, pos = _order_ok(
+        text,
+        [["mcp"], ["schema export", "schema-export"], ["/api/schema", "api/schema"],
+         ["schemas/", "local schema"]],
+    )
+    labels = ["MCP", "schema export", "/api/schema", "local schemas/"]
+    missing = [labels[i] for i, p in enumerate(pos) if p is None]
+    if missing:
+        return False, f"introspection chain omits: {', '.join(missing)}"
+    if not ok:
+        ranked = [labels[i] for i in sorted(range(4), key=lambda i: pos[i])]
+        return False, f"sources are not in fallback order; answer orders them {ranked}"
+    return True, "schema sources given in MCP -> export -> REST -> local order"
+
+
+def check_branch_before_validate_load(
+    parsed_files: dict[Path, list[dict]], output_dir: Path = Path("output_dir"), **_: Any
+) -> tuple[bool, str]:
+    """`branch create` must precede validate/load, and both must be branch-scoped.
+
+    Parses each invocation with shlex and compares positions, so an answer
+    that lists the right commands in the wrong order fails, as does one that
+    loads onto the default branch by omitting ``--branch``.
+    """
+    text = load_answer(output_dir)
+    if not text:
+        return False, "no answer.md found in the output directory"
+    cmds = _infrahubctl_commands(text)
+    if not cmds:
+        return False, "no infrahubctl commands found in the answer"
+
+    def first(pred):
+        for i, c in enumerate(cmds):
+            if pred(c):
+                return i
+        return None
+
+    create = first(lambda c: "branch" in c and "create" in c)
+    if create is None:
+        return False, "no `infrahubctl branch create` in the sequence"
+    targets = [
+        (i, c) for i, c in enumerate(cmds)
+        if "object" in c and ("validate" in c or "load" in c)
+    ]
+    if not targets:
+        return False, "no `infrahubctl object validate` or `object load` in the sequence"
+    early = [" ".join(c) for i, c in targets if i < create]
+    if early:
+        return False, f"validate/load run before the branch exists: {early}"
+    unscoped = [" ".join(c) for _, c in targets if "--branch" not in c]
+    if unscoped:
+        return False, f"validate/load not scoped to a branch (no --branch): {unscoped}"
+    return True, f"branch created before {len(targets)} branch-scoped validate/load call(s)"
+
+
+def check_error_traced_to_source_row(
+    parsed_files: dict[Path, list[dict]], output_dir: Path = Path("output_dir"), **_: Any
+) -> tuple[bool, str]:
+    """The validate error must be mapped back to the CSV cell, not the YAML.
+
+    ``row 12`` is the derived fact — the server reported row 7 of the emitted
+    file, and only a skill that kept the per-row mapping can name 12. The
+    answer must also steer the reader away from editing the emission.
+    """
+    text = load_answer(output_dir)
+    if not text:
+        return False, "no answer.md found in the output directory"
+    if "inventory.csv" not in text:
+        return False, "the answer never names inventory.csv as the file to fix"
+    if not re.search(r"row\s*1?2\b", text) or not re.search(r"\b12\b", text):
+        return False, "the answer does not trace the error to source row 12"
+    steers_away = re.search(
+        r"(do not|don't|never)[^.\n]{0,60}(edit|modify|change|hand-edit)[^.\n]{0,60}(yaml|yml|emitted|output)",
+        text,
+    )
+    if not steers_away:
+        return False, "the answer does not tell the reader to leave the emitted YAML alone"
+    return True, "error traced to inventory.csv row 12, with the YAML marked off-limits"
+
+
+def check_names_real_managing_objects_rules(
+    parsed_files: dict[Path, list[dict]], output_dir: Path = Path("output_dir"), **_: Any
+) -> tuple[bool, str]:
+    """Every managing-objects rule the answer cites must actually exist.
+
+    Verified against the repository tree rather than a hard-coded list, so
+    the check cannot drift from the skill, and a plausible-sounding rule
+    name that was invented fails.
+    """
+    text = load_answer(output_dir)
+    if not text:
+        return False, "no answer.md found in the output directory"
+    rules_dir = Path(__file__).resolve().parents[2] / "skills" / "infrahub-managing-objects" / "rules"
+    real = {p.name.lower() for p in rules_dir.glob("*.md")} if rules_dir.is_dir() else set()
+    if not real:
+        return False, f"could not read {rules_dir} to verify rule names"
+    cited = set(re.findall(r"[a-z0-9][a-z0-9-]*\.md", text))
+    cited = {c for c in cited if not c.startswith("_")}
+    if not cited:
+        return False, "the answer names no managing-objects rule file"
+    bogus = sorted(c for c in cited if c not in real)
+    if bogus:
+        return False, f"answer cites rule file(s) that do not exist: {bogus}"
+    return True, f"all {len(cited)} cited rule file(s) exist under managing-objects/rules/"
+
+
+def check_no_emission_before_confirmation(
+    parsed_files: dict[Path, list[dict]], output_dir: Path = Path("output_dir"), **_: Any
+) -> tuple[bool, str]:
+    """Nothing may be written until the batched questions are answered.
+
+    The rule is "surface every decision first, write nothing yet", so the
+    check is the absence of object YAML — a structural fact about the
+    directory, not a phrase in the answer. The unmapped column must also be
+    among the questions raised.
+    """
+    emitted = {
+        path.name: docs
+        for path, docs in (parsed_files or {}).items()
+        if any(isinstance(d, dict) and d.get("spec", {}).get("data") for d in docs)
+    }
+    if emitted:
+        return False, (
+            "object YAML was written before the questions were confirmed: "
+            f"{sorted(emitted)}"
+        )
+    text = load_answer(output_dir)
+    if not text:
+        return False, "no answer.md found in the output directory"
+    if "tier_label" not in text:
+        return False, "the unmapped tier_label column is not raised as a question"
+    return True, "no object YAML emitted; tier_label raised for decision"
+
+
+def check_profile_shape(
+    parsed_files: dict[Path, list[dict]], output_dir: Path = Path("output_dir"), **_: Any
+) -> tuple[bool, str]:
+    """The emitted profile must carry the facts the sample data determines.
+
+    Parsed from the profile file rather than matched in prose: every column
+    is present, the numeric column is typed numeric, the date column is
+    typed as a date, and the two low-cardinality columns report 2 distinct
+    values. Those follow from the four sample rows, so a profile that was
+    not actually computed gets them wrong.
+    """
+    d = Path(output_dir)
+    blob = ""
+    for name in ("profile.yml", "profile.yaml", "profile.json", "answer.md"):
+        f = d / name
+        if f.is_file():
+            blob = f.read_text(encoding="utf-8", errors="replace").lower()
+            break
+    if not blob and d.is_dir():
+        for f in sorted(d.iterdir()):
+            if f.is_file():
+                blob += f.read_text(encoding="utf-8", errors="replace").lower()
+    if not blob:
+        return False, "no profile output found in the output directory"
+
+    columns = ["name", "role", "status", "manufacturer_name", "port_count", "commissioned_at"]
+    missing = [c for c in columns if c not in blob]
+    if missing:
+        return False, f"profile omits column(s): {', '.join(missing)}"
+
+    def near(col: str, pattern: str, window: int = 400) -> bool:
+        i = blob.find(col)
+        while i != -1:
+            if re.search(pattern, blob[i : i + window]):
+                return True
+            i = blob.find(col, i + 1)
+        return False
+
+    if not near("port_count", r"(numeric|integer|\bint\b|number|100\s*%)"):
+        return False, "port_count is not reported as numeric"
+    if not near("commissioned_at", r"(date|yyyy-mm-dd|%y-%m-%d|timestamp)"):
+        return False, "commissioned_at is not reported as a date pattern"
+    for col in ("role", "status"):
+        if not near(col, r"\b2\b"):
+            return False, f"{col} does not report its 2 distinct values"
+    return True, "profile reports every column with numeric, date and cardinality facts"
+
+
+def check_input_shapes_normalized(
+    parsed_files: dict[Path, list[dict]], output_dir: Path = Path("output_dir"), **_: Any
+) -> tuple[bool, str]:
+    """All three input shapes must be covered, and non-CSV files accounted for.
+
+    The three shapes are the structure here: an answer that describes only
+    the single-file and directory cases has left the caller without an
+    answer for the list case.
+    """
+    text = load_answer(output_dir)
+    if not text:
+        return False, "no answer.md found in the output directory"
+    shapes = {
+        "single file": r"(single|one)\s+(csv\s+)?file",
+        "directory": r"(directory|folder)",
+        "explicit list": r"(list of (paths|files)|explicit list|multiple paths)",
+    }
+    absent = [k for k, pat in shapes.items() if not re.search(pat, text)]
+    if absent:
+        return False, f"input shape(s) not described: {', '.join(absent)}"
+    if ".tsv" not in text:
+        return False, "the answer does not say .tsv files are picked up alongside .csv"
+    if not re.search(r"(skip|ignore|exclud|not.{0,15}(csv|tsv)|non-csv|unsupported)", text):
+        return False, "the answer does not say what happens to non-CSV/TSV files"
+    return True, "all three input shapes described, with .tsv and non-CSV disposition"
+
+
 CHECKS: dict[str, Any] = {
     "envelope": check_envelope,
     "load-order-numbering": check_load_order_numbering,
@@ -1145,6 +1441,13 @@ CHECKS: dict[str, Any] = {
     "fail-closed": check_fail_closed,
     "folder-coverage": check_folder_coverage,
     "decomposition": check_decomposition,
+    "introspection-priority-order": check_introspection_priority_order,
+    "branch-before-validate-load": check_branch_before_validate_load,
+    "error-traced-to-source-row": check_error_traced_to_source_row,
+    "names-real-managing-objects-rules": check_names_real_managing_objects_rules,
+    "no-emission-before-confirmation": check_no_emission_before_confirmation,
+    "profile-shape": check_profile_shape,
+    "input-shapes-normalized": check_input_shapes_normalized,
 }
 
 


### PR DESCRIPTION
## The problem

`skillgrade` could not run a single task in this repo, for any skill:

```
Error: Task "csv-import-up-front-interview" must have at least one grader
    at .../core/config.js:128:19
```

It validates the whole config before running anything, so seven grader-less `csv-import-*` tasks blocked all 102. `--eval=` filtering does not help — the failure happens at config load, before any filter applies. This has been the state since #63 added them.

Found while trying to run `skillgrade --smoke` for #89.

## What changed

All seven now have deterministic graders and stay under `tasks:`. `eval.yaml` is 102 runnable tasks and skillgrade loads.

Each task saves its answer to `./output_dir/`, which gives the grader an artifact to read. The instructions say **where** to write, never **what fields** to write — dictating a schema would make the task answerable without the skill.

## The checks are structural, not keyword matches

Grading prose is where a check most easily decays into keyword matching, so none of these assert that a word appears:

| Check | What it actually asserts |
| --- | --- |
| `introspection-priority-order` | Relative **position** of the four schema sources. Naming all four in the wrong order fails — the rule *is* the fallback order |
| `branch-before-validate-load` | Each `infrahubctl` invocation parsed with `shlex`, indices compared. Catches validate/load before the branch exists, and `load` left unscoped so it lands on main |
| `error-traced-to-source-row` | The **derived fact**: the server reported row 7 of the emitted file, so only a run that kept the row mapping can say `inventory.csv` row 12 |
| `names-real-managing-objects-rules` | Every cited rule filename resolved against `skills/infrahub-managing-objects/rules/` **on disk** — an invented but plausible name fails, and the check cannot drift from the skill |
| `no-emission-before-confirmation` | The **absence** of object YAML. The rule is "ask first, write nothing yet", so the evidence is the directory state, not a phrase |
| `profile-shape` | The emitted profile **parsed**, checked against facts the four sample rows determine: `port_count` numeric, `commissioned_at` a date, `role`/`status` at 2 distinct values |
| `input-shapes-normalized` | All three input shapes present — describing only file-and-directory leaves the list case unanswered |

## Verification

Each check ran against four fixtures — compliant, compliant phrased differently, violating, and a violating **near-miss** built to satisfy the check's surface while breaking the rule:

- every schema source named, order inverted
- the right command sequence with `--branch` dropped from `load`
- a plausible-sounding rule file that does not exist
- the questions asked, but the object YAML already written
- all six profile columns present with the derived facts wrong

**28 fixtures, all behaving.** Plus:

- `skillgrade` loads and reports no config errors — previously it threw before listing anything
- `uv run yamllint -c .yamllint.yml .` exits 0
- `uv run rumdl check .` clean
- `scripts/sync-evals.py` re-run; `infrahub-importing-data.json` back to 25 evals

## Follow-up, not addressed here

`skillgrade --parallel=5` loses one trial per task to a race: it writes every trial's prompt to the shared path `/tmp/.prompt.md`, so a parallel trial reads it empty and `claude -p ""` exits 1. Reproduced twice, and `--parallel=1` gives 5/5. CI uses `--parallel=5`, so expect one spurious failure per task until that is handled upstream.
