### PR TITLE
chore(ci): clear the ruff findings and gate the rule set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,25 @@ jobs:
       - run: yamllint -c .yamllint.yml .
 
   # ---------------------------------------------------------------------------
+  # Lint Python files
+  #
+  # Reuses the `tests` filter deliberately: it already resolves to every
+  # `**/*.py`, `pyproject.toml`, `uv.lock` and `ci.yml` change, which is
+  # exactly the trigger set a Python lint job wants.
+  #
+  # The rule set is pinned in `pyproject.toml` rather than inherited from
+  # whichever ruff resolves, so this gate cannot widen on a version bump.
+  # ---------------------------------------------------------------------------
+  python-lint:
+    needs: files-changed
+    if: needs.files-changed.outputs.tests == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv run ruff check .
+
+  # ---------------------------------------------------------------------------
   # Run the Python test suite — grader libraries and the bundled skill scripts
   #
   # Matrixed over the floor and the current interpreter: pyproject declares

--- a/graders/managing-generators/lib.py
+++ b/graders/managing-generators/lib.py
@@ -685,7 +685,7 @@ def check_uses_from_graphql(output: dict, **_: Any) -> tuple[bool, str]:
                 f"with client= and data= kwargs ({len(in_loop)} total)"
             )
     return False, (
-        f"InfrahubNode.from_graphql called inside a for-loop but missing "
+        "InfrahubNode.from_graphql called inside a for-loop but missing "
         "client= or data= kwargs"
     )
 

--- a/graders/managing-menus/lib.py
+++ b/graders/managing-menus/lib.py
@@ -18,7 +18,6 @@ Usage (in a per-task grader script)::
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
 
@@ -450,7 +449,6 @@ def run_checks(
     total = len(check_names)
     score = round(passed_count / total, 4) if total > 0 else 0.0
 
-    passed_names = [e["name"] for e in entries if e["passed"]]
     failed_names = [e["name"] for e in entries if not e["passed"]]
     if failed_names:
         details = f"{passed_count}/{total} checks passed. Failed: {', '.join(failed_names)}"

--- a/graders/managing-schemas/lib.py
+++ b/graders/managing-schemas/lib.py
@@ -2496,7 +2496,6 @@ def run_checks(
     total = len(check_names)
     score = round(passed_count / total, 4) if total > 0 else 0.0
 
-    passed_names = [e["name"] for e in entries if e["passed"]]
     failed_names = [e["name"] for e in entries if not e["passed"]]
     if failed_names:
         details = f"{passed_count}/{total} checks passed. Failed: {', '.join(failed_names)}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.10"
 dev = [
     "rumdl",
     "invoke>=2.2.0",
+    "ruff>=0.14.0",
     "yamllint>=1.37.1",
 ]
 
@@ -64,3 +65,11 @@ front-matter-title = ""
 # MD060: require leading and trailing pipes
 [tool.rumdl.MD060]
 enabled = true
+
+[tool.ruff.lint]
+# Pinned to what was ruff's default rule set through 0.15, which is the set
+# this repo was cleaned against. Left implicit, the gate would silently widen
+# on a ruff upgrade: 0.16 turned on RUF/EXE/I/BLE/N/SIM/UP and friends, which
+# report 352 further findings here. Adopting any of those is a deliberate
+# change with its own diff to clear, not a side effect of bumping a floor.
+select = ["E4", "E7", "E9", "F"]

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -959,7 +959,7 @@ def main():
             print(f"\n  Eval {eval_id}: {ev['prompt'][:80]}...")
 
             # Run with skill
-            print(f"    Running with skill...")
+            print("    Running with skill...")
             ws_dir = eval_dir / "with_skill" / "outputs"
             ws_timing = run_claude_prompt(
                 ev["prompt"], ws_dir, with_skill=True,
@@ -970,7 +970,7 @@ def main():
             # Run without skill
             wos_timing = {"total_tokens": 0, "duration_ms": 0, "total_duration_seconds": 0}
             if not args.skip_baseline:
-                print(f"    Running without skill (baseline)...")
+                print("    Running without skill (baseline)...")
                 wos_dir = eval_dir / "without_skill" / "outputs"
                 wos_timing = run_claude_prompt(
                     ev["prompt"], wos_dir, with_skill=False, model=args.model,
@@ -982,7 +982,7 @@ def main():
             ws_schema = eval_dir / "with_skill" / "outputs" / "schema.yml"
             wos_schema = eval_dir / "without_skill" / "outputs" / "schema.yml"
 
-            print(f"    Grading...")
+            print("    Grading...")
             ws_grading = grade_schema(ws_schema, assertions) if ws_schema.exists() else {
                 "expectations": [{"text": a.get("check", "<missing check>"), "passed": False, "evidence": "No schema file produced"} for a in assertions],
                 "summary": {"passed": 0, "failed": len(assertions), "total": len(assertions), "pass_rate": 0.0},

--- a/tests/graders/test_generators_lib.py
+++ b/tests/graders/test_generators_lib.py
@@ -1,5 +1,6 @@
 """Tests for graders/managing-generators/lib.py AST helpers."""
 
+import ast
 import importlib.util
 from pathlib import Path
 
@@ -22,8 +23,6 @@ is_bare_string = _mod.is_bare_string
 is_name_or_attribute = _mod.is_name_or_attribute
 load_output_py = _mod.load_output_py
 
-
-import ast
 
 
 def _parse(src: str) -> ast.Module:

--- a/tests/graders/test_menu_lib.py
+++ b/tests/graders/test_menu_lib.py
@@ -7,7 +7,6 @@ import importlib.util
 import json
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/graders/test_schema_graders.py
+++ b/tests/graders/test_schema_graders.py
@@ -15,10 +15,8 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
-import pytest
 import yaml
 
 # ---------------------------------------------------------------------------

--- a/tests/graders/test_schema_lib.py
+++ b/tests/graders/test_schema_lib.py
@@ -3,8 +3,6 @@
 Covers >= 10 check functions against both good and bad schemas.
 """
 
-import json
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -17,7 +15,6 @@ import yaml
 # importlib.util to load the module directly by file path.
 # ---------------------------------------------------------------------------
 import importlib.util
-import sys
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _LIB_PATH = _REPO_ROOT / "graders" / "managing-schemas" / "lib.py"

--- a/uv.lock
+++ b/uv.lock
@@ -191,6 +191,7 @@ source = { virtual = "." }
 [package.dev-dependencies]
 dev = [
     { name = "invoke" },
+    { name = "ruff" },
     { name = "rumdl" },
     { name = "yamllint" },
 ]
@@ -205,6 +206,7 @@ test = [
 [package.metadata.requires-dev]
 dev = [
     { name = "invoke", specifier = ">=2.2.0" },
+    { name = "ruff", specifier = ">=0.14.0" },
     { name = "rumdl" },
     { name = "yamllint", specifier = ">=1.37.1" },
 ]
@@ -511,6 +513,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
+    { url = "https://files.pythonhosted.org/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
+    { url = "https://files.pythonhosted.org/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A health check of `main` after today's merges (#85, #89, #109-#114, #120, #121, #126) turned up one gate-shaped gap and two pieces of coverage debt. This PR fixes the gap. The debt is written up below rather than fixed, because both need a decision rather than an edit.

## The gap: ruff was the one linter with no job

`main` carried **14 ruff findings** — 7 unused imports, 4 f-strings with no placeholder, 2 dead locals and one import sitting below the module body. `rumdl`, `yamllint`, `pytest` and `cli-invocations` all gate on CI; ruff did not, so its findings accumulated quietly.

All 14 are cleared and a `python-lint` job is added. Two notes on the how:

- The dead `passed_names` locals in `graders/managing-menus/lib.py` and `graders/managing-schemas/lib.py` are **removed rather than wired in**. The adjacent `failed_names` is what builds the details string, so the pair reads as an oversight, not an intent. If either was meant to appear in the grader output, this is the wrong fix and worth saying so.
- `import ast` is hoisted to the top of `test_generators_lib.py` rather than given a `# noqa: E402`, since nothing about the dynamic module load requires it to sit below.

## The rule set is pinned, and that turned out to matter

ruff was not a declared dependency, so `uv run ruff` resolved to whatever happened to be installed — 0.15.5 on the machine this was measured on. Declaring it resolves **0.16.6**, whose wider defaults report **352 further findings** across `RUF100`, `EXE001`, `RUF059`, `I001`, `BLE001`, `N999` and others.

So the first version of this change would have added a gate that passed locally and failed CI on a diff nobody wrote, and would have widened again on the next ruff bump. `pyproject.toml` now pins `select = ["E4", "E7", "E9", "F"]` — ruff's default set through 0.15, and the set this repo was actually cleaned against. Adopting any of the other 352 is a deliberate change with its own diff to clear; `RUF100` (115 unused `noqa` directives) and `I001` (34 unsorted imports) look like the cheapest two if anyone wants to take them.

## Debt found but not fixed here

**10 check functions are registered in a `CHECKS` registry, requested by no grader script, named in no `eval.yaml` task, and covered by no test.** They read as coverage without being coverage:

| Skill | Dead registrations |
| --- | --- |
| `importing-data` | `branch-before-validate-load`, `error-traced-to-source-row`, `input-shapes-normalized`, `introspection-priority-order`, `names-real-managing-objects-rules`, `no-emission-before-confirmation`, `profile-shape` |
| `auditing-repo` | `yagni-finding-absent`, `yagni-replacement-mentions` |
| `reporting-skill-gaps` | `recurring` |

The `importing-data` cluster is the one worth attention: 7 of them, in a skill with 25 eval tasks, so the rules they were written for are unscored. Wiring one into a grader script changes what an existing task scores, which is why none is touched here — each needs a call about which task should own it, or an explicit decision to delete.

**71 of 181 rule files are not named anywhere in their own `SKILL.md`.** This is the reachability rule #120 just landed, and #120's own description put the figure at "60+", so it is known rather than new. `infrahub-auditing-repo` (28/30) and `infrahub-common` (11/11) are arguably by design — audit rules are emitted by a procedure and common rules are loaded by other skills — but `infrahub-managing-schemas` at 11/29 and `infrahub-managing-generators` at 5/13 are the same defect the rule describes. Too large to fold in here.

## Verification

- `uv run ruff check .` — clean, under the declared 0.16.6 with the pinned select.
- `uv run --group test pytest` — 622 passed.
- `uv run rumdl check .` — clean, 291 files.
- `uv run yamllint -c .yamllint.yml .` — clean (the only warning comes from a local scratch directory outside the repo's tracked files).
- `python scripts/check-cli-invocations.py` — OK.
- `scripts/sync-evals.py` — no drift; `eval.yaml` and `evaluations/` unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
