### PR TITLE
docs(release-notes): add 1.2.8 and complete the release manifest

### DIFF
--- a/.github/.release-manifest.json
+++ b/.github/.release-manifest.json
@@ -10,6 +10,7 @@
     "infrahub-auditing-repo",
     "infrahub-analyzing-data",
     "infrahub-reporting-issues",
+    "infrahub-reporting-skill-gaps",
     "infrahub-collecting-diagnostics",
     "infrahub-analyzing-diagnostics",
     "infrahub-importing-data",

--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -163,6 +163,8 @@ toml
 tomek
 towncrier
 Towncrier
+traceback
+tracebacks
 uncheck
 untrust
 uniqueness_constraints
@@ -173,6 +175,7 @@ userinfo
 uv
 uuid
 UUID
+UUIDs
 validator
 validators
 Version Control

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,5 +94,21 @@ rule as covered forever.
 All skills share a unified version. When bumping, update together:
 
 1. `.claude-plugin/plugin.json`
-2. `.github/.release-manifest.json`
-3. Every `skills/*/SKILL.md` frontmatter
+2. `.github/.release-manifest.json` — also lists the
+   skills the published release claims to ship
+3. `pyproject.toml`
+4. Every `skills/*/SKILL.md` frontmatter
+5. `uv.lock` — any `uv run` rewrites it, so a stale
+   version reappears as a stray diff in later PRs
+
+`scripts/sync-versions.sh <version>` does 2-4;
+`auto-bump.yml` does 1 before calling it. `release.yml`
+validates 1-4 against the tag and fails the publish on
+a mismatch — nothing validates 5.
+
+Each release also gets a curated notes page under
+`docs/docs/release-notes/`, with `sidebar_position: 1`
+and every older page shifted down by one. Merging to
+`main` regenerates the GitHub draft release body, so
+paste the curated notes into the draft after the last
+PR lands and before publishing.

--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -64,6 +64,8 @@ For full lifecycle workflows. The AI generates files, loads them with `infrahubc
 | [Issue Reporter](./skills-reference/reporting-issues.mdx) | Routes a bug or feature request to the right Infrahub-ecosystem repository and prepares a sanitized draft for your review |
 | [Skill Gap Reporter](./skills-reference/reporting-skill-gaps.mdx) | Turns friction with an Infrahub skill into a reviewed issue with a proposed rule change, filed through the Issue Reporter |
 | [Concept Tutor](./skills-reference/teaching-concepts.mdx) | Teaches Infrahub concepts through the learner's own repo and instance, with verified exercises and progress tracking |
+| [Diagnostics Analyzer](./skills-reference/analyzing-diagnostics.mdx) | Turns a collected diagnostic bundle into a triage report, correlating errors into incidents and matching them against known Infrahub issues |
+| [NetBox Device Type Converter](./skills-reference/converting-netbox-device-types.mdx) | Converts NetBox device-type and module-type definitions into Infrahub Object Templates via a mapping-profile-driven converter |
 
 A shared reference library (`infrahub-common`) provides GraphQL query syntax, `.infrahub.yml` configuration format, YAML structure conventions, and the Profiles vs Object Templates distinction to all skills.
 

--- a/docs/docs/release-notes/release-0_0_1.mdx
+++ b/docs/docs/release-notes/release-0_0_1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 0.0.1
-sidebar_position: 9
+sidebar_position: 10
 description: The first release of Infrahub Skills — eight skills that build, query, and audit Infrahub resources from natural language.
 ---
 

--- a/docs/docs/release-notes/release-1_2_0.mdx
+++ b/docs/docs/release-notes/release-1_2_0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.2.0
-sidebar_position: 8
+sidebar_position: 9
 description: Version realignment from 0.0.1 to 1.2.0 ahead of the automated release tooling. No skill changes.
 ---
 

--- a/docs/docs/release-notes/release-1_2_1.mdx
+++ b/docs/docs/release-notes/release-1_2_1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.2.1
-sidebar_position: 7
+sidebar_position: 8
 description: A documentation site for the skills package — installation, how-it-works, and a per-skill reference.
 ---
 

--- a/docs/docs/release-notes/release-1_2_2.mdx
+++ b/docs/docs/release-notes/release-1_2_2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.2.2
-sidebar_position: 6
+sidebar_position: 7
 description: New managing-schemas rules for production patterns, plus relationship and check-registration fixes.
 ---
 

--- a/docs/docs/release-notes/release-1_2_3.mdx
+++ b/docs/docs/release-notes/release-1_2_3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.2.3
-sidebar_position: 5
+sidebar_position: 6
 description: Every managing-* skill appears again after a fresh install; a frontmatter field had hidden six of them.
 ---
 

--- a/docs/docs/release-notes/release-1_2_4.mdx
+++ b/docs/docs/release-notes/release-1_2_4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.2.4
-sidebar_position: 4
+sidebar_position: 5
 description: analyzing-data now answers the question you asked instead of a built-in example when none is passed.
 ---
 

--- a/docs/docs/release-notes/release-1_2_5.mdx
+++ b/docs/docs/release-notes/release-1_2_5.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.2.5
-sidebar_position: 3
+sidebar_position: 4
 description: Report Infrahub bugs and feature requests with the reporting-issues skill, sanitized and routed automatically.
 ---
 

--- a/docs/docs/release-notes/release-1_2_6.mdx
+++ b/docs/docs/release-notes/release-1_2_6.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.2.6
-sidebar_position: 2
+sidebar_position: 3
 description: A diagnostics skill, CoreFileObject schema support, and a branch-first default for every data change.
 ---
 

--- a/docs/docs/release-notes/release-1_2_7.mdx
+++ b/docs/docs/release-notes/release-1_2_7.mdx
@@ -1,6 +1,6 @@
 ---
 title: Release 1.2.7
-sidebar_position: 1
+sidebar_position: 2
 description: A CSV/TSV import skill, Profiles and Object Templates support, YAGNI audit rules, and diagnostics collection built on the infrahub-collect tool.
 ---
 

--- a/docs/docs/release-notes/release-1_2_8.mdx
+++ b/docs/docs/release-notes/release-1_2_8.mdx
@@ -27,7 +27,7 @@ description: Four new skills — NetBox device-type conversion, concept tutoring
 
 ## Release summary
 
-After upgrading, you can convert NetBox device-type definitions into Infrahub object templates, learn Infrahub concepts through your own repository and instance, triage a diagnostic bundle before escalating it, and report a skill's own missing guidance as a reviewed issue. The schema, check, transform, and generator guidance also changed: what a declaration on a generic imposes on every inheriting kind is now stated explicitly, and every `infrahubctl` command the skills print has been checked against the CLI.
+After upgrading, you can convert NetBox device-type definitions into Infrahub Object Templates, learn Infrahub concepts through your own repository and instance, triage a diagnostic bundle before escalating it, and report a skill's own missing guidance as a reviewed issue. The schema, check, transform, and generator guidance also changed: what a declaration on a generic imposes on every inheriting kind is now stated explicitly, and every `infrahubctl` command the skills print has been checked against the CLI.
 
 :::note What to expect after upgrading
 
@@ -39,9 +39,9 @@ See [Upgrade notes](#upgrade-notes) for full details.
 
 :::
 
-### Convert NetBox device-type definitions into Infrahub object templates
+### Convert NetBox device-type definitions into Infrahub Object Templates
 
-Turn NetBox device-type and module-type files — the [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) format — into Infrahub object templates with the new converting-netbox-device-types skill. A bundled Python converter reads a mapping profile describing your target schema and writes manufacturers, device types, module types, and component templates as object YAML, alongside a coverage report naming everything it could not map ([#80](https://github.com/opsmill/infrahub-skills/pull/80)).
+Turn NetBox device-type and module-type files — the [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) format — into Infrahub Object Templates with the new [converting-netbox-device-types](../skills-reference/converting-netbox-device-types.mdx) skill. A bundled Python converter reads a mapping profile describing your target schema and writes manufacturers, device types, module types, and component templates as object YAML, alongside a coverage report naming everything it could not map ([#80](https://github.com/opsmill/infrahub-skills/pull/80)).
 
 * Convert a single file, a folder, or a mixed tree of device types and module types in one pass. The two families are told apart by `slug`, which every device type carries and no module type does, so a mixed tree does not have to be split up first. Output files are numbered `01_manufacturers` through `05_module_templates` so `infrahubctl object load` runs them in dependency order.
 * Point the converter at your own schema with a mapping profile rather than editing the script. Every Infrahub kind, attribute, and relationship name is read from a YAML profile, so a custom schema needs a new profile instead of a forked converter. Three profiles ship: `schema-library.yml`, `schema-library-modules.yml`, and an annotated `_template.yml`.
@@ -59,7 +59,7 @@ Work through Infrahub concepts — foundations, schema, objects, GraphQL, branch
 
 ### Triage a diagnostic bundle before escalating it
 
-Read a bundle collected by [collecting-diagnostics](../skills-reference/collecting-diagnostics.mdx) yourself with the new analyzing-diagnostics skill. It reads the manifest first, sweeps every service's logs for tracebacks, ERROR and CRITICAL lines, OOM kills, and `*.previous.log` restart evidence, then reports correlated incidents with root causes separated from cascades rather than a flat list of errors ([#76](https://github.com/opsmill/infrahub-skills/pull/76)).
+Read a bundle collected by [collecting-diagnostics](../skills-reference/collecting-diagnostics.mdx) yourself with the new [analyzing-diagnostics](../skills-reference/analyzing-diagnostics.mdx) skill. It reads the manifest first, sweeps every service's logs for tracebacks, ERROR and CRITICAL lines, OOM kills, and `*.previous.log` restart evidence, then reports correlated incidents with root causes separated from cascades rather than a flat list of errors ([#76](https://github.com/opsmill/infrahub-skills/pull/76)).
 
 * Find out whether your crash is already known, and possibly already fixed, before anyone files an issue or waits on support. Findings are matched against existing `opsmill/infrahub` issues using stable search keys — exception class plus normalized message — with volatile tokens such as branch names, UUIDs, and hostnames stripped so a known issue actually matches. A match then resolves against the version the bundle reports running: a newer fix version means upgrade, and already running the fix means an unconfirmed match or a possible regression.
 * Read every finding against evidence you can check. Each claim cites a bundle path with a quoted excerpt, the report opens with the deployment context — running version, topology, replica counts — and what the bundle cannot answer is reported as an open question mapped to the `infrahub-collect create` flags a next bundle would need.

--- a/docs/docs/release-notes/release-1_2_8.mdx
+++ b/docs/docs/release-notes/release-1_2_8.mdx
@@ -1,0 +1,207 @@
+---
+title: Release 1.2.8
+sidebar_position: 1
+description: Four new skills — NetBox device-type conversion, concept tutoring, diagnostic-bundle triage, and skill-gap reporting — plus verified generic and cardinality semantics and a corrected infrahubctl command surface.
+---
+
+<table>
+  <tbody>
+    <tr>
+      <th>Release Number</th>
+      <td>1.2.8</td>
+    </tr>
+    <tr>
+      <th>Release Type</th>
+      <td>Feature</td>
+    </tr>
+    <tr>
+      <th>Release Date</th>
+      <td>September 10th, 2026</td>
+    </tr>
+    <tr>
+      <th>Tag</th>
+      <td>[v1.2.8](https://github.com/opsmill/infrahub-skills/releases/tag/v1.2.8)</td>
+    </tr>
+  </tbody>
+</table>
+
+## Release summary
+
+After upgrading, you can convert NetBox device-type definitions into Infrahub object templates, learn Infrahub concepts through your own repository and instance, triage a diagnostic bundle before escalating it, and report a skill's own missing guidance as a reviewed issue. The schema, check, transform, and generator guidance also changed: what a declaration on a generic imposes on every inheriting kind is now stated explicitly, and every `infrahubctl` command the skills print has been checked against the CLI.
+
+:::note What to expect after upgrading
+
+Most of what changed is what the skills know rather than how you invoke them, so existing schema, object, check, transform, and generator work continues unchanged. One item needs an edit on your side.
+
+- Refresh any vendored copy of these skills; a stale copy may still print `infrahubctl` commands that do not exist.
+
+See [Upgrade notes](#upgrade-notes) for full details.
+
+:::
+
+### Convert NetBox device-type definitions into Infrahub object templates
+
+Turn NetBox device-type and module-type files — the [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) format — into Infrahub object templates with the new converting-netbox-device-types skill. A bundled Python converter reads a mapping profile describing your target schema and writes manufacturers, device types, module types, and component templates as object YAML, alongside a coverage report naming everything it could not map ([#80](https://github.com/opsmill/infrahub-skills/pull/80)).
+
+* Convert a single file, a folder, or a mixed tree of device types and module types in one pass. The two families are told apart by `slug`, which every device type carries and no module type does, so a mixed tree does not have to be split up first. Output files are numbered `01_manufacturers` through `05_module_templates` so `infrahubctl object load` runs them in dependency order.
+* Point the converter at your own schema with a mapping profile rather than editing the script. Every Infrahub kind, attribute, and relationship name is read from a YAML profile, so a custom schema needs a new profile instead of a forked converter. Three profiles ship: `schema-library.yml`, `schema-library-modules.yml`, and an annotated `_template.yml`.
+* Read the Markdown coverage report before loading anything. Anything the profile cannot map is skipped and named rather than dropped silently, and against the stock `schema-library.yml` profile no published device type converts losslessly, because schema-library models no equivalent node for most NetBox component lists. Turn each report line into a schema change with the worked YAML in `extending-your-schema.md` — the skill offers the change rather than making it, since enabling `generate_template` is a migration against your source of truth.
+* Create the real interfaces behind a `{module}` token with the bundled module-port generator. The token cannot be resolved at conversion time, so a template carries it and the generator resolves it per installed module after the templates are loaded.
+
+### Learn Infrahub concepts through your own repository and instance
+
+Work through Infrahub concepts — foundations, schema, objects, GraphQL, branches, repository integration, proposed changes, checks, transforms, generators, and menus — with the new [teaching-concepts](../skills-reference/teaching-concepts.mdx) skill. It asks what you already know before it explains anything, and teaches from your own repository files and read-only instance queries rather than from generic examples ([#118](https://github.com/opsmill/infrahub-skills/pull/118)).
+
+* Resume a session instead of restarting it. Progress, lessons, and exercises are recorded in a `.infrahub-learning/` workspace, and each lesson is written to `lessons/<concept>.md` in a fixed Probe, Explain, Exercise, Check shape that doubles as the durable learning record.
+* Follow a dependency-ordered map of eleven concepts. Each carries its own probe questions, exercise specification, verification method, documentation anchors, and a graduation pointer to the skill that does the same work for real.
+* Attempt an exercise knowing it is solvable. The reference solution is written and verified — through offline schema validation, a read-only query, or an `infrahubctl` run — before the exercise is shown, and a hint ladder runs before any solution is revealed.
+* Keep your instance safe while learning. Read-only access is the default, authoring exercises are done in local files, and instance writes need an explicit opt-in, run only in a `learning-*` branch, are never merged, and are always deleted. Nothing writes to the default branch.
+
+### Triage a diagnostic bundle before escalating it
+
+Read a bundle collected by [collecting-diagnostics](../skills-reference/collecting-diagnostics.mdx) yourself with the new analyzing-diagnostics skill. It reads the manifest first, sweeps every service's logs for tracebacks, ERROR and CRITICAL lines, OOM kills, and `*.previous.log` restart evidence, then reports correlated incidents with root causes separated from cascades rather than a flat list of errors ([#76](https://github.com/opsmill/infrahub-skills/pull/76)).
+
+* Find out whether your crash is already known, and possibly already fixed, before anyone files an issue or waits on support. Findings are matched against existing `opsmill/infrahub` issues using stable search keys — exception class plus normalized message — with volatile tokens such as branch names, UUIDs, and hostnames stripped so a known issue actually matches. A match then resolves against the version the bundle reports running: a newer fix version means upgrade, and already running the fix means an unconfirmed match or a possible regression.
+* Read every finding against evidence you can check. Each claim cites a bundle path with a quoted excerpt, the report opens with the deployment context — running version, topology, replica counts — and what the bundle cannot answer is reported as an open question mapped to the `infrahub-collect create` flags a next bundle would need.
+* Search targeted failure patterns instead of generic ones. A known-failure-patterns reference covers Prefect background services disabled by edited Helm values, lock deadlocks after crashed merges, stale RUNNING tasks, and storage-persistence and multi-replica shared-storage misconfigurations, each mapped to where its evidence sits in the bundle.
+* Keep the analysis read-only toward your deployment. It never files anything: filing hands off to reporting-issues, a second collection hands back to collecting-diagnostics, and both diagnostics skills now frame `--include-backup` as a last resort, with a caution about restored backups carrying live git repository connections.
+
+### Report a skill's missing or wrong guidance as a reviewed issue
+
+When an Infrahub skill's guidance is missing or wrong, the failure is quiet — extra requests and repeated corrections, never a crash. Diagnose it with the new [reporting-skill-gaps](../skills-reference/reporting-skill-gaps.mdx) skill, which works out which rule file is at fault and what it should say instead, then hands the draft to [reporting-issues](../skills-reference/reporting-issues.mdx) for everything GitHub-facing ([#83](https://github.com/opsmill/infrahub-skills/pull/83), [#119](https://github.com/opsmill/infrahub-skills/pull/119)).
+
+* Rest a report on evidence rather than an impression. Four probes run strongest first: a verifier that failed and later passed, a coverage read of the skill's `rules/` naming the file or its absence, the difference between the rejected and the accepted artifact, and retry counts. A draft resting only on retry counters is refused, and the refusal names the probe that came up empty.
+* See the report classified before it is filed. A case a rule covers where the guidance still produced the wrong answer is a bug; a case no rule covers where the documentation supplied the answer is a feature request; a case no rule covers where the documentation did not is a documentation gap. The discriminator is what happened after the escape to documentation, not whether documentation existed.
+* Read which revision of the guidance failed from the report header, which records the skills-plugin version alongside the Infrahub SDK and Infrahub versions. All three come from one `infrahubctl info` call, and `unknown` and `n/a` are accepted because offline work never reaches a server.
+* Keep diagnosis and filing separate. This skill never files and never names a target repository — reporting-issues resolves that from the report type against the registry it already owns — and the tracker search it ran is passed across, so the search is not repeated and answered differently.
+
+### Know what a generic imposes on every kind that inherits it
+
+Declaring something on a generic behaves differently from declaring it on a kind, and until now [managing-schemas](../skills-reference/managing-schemas.mdx) described the syntax without the semantics. Model with generics knowing what each declaration imposes on every inheriting kind: every rule below quotes the load-time error its violation produces, proven against Infrahub's in-memory schema validator rather than inferred from reading code ([#85](https://github.com/opsmill/infrahub-skills/pull/85), [#111](https://github.com/opsmill/infrahub-skills/pull/111), [#112](https://github.com/opsmill/infrahub-skills/pull/112), [#113](https://github.com/opsmill/infrahub-skills/pull/113)).
+
+* Scope a `uniqueness_constraints` entry before you declare it. A constraint on a generic is enforced across every kind that inherits it, and a concrete kind cannot narrow what it inherits — declaring its own constraints only adds a kind-scoped check while the generic's still runs. That decides a migration: on the generic, old and new instances collide and deletion becomes an ordering precondition; on the concrete kinds they coexist and the migration stays reversible.
+* Meet the three preconditions a relationship named in a `uniqueness_constraints` entry has to satisfy — `optional: false`, `cardinality: one`, and the bare relationship name with no peer-attribute path — each with its verbatim error string and a loadable example. A `human_friendly_id` is compiled into a uniqueness constraint too, so an optional relationship reached by an HFID path fails schema load with a `uniqueness_constraints:` error that names a field you never wrote.
+* Override a `Dropdown` attribute on an implementer without widening it by accident. A shorter `choices` list loads cleanly, and so does a longer one carrying an invented choice, so a concrete kind can hold a value the generic says is impossible and a query over the generic can return it. Guard it with a test comparing each restated list against the generic's, or with `allow_override: none` on the generic's attribute, which rejects any override and trades away per-kind defaults.
+* Treat a generic's implementer set as an interface its consumers already read. A brand-new kind inheriting a generic produces no migration and no constraint validation, so every offline gate stays green while queries, groups, menus, and constraints declared on the generic include the new kind. An offline test over the schema YAML asserting the expected implementer set is the gate a contributor can break, and it runs in under a second.
+* Order results within what a generic can resolve. `order_by` on a generic resolves against that generic's own declarations only, and `node_metadata__created_at` and `node_metadata__updated_at` stay valid even on a generic that declares no attributes at all. The error may name an implementer rather than the generic, because the value is copied down to every kind that declares none of its own — so when a kind whose file contains no `order_by` is named, look at its generics.
+
+### Change a relationship's cardinality without breaking the queries that read it
+
+Setting `cardinality: one`, hitting a write-time failure on the second object, and widening the relationship is a common sequence, and its second half breaks every stored query that selects that relationship. Both halves are now documented across the schema and query rules, read from Infrahub v1.10.8 source with every schema outcome reproduced by running that checkout's validator ([#114](https://github.com/opsmill/infrahub-skills/pull/114)).
+
+* Widen the side that actually holds the cap. Your own `cardinality: one` limits what you hold; how many objects may point at a peer is set by that peer's reciprocal declaration on the same identifier, and where the peer declares nothing there is no inbound cap at all. Widening only your own side loads cleanly and leaves the write-time failure exactly where it was.
+* Rewrite the query the change invalidates. `one` generates `NestedEdged<Kind>`, selected as `{ node { … } }`; `many` generates `NestedPaginated<Kind>`, selected as `{ edges { node { … } } }` with `count`. Widening leaves a stored query selecting `{ node … }` against a now-paginated field, which returns `Cannot query field 'node' on type 'NestedPaginated<Kind>'` — and that type name appears in no schema file, `.gql` file, or documentation page, so the error is hard to connect to the cardinality edit that caused it.
+* Express a genuine cap of one with `cardinality: one`. `max_count: 1` on a cardinality-many relationship is rejected outright. A hierarchical kind is the exception to all of this: its generated fields ignore what you declared, with `parent` always node-shaped and `children`, `ancestors`, and `descendants` always edges-shaped.
+
+### Reuse a schema the marketplace already publishes
+
+Check whether the Infrahub marketplace already publishes a domain before modelling it. A workflow step in managing-schemas checks the catalog first, a shared reference in `infrahub-common` gives every skill the same view of it, and an audit rule in [auditing-repo](../skills-reference/auditing-repo.mdx) flags a whole domain hand-rolled from scratch when the marketplace publishes it ([#69](https://github.com/opsmill/infrahub-skills/pull/69), [#113](https://github.com/opsmill/infrahub-skills/pull/113)).
+
+* Search the whole catalog for any domain with `infrahubctl marketplace list`, `search`, and `show`, and fetch with `infrahubctl marketplace get`, including collections with `-c`. The catalog API covers the discovery the CLI does not expose, and `--marketplace-url` points at an internal mirror; reachability never blocks schema work, since the guidance falls back to a custom schema built on built-in primitives.
+* Tell the three kinds of availability apart before building on one. Platform core kinds (`Core*`, `Builtin*`, `Ipam*`) exist on a clean instance; marketplace-published kinds do not, and become a dependency your repository carries, loads first, and records a version for; locally defined kinds are yours. Check with `infrahubctl schema list` on the cleanest instance you have rather than the development machine that has accumulated whatever was loaded during experiments — a kind appearing in an example is evidence of a sensible shape, not evidence it exists on your instance.
+* Evaluate a published file per generic rather than per file. The cost of a candidate is its transitive peer set, so a sibling with expensive peers is no reason to reject a cheap candidate in the same file, and rejecting per file is how a published shape gets reinvented. Taking a subset also loses the `marketplace get` update path, so the rule prefers the whole file when the cost is comparable, and asks for a provenance comment recording the identifier, the version, what was taken, and why the rest was excluded. Before adopting a generic from a published file, read what its implementer set imposes on you in [Know what a generic imposes on every kind that inherits it](#know-what-a-generic-imposes-on-every-kind-that-inherits-it).
+
+### Write checks, transforms, and generators against verified behavior
+
+Field reports kept describing one class of problem: a mechanism described correctly in one place and contradicted everywhere an example appeared. The checks, transforms, and generators skills now carry the behavior each pattern depends on, verified against Infrahub source, the SDK, and the runtime image ([#81](https://github.com/opsmill/infrahub-skills/pull/81), [#89](https://github.com/opsmill/infrahub-skills/pull/89), [#115](https://github.com/opsmill/infrahub-skills/pull/115), [#116](https://github.com/opsmill/infrahub-skills/pull/116), [#117](https://github.com/opsmill/infrahub-skills/pull/117)).
+
+* Declare a `watch` block on every `python_transforms` and `generator_definitions` entry, including `files: []` when there is nothing beyond the entry point. Infrahub never scans the imports, so with no key it folds the commit id into the definition's fingerprint and the definition re-renders or re-runs on every commit; a present key is your assertion that the list is complete. `jinja2_transforms` are the exception, because their closure comes from parsing the template. No `watch` is noisy but safe, and a wrong `watch` is silent — declaring anything switches off the conservative fallback, and an incomplete list then under-regenerates with no error anywhere.
+* Validate a node against a related node's state in a [check](../skills-reference/managing-checks.mdx) by traversing the relationship in the query itself. A check runs its query once and `validate()` receives that single payload with no lazy fetch, so a query selecting only the child has no parent state left to test. The rule covers unwrapping each hop null-safely, surfacing an unresolvable related node as a violation rather than a silent skip, and exempting the root of a containment chain, which has no parent.
+* Read GraphQL failures from the response body, not the status code. The server hard-codes `status_code=200` on every response whose document executed and puts constraint violations, unknown fields, and permission denials in the body's `errors` array. `self.client.execute_graphql` raises `GraphQLError` on those, so a check using the SDK client is not exposed; the trap is raw `httpx` against `/graphql` branching on the status code. Test the failing path — a check that fails open cannot be told apart from a passing check by observation.
+* Constrain a path traversal in a [generator](../skills-reference/managing-generators.mdx) with `relationship_filter`, which takes schema relationship identifiers such as `device__interface` rather than the per-side names that appear in the result. `kind_filter` is a whitelist of node kinds and still lets a shared catalog node of an allowed kind bridge unrelated subgraphs; `included_kinds` re-includes kinds excluded by default and is not a whitelist. Check `truncated_at_depth` in the result, since a non-null value means the search ran out of budget and the answer is incomplete, and note that `shortest_paths_only` defaults to `true` and drops longer routes through the same intermediate objects.
+* Write a group membership from the side whose peer can be resolved by name. `CoreGroup.members` peers `CoreNode`, which has no attributes, no `default_filter`, and no `human_friendly_id`, so a member name has nothing to resolve against; `member_of_groups` peers `CoreGroup`, which does have `default_filter: name__value`. The general rule: a relationship whose peer is a bare generic cannot be resolved by name in object data. A generator's target group must also exist and be non-empty, because an existing but empty group dispatches nothing and reports no error.
+* Emit a non-text artifact from a [transform](../skills-reference/managing-transforms.mdx). A complete `image/svg+xml` example now sits alongside the content-type table — query, transform, `python_transforms` registration, `artifact_definitions` entry with its target group, and the `CoreArtifactTarget` requirement — and the serialization rule is stated as a matrix rather than a return-type column: only `application/json` and `application/yaml` special-case a returned dict, so returning a dict for `text/csv` or `image/svg+xml` writes a Python repr into the artifact body with no error and no warning. Returning nothing is the one case that fails loudly.
+
+### Audit a repository without changing your working tree
+
+An audit is most useful on a tree holding uncommitted work, which is exactly the tree where a write cannot be undone. Run an audit with auditing-repo and it now reads without writing: a CRITICAL conduct rule constrains the auditor rather than the repository, and Phase 0 of the audit procedure states it before the first check runs ([#109](https://github.com/opsmill/infrahub-skills/pull/109)).
+
+* Get your uncommitted work back unchanged. In a reported failure, an audit had stashed the tree, run a generator with `--check`, popped the stash, and then run `git checkout -- objects/`, destroying another agent's regenerated files while reporting its findings correctly and never mentioning that it had modified anything. The rule names cleanup itself as the hazard, including cleanup that undoes the auditor's own side effect.
+* Read the audit's own account of what it did. The report format now carries the tree's condition at audit time and whether the audit modified it, and an honest "check not performed" finding is available for a check that cannot be run without a write — the compliance checks read the list of commands the audit ran rather than its prose, so disclosing what you did not run counts as compliance.
+* Compare against committed state with read-only git: `git show <ref>:<path>`, `git diff <ref> -- <path>`, `git cat-file`, and `git ls-tree` answer every "what does this look like as committed?" question without touching the tree.
+* See where a bare-string `kind` could be a typed protocol class. A new LOW-severity rule at step 7 of the cost-to-fix ladder flags non-trivial schema-coupled Python that passes `client.create` or `client.get` a `kind="Foo"` string, or hand-builds dict payloads, when a generated protocol class exists for that kind. Generate the classes with `infrahubctl protocols`, and a schema change becomes a type error on the exact line instead of a runtime failure in the pipeline. The rule carries its own limits: protocols type attributes, not relationship peers, and trivial one-off scripts are not flagged. It sits at the far end of the same cost-to-fix ladder whose first step is [Reuse a schema the marketplace already publishes](#reuse-a-schema-the-marketplace-already-publishes) ([#79](https://github.com/opsmill/infrahub-skills/pull/79)).
+
+## Bug fixes
+
+* Every `infrahubctl` command the skills print is now a real one. A sweep found 11 invalid invocations — `schema validate`, `check run <name>`, `transform run <name>`, `generator run <name>`, `generator list`, and `import load` — of which only two had been reported. The offline gate is `infrahubctl schema format --check`, now documented in managing-schemas ([#74](https://github.com/opsmill/infrahub-skills/pull/74)), and the server-side check is `infrahubctl schema check`. `check`, `generator`, and `transform` take their target as a positional argument, so `check run mycheck` had looked for a check literally named `run`, and there is no `import` or `export` command group, since the LDJSON tools are the top-level `load` and `dump`. Every form was verified against `infrahub-sdk` 1.23.1, and a continuous-integration check now gates every invocation the repository prints, including the ones in graders and eval rubrics ([#110](https://github.com/opsmill/infrahub-skills/pull/110)).
+* `infrahubctl render` cannot serve a Python transform, and the message it returns for one — *"Unable to find \<name\> in repository config file"* — reads like an unregistered transform rather than the wrong command, so a reader concludes the dry-run gate is unavailable and skips it. `render` resolves Jinja2 transforms and `transform` resolves Python ones; the rule now gives both and says which serves which section, plus the two details that each cost a failed run: a required query variable must be typed manually when run locally, because the artifact definition binds it from the target in the pipeline, and neither command reaches a check or a generator ([#110](https://github.com/opsmill/infrahub-skills/pull/110)).
+* `infrahubctl info` reports a green status with no token, because the user lookup is skipped entirely when neither a token nor a username is set while the server information call succeeds anonymously. A green result therefore does not prove write authorization. The connectivity rule now carries that three-way asymmetry and gives a create-and-delete branch write probe rather than a branch listing, which is a read ([#110](https://github.com/opsmill/infrahub-skills/pull/110)).
+* The `infrahubctl --version` flag does not exist and errors with "No such option". `infrahubctl info` prints `SDK Version` and `Infrahub Version` together. Three places were wrong, including the shared connectivity rule every skill inherits, which showed output labels that appear nowhere in the real output — so grepping for them found nothing ([#119](https://github.com/opsmill/infrahub-skills/pull/119)).
+* Retrofitting or changing a relationship `identifier` on a relationship that already exists in an instance produces `'not_supported': <Kind> <rel> None` from `infrahubctl schema check`, and nothing explained it. It is a schema-update immutability error, not an invalid `kind`/`cardinality` pairing: `identifier`, `direction`, `branch`, and `hierarchical` are the relationship fields that cannot be updated, while `kind`, `cardinality`, and `optional` can. Any `kind`/`cardinality` pairing is valid given a shared identifier and a fresh kind. Both the error and its fix are now in the relationship rules and the common-errors lookup table ([#75](https://github.com/opsmill/infrahub-skills/pull/75)).
+
+## Minor changes
+
+**Developer experience**
+
+* `AGENTS.md` links the `dev/` guides instead of `@`-importing them, so each guide loads only when a task needs it; always-loaded project memory drops from about 50 KB to about 4.5 KB per session ([#77](https://github.com/opsmill/infrahub-skills/pull/77)).
+* `eval.yaml` loads in `skillgrade` again. Seven grader-less `csv-import-*` tasks had failed configuration validation before any task could run, which blocked all of them for every skill ([#126](https://github.com/opsmill/infrahub-skills/pull/126)).
+
+## Upgrade notes
+
+### Vendored copies of the skills
+
+If: you copied these skills into a repository rather than installing the plugin.
+
+Then: refresh the copy. The invalid command forms corrected here — among them `infrahubctl protocols generate --async`, which is really `infrahubctl protocols` — had already propagated into vendored copies, so a stale copy keeps printing commands that do not exist.
+
+Notes: no action is needed if you install the plugin.
+
+## Full changelog
+
+### Added
+
+* `infrahub-converting-netbox-device-types` skill, with a bundled converter, three mapping profiles, and a module-port generator ([#80](https://github.com/opsmill/infrahub-skills/pull/80)).
+* `infrahub-teaching-concepts` skill: twelve tutor rules, a dependency-ordered concept map, and a lesson protocol ([#118](https://github.com/opsmill/infrahub-skills/pull/118)).
+* `infrahub-analyzing-diagnostics` skill for diagnostic-bundle triage ([#76](https://github.com/opsmill/infrahub-skills/pull/76)).
+* `infrahub-reporting-skill-gaps` skill, filing through `infrahub-reporting-issues` ([#83](https://github.com/opsmill/infrahub-skills/pull/83)).
+* Marketplace visibility across the schema, objects, generators, and audit skills, plus the `yagni-reuse-existing-marketplace-schema` audit rule ([#69](https://github.com/opsmill/infrahub-skills/pull/69)).
+* `yagni-untyped-python-vs-generated-protocols` audit rule and generated-protocol adoption guidance ([#79](https://github.com/opsmill/infrahub-skills/pull/79)).
+* `watch` dependency declarations in `infrahub-common`, managing-transforms, and managing-generators ([#89](https://github.com/opsmill/infrahub-skills/pull/89)).
+* Read-only audit conduct rule and Phase 0 of the audit procedure ([#109](https://github.com/opsmill/infrahub-skills/pull/109)).
+* `uniqueness_constraints` semantics, including inheritance scope, the null-collision case, and the relationship preconditions ([#111](https://github.com/opsmill/infrahub-skills/pull/111), [#85](https://github.com/opsmill/infrahub-skills/pull/85)).
+* Generic inheritance rules for `order_by` scope, `Dropdown` overrides, and relationship peer kinds ([#112](https://github.com/opsmill/infrahub-skills/pull/112)).
+* Schema reuse rules and the generic-membership interface rule ([#113](https://github.com/opsmill/infrahub-skills/pull/113)).
+* Cardinality consequences across the schema and GraphQL query rules ([#114](https://github.com/opsmill/infrahub-skills/pull/114)).
+* `image/svg+xml` artifact example and the artifact serialization matrix ([#115](https://github.com/opsmill/infrahub-skills/pull/115)).
+* GraphQL error-surface and shared-module rules for managing-checks ([#116](https://github.com/opsmill/infrahub-skills/pull/116)).
+* Relationship-traversal validation rule for managing-checks ([#81](https://github.com/opsmill/infrahub-skills/pull/81)).
+* Path traversal, group membership, and shared-object ownership rules for managing-generators ([#117](https://github.com/opsmill/infrahub-skills/pull/117)).
+* `infrahubctl schema format` documented in managing-schemas ([#74](https://github.com/opsmill/infrahub-skills/pull/74)).
+* Infrahub SDK and Infrahub versions in the skill-gap report header ([#119](https://github.com/opsmill/infrahub-skills/pull/119)).
+* `python-lint` job with a pinned ruff rule set ([#128](https://github.com/opsmill/infrahub-skills/pull/128)).
+* Python test suite in continuous integration ([#80](https://github.com/opsmill/infrahub-skills/pull/80)).
+
+### Changed
+
+* `AGENTS.md` links the `dev/` guides instead of `@`-importing them ([#77](https://github.com/opsmill/infrahub-skills/pull/77)).
+* Review lessons from pull requests #85 through #117 routed into the `dev/` guides ([#120](https://github.com/opsmill/infrahub-skills/pull/120)).
+* Evidence discovery in reporting-skill-gaps made assistant-agnostic, and the docs-site listing extended to the Issue Reporter and Skill Gap Reporter ([#119](https://github.com/opsmill/infrahub-skills/pull/119)).
+
+### Fixed
+
+* 11 invalid `infrahubctl` invocations, with a continuous-integration gate on every printed invocation ([#110](https://github.com/opsmill/infrahub-skills/pull/110)).
+* `infrahubctl --version` references replaced with `infrahubctl info` ([#119](https://github.com/opsmill/infrahub-skills/pull/119)).
+* Shared-identifier relationship rules and the `not_supported` schema-check error explained ([#75](https://github.com/opsmill/infrahub-skills/pull/75)).
+* Seven grader-less eval tasks that stopped `skillgrade` loading `eval.yaml` ([#126](https://github.com/opsmill/infrahub-skills/pull/126)).
+* 14 ruff findings on `main` ([#128](https://github.com/opsmill/infrahub-skills/pull/128)).
+* A fenced-block marker in an eval prompt that desynchronized the CLI invocation sweep ([#130](https://github.com/opsmill/infrahub-skills/pull/130)).
+* `uv.lock` synced to the project version, removing a stray diff from unrelated pull requests ([#121](https://github.com/opsmill/infrahub-skills/pull/121)).
+* direnv files ignored ([#82](https://github.com/opsmill/infrahub-skills/pull/82)).
+
+## Skills included
+
+* infrahub-managing-schemas
+* infrahub-managing-objects
+* infrahub-managing-checks
+* infrahub-managing-generators
+* infrahub-managing-transforms
+* infrahub-managing-menus
+* infrahub-auditing-repo
+* infrahub-analyzing-data
+* infrahub-reporting-issues
+* infrahub-reporting-skill-gaps
+* infrahub-collecting-diagnostics
+* infrahub-analyzing-diagnostics
+* infrahub-importing-data
+* infrahub-teaching-concepts
+* infrahub-converting-netbox-device-types

--- a/docs/docs/skills-reference/analyzing-diagnostics.mdx
+++ b/docs/docs/skills-reference/analyzing-diagnostics.mdx
@@ -1,0 +1,71 @@
+---
+title: Diagnostics Analyzer
+sidebar_position: 14
+---
+
+The Diagnostics Analyzer reads a bundle the [Diagnostics Collector](./collecting-diagnostics.mdx) already produced and turns its logs into a triage report. It reads the manifest before any log, sweeps every service for tracebacks and other error signals, correlates related errors into incidents with root causes separated from cascades, and searches existing `opsmill/infrahub` issues so you learn whether your crash is already known — without touching the running deployment, applying a fix, or filing anything on your behalf.
+
+## When to use
+
+- You have a bundle in hand and want to know what it says before involving support
+- Tracebacks in the logs need interpreting
+- Deciding whether a crash is a known Infrahub issue, and whether a newer version already fixes it
+- A container or worker keeps restarting and you need the pre-restart cause
+- A performance symptom, where a `--benchmark` collection needs reading alongside the logs
+
+## What it produces
+
+A findings report grounded in bundle evidence:
+
+- A deployment-context header — running Infrahub version, topology (Docker Compose or Kubernetes), replica counts — because the version is what turns a matched issue into a conclusion rather than a coincidence
+- One section per incident, with severity, the evidence as bundle file paths plus quoted excerpts, and the reasoning that grouped those signals into one incident
+- Matching `opsmill/infrahub` issues with title, state, and URL, searched across open and closed
+- Open questions, including whether the symptom reproduces on demand, each mapped to the `infrahub-collect create` flags a next bundle would need to answer it
+
+## Example prompts
+
+- "I collected a bundle — can you tell me what's wrong?"
+- "Analyze these Infrahub logs"
+- "What do the tracebacks in the bundle mean?"
+- "Is this crash a known Infrahub issue?"
+- "Why did the task-worker keep restarting?"
+
+## Key rules enforced
+
+- **You name the bundle** — the skill asks for the path instead of scanning for one, because a machine often holds several bundles and picking the wrong one produces a confident report about the wrong incident
+- **Manifest before any log** — `bundle_information.json` records what was collected and what failed, and a service whose logs could not be collected is often the service that is down, so collection failures are findings rather than gaps in the evidence
+- **Every service, not just the server** — the sweep covers each directory under `bundle/logs/` for tracebacks, ERROR and CRITICAL lines, panics, OOM kills, and connection failures, and treats any `*.previous.log` as restart evidence whose tail usually holds the crash cause
+- **Incidents, not error lists** — signals are grouped by timestamp and causal chain, so a database OOM followed by server connection errors is reported as one incident with a named root rather than two problems
+- **Stable search keys** — a key is built from the exception class, the normalized message, and the innermost Infrahub frame, with branch names, UUIDs, and hostnames stripped, so a known issue actually matches
+- **Both halves of the tracker** — the issue search covers open and closed issues, because a closed match is the one that tells you which version includes the fix
+- **Evidence per finding** — every claim cites a bundle path and a quoted excerpt, and what the bundle cannot answer is stated as an open question rather than left out
+- **Read-only** — the analysis reads an already-collected bundle and runs issue searches; it never touches the running instance, restarts nothing, edits no configuration, and creates no issue
+
+## Diagnostics Collector vs. Diagnostics Analyzer
+
+| Use the Diagnostics Collector when... | Use the Diagnostics Analyzer when... |
+| --------------------------------------- | -------------------------------------- |
+| Infrahub is misbehaving and no bundle exists yet | A bundle already exists, or you have its contents |
+| You need the right `infrahub-collect` command for your symptom | You need to know what the collected logs actually say |
+| Output is a support bundle on disk | Output is a findings report citing that bundle |
+| The next step is sharing it with OpsMill | The next step is an upgrade, a comment on an existing issue, or a new report |
+
+## Common mistakes it catches
+
+| Mistake | What the skill does instead |
+| --------- | --------------------------- |
+| Reading only the server's logs | Sweeps every service directory under `bundle/logs/` |
+| Treating a log that could not be collected as a gap in the bundle | Reports it as a finding — that service is often the one that failed |
+| Reporting every error line as its own problem | Correlates signals into incidents and names the root |
+| Searching a traceback verbatim | Strips branch names, UUIDs, and hostnames first, so the search matches |
+| Limiting the issue search to open issues | Searches open and closed, since a closed match names the fixing version |
+| Restarting a container to test a theory | Recommends it in the report and applies nothing |
+| Filing the bug from here | Hands off to the [Issue Reporter](./reporting-issues.mdx) |
+
+:::tip
+Benchmark data exists only if the bundle was created with `infrahub-collect create --benchmark`. For a performance symptom without it, the report asks for a new bundle created with that flag rather than guessing from logs alone — the single-CPU score and the storage IOPS of the Neo4j and PostgreSQL volumes are often what decide whether the cause is software or an undersized host.
+:::
+
+:::note
+No bundle yet? Start with the [Diagnostics Collector](./collecting-diagnostics.mdx). This skill will not scrape `docker compose logs` or `kubectl logs` as a substitute, because a hand-scraped set of logs misses the replica coverage, the previous-container logs, and the manifest that the analysis depends on.
+:::

--- a/docs/docs/skills-reference/converting-netbox-device-types.mdx
+++ b/docs/docs/skills-reference/converting-netbox-device-types.mdx
@@ -1,0 +1,91 @@
+---
+title: NetBox Device Type Converter
+sidebar_position: 15
+---
+
+The NetBox Device Type Converter turns NetBox device-type and module-type YAML into Infrahub Object Templates, so you create a device with its ports already in place from one reusable definition. The input format is [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library), which you can browse at the [NetBox Data Exchange](https://netboxlabs.com/ndx/). A bundled Python script does the conversion, driven by a mapping profile that describes your target schema. Point it at the right schema and read what it reports back — without editing your schema for you or guessing a field name the profile does not define.
+
+## When to use
+
+- Seeding a new Infrahub instance with vendor device models from the NetBox library
+- Converting a handful of device types for a specific project or lab topology
+- Re-running a conversion after the upstream library or your local schema changed
+- Building the mapping profile that binds NetBox fields to a custom Infrahub schema
+
+Not for syncing a **live** NetBox instance into Infrahub — that is [infrahub-sync](https://docs.infrahub.app/sync/), a separate product. This skill converts the static YAML definitions.
+
+## What it produces
+
+One NetBox file becomes several Infrahub artifacts, because Infrahub splits what NetBox keeps together:
+
+| NetBox | Infrahub | Why |
+| -------- | ---------- | ----- |
+| `manufacturer: Cisco` | `OrganizationManufacturer` object | Manufacturers are first-class objects |
+| `model`, `part_number`, `u_height`, `weight` | `DcimDeviceType` object | Templates hold no model data |
+| `interfaces:` and other component lists | `TemplateDcimDevice` plus component templates | The reusable blueprint |
+| `module-types/*.yaml` | `DcimModuleType` object, optionally a module template | A second input family, told apart by the absence of a `slug` |
+
+The files are numbered in dependency order, so loading them in sequence satisfies each file's references:
+
+- `01_manufacturers.yml`
+- `02_device_types.yml`
+- `03_device_templates.yml`
+- `04_module_types.yml`
+- `05_module_templates.yml`
+
+Empty files are not written, so a device-types-only run produces just the first three.
+
+A Markdown coverage report names everything the profile could not map. It is written to the `--report` path, which is resolved on its own rather than inside the output directory, and defaults to `coverage-report.md` in the current directory.
+
+## Example prompts
+
+- "Convert these Cisco device types into Infrahub object templates"
+- "Seed my instance with device models from the NetBox devicetype-library"
+- "Build a mapping profile for my custom DCIM schema"
+- "Re-run the device-type conversion — we upgraded schema-library"
+- "Convert the module types too, including the line cards"
+
+## Key rules enforced
+
+- **`generate_template: true` comes first** — `Template*` kinds exist only where a node declares it, so the skill checks the target schema rather than assuming either way; this is the most common reason a conversion loads nothing
+- **Names come from the profile, never guessed** — every Infrahub kind, attribute, and relationship name is read from a YAML mapping profile, so a custom schema needs a new profile rather than a forked script
+- **Competing fields declare precedence** — NetBox defines more free-text fields than most schemas have room for, so the profile names which field falls back to which; the loser is reported as shadowed, and an undeclared collision is refused rather than letting mapping order decide it silently
+- **Shared relationships accumulate** — where two NetBox component lists map to the same Infrahub relationship, both are kept; assigning rather than accumulating would silently erase the first list
+- **Integers only** — Infrahub has no float or decimal attribute kind, so every numeric transform emits a whole number
+- **Nothing is dropped silently** — anything the profile cannot map is skipped and named in the coverage report, which closes with an explanation of why each gap exists
+- **Template names are slug-based and parent-namespaced** — so names stay unique across the whole library rather than colliding between vendors
+- **The skill offers schema changes; it does not make them** — enabling `generate_template` is a migration against your source of truth, so it is proposed for you to apply
+
+## Running the converter
+
+The skill normally runs the converter for you. To run it by hand, resolve the two `skills/...` paths against wherever your installation put the skill directory. The command below assumes the [manual copy](../installation-setup.mdx), which puts it under your project root; the `npx` installer and the Claude Code plugin place it elsewhere.
+
+```bash
+python skills/infrahub-converting-netbox-device-types/scripts/netbox_to_infrahub_templates.py \
+  devicetype-library/device-types/Cisco/ \
+  --mapping skills/infrahub-converting-netbox-device-types/scripts/mappings/schema-library.yml \
+  --output-dir ./generated \
+  --report ./generated/coverage-report.md
+```
+
+Point it at a single file, a folder, or a mixed tree of device types and module types — the two families are told apart automatically, so a mixed tree converts in one pass. The skill includes three mapping profiles: `schema-library.yml`, `schema-library-modules.yml`, and an annotated `_template.yml` to copy for a custom schema.
+
+## Common mistakes it catches
+
+| Mistake | What the skill does instead |
+| --------- | --------------------------- |
+| Assuming `Template*` kinds already exist | Checks the target schema for `generate_template: true` before converting |
+| Hand-transcribing a 48-port switch | Runs the script, which is exact and repeatable across thousands of device types |
+| Editing the script for a custom schema | Writes a new mapping profile, leaving the script untouched |
+| Reading a clean run as a lossless one | Points you at the coverage report, which names what did not convert |
+| Loading the output files in arbitrary order | Numbers them `01`–`05` in dependency order |
+| Expecting `{module}` port names to resolve | Explains that the bay position is known only once a module is installed |
+| Reaching for this to sync a live NetBox | Sends you to infrahub-sync, which is a different product |
+
+:::warning
+Read the coverage report before loading anything. Against the stock `schema-library.yml` profile most NetBox component lists have no equivalent node, so a report full of unmapped entries is the normal path rather than an error — it is the list of schema changes a lossless conversion would need.
+:::
+
+:::tip
+Module port names contain NetBox's `{module}` token, which no conversion can resolve, because the bay position is known only once a module is installed. Once the schema-library module extensions are loaded, a bundled generator resolves the token per installed module and creates the real device interfaces.
+:::

--- a/docs/docs/skills-reference/reporting-skill-gaps.mdx
+++ b/docs/docs/skills-reference/reporting-skill-gaps.mdx
@@ -14,6 +14,8 @@ The Skill Gap Reporter turns friction with an Infrahub skill into a reviewed Git
 
 Do not use it for a bug in Infrahub itself, the SDK, or any other `opsmill/infrahub-*` product. That belongs to the Issue Reporter. It is also not for ordinary work that finished without friction.
 
+That offer can also arrive on its own. With the [infrahub-speckit](https://github.com/opsmill/infrahub-speckit) extension installed, Spec Kit's `after_implement` hook checks every finished `/speckit.implement` cycle and prints a one-line offer when it finds evidence of a gap; replying routes into this skill. The hook detects, it never drafts or files. See [Skill-gap detection after implement](../spec-driven-development.mdx#skill-gap-detection-after-implement).
+
 ## What it produces
 
 - A named artifact: the rule file that should have prevented the friction, or a plain statement that no rule covers the topic

--- a/docs/docs/spec-driven-development.mdx
+++ b/docs/docs/spec-driven-development.mdx
@@ -47,7 +47,68 @@ Simple builds execute sequentially: schema first, then objects, then checks. Com
 
 ## Compatible SDD frameworks
 
-SDD works with any framework that supports a spec, plan, task, and implement workflow. The [infrahub-template](https://github.com/opsmill/infrahub-template) repository includes a pre-configured SDD setup using Spec Kit as a starting point.
+SDD works with any framework that supports a spec, plan, task, and implement workflow. The [infrahub-template](https://github.com/opsmill/infrahub-template) repository scaffolds an Infrahub project and documents the Spec Kit setup it expects, which is the quickest starting point.
+
+## Infrahub routing for Spec Kit
+
+The [infrahub-speckit](https://github.com/opsmill/infrahub-speckit) extension wires the Infrahub skills into Spec Kit's own commands. It needs Spec Kit 0.8.0 or newer:
+
+```bash
+specify extension add infrahub-speckit --from https://github.com/opsmill/infrahub-speckit/archive/refs/heads/main.zip
+```
+
+The extension registers four hooks against the core Spec Kit skills. All four fire whether the skill was invoked by a slash command, by another skill, or by an autonomous agent, and all four no-op in a project with no `.infrahub.yml`:
+
+| Hook | When it fires | What it does |
+| ------ | --------------- | -------------- |
+| `before_specify` | Before `/speckit.specify` writes anything | Classifies the requested artifact type, verifies the Infrahub skills are installed and the instance is reachable, then selects the matching Infrahub spec template |
+| `before_plan` | Before `/speckit.plan` starts research | Re-invokes the skill that matches the artifact |
+| `before_implement` | Before `/speckit.implement` runs its tasks | Re-invokes the matching skill for each artifact type in `tasks.md` |
+| `after_implement` | After `/speckit.implement` finishes | Checks the finished cycle for evidence that a skill's own guidance had a gap, and offers to report it |
+
+All three `before_*` hooks halt with install guidance when the Infrahub skills are not present, and `before_specify` also halts when the instance is unreachable. The `after_implement` hook never halts: implementation is already done, so a missing skill, an error, or an ambiguous read all degrade to a no-op line rather than disrupting finished work.
+
+### Skill-gap detection after implement
+
+Infrahub skills fail quietly. A missing or unclear rule does not crash the run, it produces extra round trips and repeated nudges until the model works the answer out anyway. By the time the cycle ends, that friction is invisible. The `after_implement` hook looks for it while the session still holds the evidence.
+
+Detection is automatic; drafting and filing are not. On most cycles the whole hook is one line:
+
+```text
+[infrahub-speckit] No skill-guidance friction detected this cycle.
+```
+
+When the evidence gate opens, you get an offer and nothing else:
+
+```text
+[infrahub-speckit — friction offer, /speckit.implement]
+
+Skill:        infrahub-managing-schemas
+Evidence:     schema load failed on relationship cardinality, passed after correction
+Rule coverage: no rule file covers this topic
+
+An Infrahub skill's guidance may have a gap here. Reply "report it" to draft a
+skill-friction report for review. Nothing is filed without your approval.
+```
+
+Ignoring it costs nothing. Replying routes the session into the [Skill Gap Reporter](./skills-reference/reporting-skill-gaps.mdx), which searches the tracker, decides whether the skill or Infrahub itself is at fault, and drafts a redacted report. That skill cannot file: it hands the draft to the [Issue Reporter](./skills-reference/reporting-issues.mdx), which shows you the target repository and the full body, then asks how to submit it. You can stop at either gate, and the manual submission method sends nothing from your machine.
+
+Two probes open the gate:
+
+- **A verifier verdict**: a verifier rejected an artifact and later accepted it, red to green on the same target
+- **A correction delta**: you rewrote something the agent authored, in a way a rule could have prevented
+
+Nothing else does:
+
+- **A missing rule file on its own**: the rule-coverage read names the file that should have covered the topic, which is attribution for a finding rather than a trigger for one, and plenty of topics on a healthy cycle have no rule file
+- **Failures the skills do not own**: authentication, connectivity, a container that never started, or a product-side 5xx
+- **Session-shape counters**: retry counts, edit churn, repeated asks, and docs escapes rise for reasons unrelated to a skill's guidance, such as an unclear request
+
+The hook also stays quiet unless the skill guided the authoring inside that same implement run, and unless both the Skill Gap Reporter and the Issue Reporter are installed, since the accept path needs both.
+
+:::note
+Two per-project escape hatches live on the hook's entry in `.specify/extensions.yml`: `optional: true` turns the check into an opt-in offer, and `enabled: false` disables it.
+:::
 
 ## Example walkthrough: VLAN management domain
 
@@ -55,12 +116,25 @@ This example uses [Spec Kit](https://github.com/github/spec-kit) to design a VLA
 
 ### Setup
 
+Start from [infrahub-template](https://github.com/opsmill/infrahub-template), which scaffolds the repository layout the skills expect and ships `invoke` tasks for the instance:
+
 ```bash
-# Initialize Spec Kit in your Infrahub project
-specify init . --ai claude
+uv tool run --from 'copier' copier copy https://github.com/opsmill/infrahub-template.git vlan-demo
+cd vlan-demo
+uv sync --all-packages
+invoke start
 ```
 
-This creates `.speckit/` config and installs slash commands into `.claude/commands/`.
+Then install the skills, Spec Kit, and the Infrahub routing extension:
+
+```bash
+npx skills add opsmill/infrahub-skills
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+specify init --here --integration claude
+specify extension add infrahub-speckit --from https://github.com/opsmill/infrahub-speckit/archive/refs/heads/main.zip
+```
+
+`specify init` creates the `.specify/` project configuration and installs slash commands into `.claude/commands/`. Having the instance up matters for more than the data: `before_specify` gates on `infrahubctl info`, so the cycle stops early rather than planning against an instance it cannot reach.
 
 ### Step 1: Specify
 
@@ -109,7 +183,7 @@ Run `/speckit.tasks`. The AI breaks the plan into discrete steps in `tasks.md`:
 
 ### Step 5: Implement
 
-Run `/speckit.implement`. The AI executes each task using the appropriate Infrahub skill.
+Run `/speckit.implement`. The AI executes each task using the appropriate Infrahub skill. With the routing extension installed, the cycle closes with the friction check described in [Skill-gap detection after implement](#skill-gap-detection-after-implement).
 
 **Task 1 output** — `schemas/vlan_management.yml` (via Schema Manager):
 
@@ -220,6 +294,49 @@ check_definitions:
     file_path: checks/check_vlan_id_uniqueness/check.py
     query: check_vlan_id_uniqueness
 ```
+
+### Step 6: Report the gap it exposed
+
+Task 6 is where the cycle hit friction. The first version of `schemas/vlan_management.yml` left `optional` off the `group` relationship, and relationships default to optional, so `infrahubctl schema check` rejected it:
+
+```text
+cannot use group relationship, relationship must be mandatory
+```
+
+The AI added `optional: false`, re-ran the check, and it passed. That is a verifier going red to green on the same target inside a single implement run, which is exactly what the `after_implement` hook looks for. When the cycle closes, it prints one offer:
+
+> **[infrahub-speckit — friction offer, /speckit.implement]**
+>
+> Skill: `infrahub-managing-schemas`
+> Evidence: `infrahubctl schema check` rejected the VLAN node, then passed once `optional: false` was added to the constrained relationship
+> Rule coverage: `rules/uniqueness-constraints.md`
+>
+> An Infrahub skill's guidance may have a gap here. Reply "report it" to draft a skill-friction report for review. Nothing is filed without your approval.
+
+Ignoring it ends the cycle there. Replying hands the session to the [Skill Gap Reporter](./skills-reference/reporting-skill-gaps.mdx), which searches the tracker, classifies the finding, and drafts:
+
+> **bug: infrahub-managing-schemas: state the mandatory requirement where the constraint is written**
+>
+> **Skill**: infrahub-managing-schemas
+> **Type**: bug
+> **Confidence**: unconfirmed single observation
+> **Tracker search**: `repo:opsmill/infrahub-skills uniqueness constraint mandatory relationship` returned no existing report
+>
+> **What was being attempted**: scoping a uniqueness constraint by the parent relationship of a child node.
+>
+> **Rules consulted**: `uniqueness-constraints.md`, which does state that a relationship in a constraint must be mandatory, cardinality one, and referenced bare.
+>
+> **Where it went wrong**: the constraint was written correctly but the relationship was left at its default, so the check failed on the mandatory requirement. One failed verifier run and one correction.
+>
+> **What finally worked**: `optional: false` on the constrained relationship.
+>
+> **Proposed rule change**: in `uniqueness-constraints.md`, put the three requirements next to the constraint example rather than in a later section, so the relationship and the constraint that binds it are authored together.
+
+It is a **bug** rather than a feature because a rule already claimed the ground and the model still got it wrong. Had no rule covered relationships in constraints, the same friction would have drafted as a `feat:` instead, and the offer would have read `Rule coverage: no rule file covers this topic`. That classification decides the title prefix and the target repository, which is why the coverage read runs before the draft.
+
+The draft carries the version lines the template requires, read from `infrahubctl info`, and nothing that identifies your infrastructure. The Skill Gap Reporter cannot file it: it hands the draft to the [Issue Reporter](./skills-reference/reporting-issues.mdx), which shows you the target repository and the full body, then asks whether to submit through `gh`, a GitHub MCP server, or copy-paste. You can stop at either gate.
+
+Asking for the same thing without the extension installed works too: "report skill friction" reaches the Skill Gap Reporter directly. The hook only removes the need to notice the friction yourself.
 
 ### Result
 


### PR DESCRIPTION
## Summary

The v1.2.8 draft release currently carries release-drafter's raw list of 28 pull-request titles, which tells a reader what merged but not what is different about their workflow after upgrading. This adds the curated 1.2.8 release notes to the docs site in the house style established by 1.2.3–1.2.7, and fixes two release-process defects that would otherwise ship with the release.

## Key Changes

- Readers get the 1.2.8 release notes on the docs site: nine workflow sections covering the four new skills (NetBox device-type conversion, concept tutoring, diagnostic-bundle triage, skill-gap reporting) and the verified generic, cardinality, and authoring semantics that landed across the schema, check, transform, and generator skills — plus bug fixes, minor changes, upgrade notes, and the full changelog.
- A published v1.2.8 will list every skill it ships. `.github/.release-manifest.json` had omitted `infrahub-reporting-skill-gaps` since #83, and `release.yml` appends that list to the release body on publish, so the release would have claimed 14 skills while 15 ship.
- Anyone bumping the version gets the whole checklist. `AGENTS.md` listed three files; `release.yml` also validates `pyproject.toml` against the tag and **fails the publish** on a mismatch, and #121 found `uv.lock` drifting for want of a mention. Both are now listed, along with the per-release notes page and the publish-time ordering — merging to `main` regenerates the draft release body, so the curated notes go in after the last PR lands and before publishing.
- The release-notes sidebar stays newest-first: `sidebar_position` shifts by one across all nine older pages so 1.2.8 sits at position 1.

## Related Context

Written from the v1.2.8 draft release, the 1.2.3–1.2.7 release notes (for house style), and the 28 pull requests merged between `v1.2.7` and `main`. Structure benchmarked against Nautobot 2.4.0 and NetBox 4.7.0.

Every technical claim was verified against the merged pull requests, `graders/common/cli_tree.py`, and the rule files on disk rather than taken from the PR bodies. That caught four errors worth noting, since three came from the source material:

- PR #110's body headlines "11 invalid invocations across **7** forms" while its own table lists six. The notes state the invocation count and enumerate the forms, asserting no total.
- `infrahubctl protocols` is a valid command (`cli_tree.py` `LEAVES`); PR #79 corrected the longer `protocols generate --schema-dir … --async` form. An earlier draft implied the command itself was invalid while another section told readers to run it.
- `infrahubctl version` is also a registered command, so the `--version` bug fix is scoped to the flag rather than claiming `info` is the only option.
- `infrahub-teaching-concepts` has eleven concepts in `references/concept-map.md`; an earlier draft named eight of them while the next line said "eleven".

Deliberately out of scope: `infrahub-analyzing-diagnostics` and `infrahub-converting-netbox-device-types` still have no page under `docs/docs/skills-reference/` (noted in #119), so the notes name both skills without linking them. Adding those two pages, and their rows in `docs/docs/readme.mdx`, is follow-up work.

Also found but not fixed here, as it belongs to the skill rather than the notes: `skills/infrahub-converting-netbox-device-types/rules/output-load-order.md` is titled "Emit Three Files in Load Order" and lists only `01`–`03`, while `reference.md` and the converter itself emit five.

## Documentation Updates

- `docs/docs/release-notes/release-1_2_8.mdx` — new.
- `release-0_0_1.mdx` through `release-1_2_7.mdx` — `sidebar_position` only, no prose changes.
- `AGENTS.md` — `### Versioning` checklist corrected.

## Test Plan

- `cd docs && npm run build` — succeeds with zero broken-link and broken-anchor warnings. Note that `onBrokenAnchors` is warn-only here, so a green build alone is not proof; all three internal anchors were additionally confirmed present as `id="…"` in the generated HTML, and all nine `../skills-reference/*.mdx` targets confirmed to exist on disk.
- `uv run rumdl check .` — clean, 313 files.
- `uv run ruff check .` — clean.
- `python scripts/check-cli-invocations.py` — clean. The invalid `infrahubctl` forms the notes quote are deliberate examples of what was wrong, and `docs/` sits outside the sweep's scan targets.
- `.release-manifest.json` `skills` now matches `skills/` on disk exactly, `infrahub-common` aside (a shared reference library, not a skill).
- `sidebar_position` across all ten notes: 1–10, no duplicates or gaps.
- Version surfaces already read 1.2.8 (`plugin.json`, `.release-manifest.json`, `pyproject.toml`, all sixteen `SKILL.md`), so no bump is included and merging triggers none — `version-drafter` resolves a patch bump from the last published release, v1.2.7 → 1.2.8, which equals the current version.

**After merge:** merging regenerates the v1.2.8 draft release body via `auto-bump.yml`, so paste the curated notes into the draft after this lands and publish before any further PR merges to `main`. On publish, `release.yml` appends its own `### Skills included` block from the manifest.

---
Assisted-by: opsmill-docs-writing-release-notes 0.1.0
Assisted-by: opsmill-dev-commit 0.1.0
Assisted-by: opsmill-dev-pr 0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
