### PR TITLE
docs(skills-reference): add the two missing skill pages

### DIFF
--- a/.vale/styles/spelling-exceptions.txt
+++ b/.vale/styles/spelling-exceptions.txt
@@ -163,6 +163,8 @@ toml
 tomek
 towncrier
 Towncrier
+traceback
+tracebacks
 uncheck
 untrust
 uniqueness_constraints
@@ -173,6 +175,7 @@ userinfo
 uv
 uuid
 UUID
+UUIDs
 validator
 validators
 Version Control

--- a/docs/docs/readme.mdx
+++ b/docs/docs/readme.mdx
@@ -64,6 +64,8 @@ For full lifecycle workflows. The AI generates files, loads them with `infrahubc
 | [Issue Reporter](./skills-reference/reporting-issues.mdx) | Routes a bug or feature request to the right Infrahub-ecosystem repository and prepares a sanitized draft for your review |
 | [Skill Gap Reporter](./skills-reference/reporting-skill-gaps.mdx) | Turns friction with an Infrahub skill into a reviewed issue with a proposed rule change, filed through the Issue Reporter |
 | [Concept Tutor](./skills-reference/teaching-concepts.mdx) | Teaches Infrahub concepts through the learner's own repo and instance, with verified exercises and progress tracking |
+| [Diagnostics Analyzer](./skills-reference/analyzing-diagnostics.mdx) | Turns a collected diagnostic bundle into a triage report, correlating errors into incidents and matching them against known Infrahub issues |
+| [NetBox Device Type Converter](./skills-reference/converting-netbox-device-types.mdx) | Converts NetBox device-type and module-type definitions into Infrahub Object Templates via a mapping-profile-driven converter |
 
 A shared reference library (`infrahub-common`) provides GraphQL query syntax, `.infrahub.yml` configuration format, YAML structure conventions, and the Profiles vs Object Templates distinction to all skills.
 

--- a/docs/docs/release-notes/release-1_2_8.mdx
+++ b/docs/docs/release-notes/release-1_2_8.mdx
@@ -27,7 +27,7 @@ description: Four new skills — NetBox device-type conversion, concept tutoring
 
 ## Release summary
 
-After upgrading, you can convert NetBox device-type definitions into Infrahub object templates, learn Infrahub concepts through your own repository and instance, triage a diagnostic bundle before escalating it, and report a skill's own missing guidance as a reviewed issue. The schema, check, transform, and generator guidance also changed: what a declaration on a generic imposes on every inheriting kind is now stated explicitly, and every `infrahubctl` command the skills print has been checked against the CLI.
+After upgrading, you can convert NetBox device-type definitions into Infrahub Object Templates, learn Infrahub concepts through your own repository and instance, triage a diagnostic bundle before escalating it, and report a skill's own missing guidance as a reviewed issue. The schema, check, transform, and generator guidance also changed: what a declaration on a generic imposes on every inheriting kind is now stated explicitly, and every `infrahubctl` command the skills print has been checked against the CLI.
 
 :::note What to expect after upgrading
 
@@ -39,9 +39,9 @@ See [Upgrade notes](#upgrade-notes) for full details.
 
 :::
 
-### Convert NetBox device-type definitions into Infrahub object templates
+### Convert NetBox device-type definitions into Infrahub Object Templates
 
-Turn NetBox device-type and module-type files — the [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) format — into Infrahub object templates with the new converting-netbox-device-types skill. A bundled Python converter reads a mapping profile describing your target schema and writes manufacturers, device types, module types, and component templates as object YAML, alongside a coverage report naming everything it could not map ([#80](https://github.com/opsmill/infrahub-skills/pull/80)).
+Turn NetBox device-type and module-type files — the [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) format — into Infrahub Object Templates with the new [converting-netbox-device-types](../skills-reference/converting-netbox-device-types.mdx) skill. A bundled Python converter reads a mapping profile describing your target schema and writes manufacturers, device types, module types, and component templates as object YAML, alongside a coverage report naming everything it could not map ([#80](https://github.com/opsmill/infrahub-skills/pull/80)).
 
 * Convert a single file, a folder, or a mixed tree of device types and module types in one pass. The two families are told apart by `slug`, which every device type carries and no module type does, so a mixed tree does not have to be split up first. Output files are numbered `01_manufacturers` through `05_module_templates` so `infrahubctl object load` runs them in dependency order.
 * Point the converter at your own schema with a mapping profile rather than editing the script. Every Infrahub kind, attribute, and relationship name is read from a YAML profile, so a custom schema needs a new profile instead of a forked converter. Three profiles ship: `schema-library.yml`, `schema-library-modules.yml`, and an annotated `_template.yml`.
@@ -59,7 +59,7 @@ Work through Infrahub concepts — foundations, schema, objects, GraphQL, branch
 
 ### Triage a diagnostic bundle before escalating it
 
-Read a bundle collected by [collecting-diagnostics](../skills-reference/collecting-diagnostics.mdx) yourself with the new analyzing-diagnostics skill. It reads the manifest first, sweeps every service's logs for tracebacks, ERROR and CRITICAL lines, OOM kills, and `*.previous.log` restart evidence, then reports correlated incidents with root causes separated from cascades rather than a flat list of errors ([#76](https://github.com/opsmill/infrahub-skills/pull/76)).
+Read a bundle collected by [collecting-diagnostics](../skills-reference/collecting-diagnostics.mdx) yourself with the new [analyzing-diagnostics](../skills-reference/analyzing-diagnostics.mdx) skill. It reads the manifest first, sweeps every service's logs for tracebacks, ERROR and CRITICAL lines, OOM kills, and `*.previous.log` restart evidence, then reports correlated incidents with root causes separated from cascades rather than a flat list of errors ([#76](https://github.com/opsmill/infrahub-skills/pull/76)).
 
 * Find out whether your crash is already known, and possibly already fixed, before anyone files an issue or waits on support. Findings are matched against existing `opsmill/infrahub` issues using stable search keys — exception class plus normalized message — with volatile tokens such as branch names, UUIDs, and hostnames stripped so a known issue actually matches. A match then resolves against the version the bundle reports running: a newer fix version means upgrade, and already running the fix means an unconfirmed match or a possible regression.
 * Read every finding against evidence you can check. Each claim cites a bundle path with a quoted excerpt, the report opens with the deployment context — running version, topology, replica counts — and what the bundle cannot answer is reported as an open question mapped to the `infrahub-collect create` flags a next bundle would need.

--- a/docs/docs/skills-reference/analyzing-diagnostics.mdx
+++ b/docs/docs/skills-reference/analyzing-diagnostics.mdx
@@ -1,0 +1,71 @@
+---
+title: Diagnostics Analyzer
+sidebar_position: 14
+---
+
+The Diagnostics Analyzer reads a bundle the [Diagnostics Collector](./collecting-diagnostics.mdx) already produced and turns its logs into a triage report. It reads the manifest before any log, sweeps every service for tracebacks and other error signals, correlates related errors into incidents with root causes separated from cascades, and searches existing `opsmill/infrahub` issues so you learn whether your crash is already known — without touching the running deployment, applying a fix, or filing anything on your behalf.
+
+## When to use
+
+- You have a bundle in hand and want to know what it says before involving support
+- Tracebacks in the logs need interpreting
+- Deciding whether a crash is a known Infrahub issue, and whether a newer version already fixes it
+- A container or worker keeps restarting and you need the pre-restart cause
+- A performance symptom, where a `--benchmark` collection needs reading alongside the logs
+
+## What it produces
+
+A findings report grounded in bundle evidence:
+
+- A deployment-context header — running Infrahub version, topology (Docker Compose or Kubernetes), replica counts — because the version is what turns a matched issue into a conclusion rather than a coincidence
+- One section per incident, with severity, the evidence as bundle file paths plus quoted excerpts, and the reasoning that grouped those signals into one incident
+- Matching `opsmill/infrahub` issues with title, state, and URL, searched across open and closed
+- Open questions, including whether the symptom reproduces on demand, each mapped to the `infrahub-collect create` flags a next bundle would need to answer it
+
+## Example prompts
+
+- "I collected a bundle — can you tell me what's wrong?"
+- "Analyze these Infrahub logs"
+- "What do the tracebacks in the bundle mean?"
+- "Is this crash a known Infrahub issue?"
+- "Why did the task-worker keep restarting?"
+
+## Key rules enforced
+
+- **You name the bundle** — the skill asks for the path instead of scanning for one, because a machine often holds several bundles and picking the wrong one produces a confident report about the wrong incident
+- **Manifest before any log** — `bundle_information.json` records what was collected and what failed, and a service whose logs could not be collected is often the service that is down, so collection failures are findings rather than gaps in the evidence
+- **Every service, not just the server** — the sweep covers each directory under `bundle/logs/` for tracebacks, ERROR and CRITICAL lines, panics, OOM kills, and connection failures, and treats any `*.previous.log` as restart evidence whose tail usually holds the crash cause
+- **Incidents, not error lists** — signals are grouped by timestamp and causal chain, so a database OOM followed by server connection errors is reported as one incident with a named root rather than two problems
+- **Stable search keys** — a key is built from the exception class, the normalized message, and the innermost Infrahub frame, with branch names, UUIDs, and hostnames stripped, so a known issue actually matches
+- **Both halves of the tracker** — the issue search covers open and closed issues, because a closed match is the one that tells you which version carries the fix
+- **Evidence per finding** — every claim cites a bundle path and a quoted excerpt, and what the bundle cannot answer is stated as an open question rather than papered over
+- **Read-only** — the analysis reads an already-collected bundle and runs issue searches; it never touches the running instance, restarts nothing, edits no config, and creates no issue
+
+## Diagnostics Collector vs. Diagnostics Analyzer
+
+| Use the Diagnostics Collector when... | Use the Diagnostics Analyzer when... |
+| --------------------------------------- | -------------------------------------- |
+| Infrahub is misbehaving and no bundle exists yet | A bundle already exists, or you have its contents |
+| You need the right `infrahub-collect` command for your symptom | You need to know what the collected logs actually say |
+| Output is a support bundle on disk | Output is a findings report citing that bundle |
+| The next step is sharing it with OpsMill | The next step is an upgrade, a comment on an existing issue, or a new report |
+
+## Common mistakes it catches
+
+| Mistake | What the skill does instead |
+| --------- | --------------------------- |
+| Reading only the server's logs | Sweeps every service directory under `bundle/logs/` |
+| Treating an uncollectable log as a gap in the bundle | Reports it as a finding — that service is often the one that failed |
+| Reporting every error line as its own problem | Correlates signals into incidents and names the root |
+| Searching a traceback verbatim | Strips branch names, UUIDs, and hostnames first, so the search matches |
+| Limiting the issue search to open issues | Searches open and closed, since a closed match names the fixing version |
+| Restarting a container to test a theory | Recommends it in the report and applies nothing |
+| Filing the bug from here | Hands off to the [Issue Reporter](./reporting-issues.mdx) |
+
+:::tip
+Benchmark data exists only if the bundle was created with `infrahub-collect create --benchmark`. For a performance symptom without it, the report asks for a new bundle carrying that flag rather than guessing from logs alone — the single-CPU score and the storage IOPS of the Neo4j and PostgreSQL volumes are often what decide whether the cause is software or an undersized host.
+:::
+
+:::note
+No bundle yet? Start with the [Diagnostics Collector](./collecting-diagnostics.mdx). This skill will not scrape `docker compose logs` or `kubectl logs` as a substitute, because a hand-scraped set of logs misses the replica coverage, the previous-container logs, and the manifest that the analysis depends on.
+:::

--- a/docs/docs/skills-reference/analyzing-diagnostics.mdx
+++ b/docs/docs/skills-reference/analyzing-diagnostics.mdx
@@ -37,9 +37,9 @@ A findings report grounded in bundle evidence:
 - **Every service, not just the server** — the sweep covers each directory under `bundle/logs/` for tracebacks, ERROR and CRITICAL lines, panics, OOM kills, and connection failures, and treats any `*.previous.log` as restart evidence whose tail usually holds the crash cause
 - **Incidents, not error lists** — signals are grouped by timestamp and causal chain, so a database OOM followed by server connection errors is reported as one incident with a named root rather than two problems
 - **Stable search keys** — a key is built from the exception class, the normalized message, and the innermost Infrahub frame, with branch names, UUIDs, and hostnames stripped, so a known issue actually matches
-- **Both halves of the tracker** — the issue search covers open and closed issues, because a closed match is the one that tells you which version carries the fix
-- **Evidence per finding** — every claim cites a bundle path and a quoted excerpt, and what the bundle cannot answer is stated as an open question rather than papered over
-- **Read-only** — the analysis reads an already-collected bundle and runs issue searches; it never touches the running instance, restarts nothing, edits no config, and creates no issue
+- **Both halves of the tracker** — the issue search covers open and closed issues, because a closed match is the one that tells you which version includes the fix
+- **Evidence per finding** — every claim cites a bundle path and a quoted excerpt, and what the bundle cannot answer is stated as an open question rather than left out
+- **Read-only** — the analysis reads an already-collected bundle and runs issue searches; it never touches the running instance, restarts nothing, edits no configuration, and creates no issue
 
 ## Diagnostics Collector vs. Diagnostics Analyzer
 
@@ -55,7 +55,7 @@ A findings report grounded in bundle evidence:
 | Mistake | What the skill does instead |
 | --------- | --------------------------- |
 | Reading only the server's logs | Sweeps every service directory under `bundle/logs/` |
-| Treating an uncollectable log as a gap in the bundle | Reports it as a finding — that service is often the one that failed |
+| Treating a log that could not be collected as a gap in the bundle | Reports it as a finding — that service is often the one that failed |
 | Reporting every error line as its own problem | Correlates signals into incidents and names the root |
 | Searching a traceback verbatim | Strips branch names, UUIDs, and hostnames first, so the search matches |
 | Limiting the issue search to open issues | Searches open and closed, since a closed match names the fixing version |
@@ -63,7 +63,7 @@ A findings report grounded in bundle evidence:
 | Filing the bug from here | Hands off to the [Issue Reporter](./reporting-issues.mdx) |
 
 :::tip
-Benchmark data exists only if the bundle was created with `infrahub-collect create --benchmark`. For a performance symptom without it, the report asks for a new bundle carrying that flag rather than guessing from logs alone — the single-CPU score and the storage IOPS of the Neo4j and PostgreSQL volumes are often what decide whether the cause is software or an undersized host.
+Benchmark data exists only if the bundle was created with `infrahub-collect create --benchmark`. For a performance symptom without it, the report asks for a new bundle created with that flag rather than guessing from logs alone — the single-CPU score and the storage IOPS of the Neo4j and PostgreSQL volumes are often what decide whether the cause is software or an undersized host.
 :::
 
 :::note

--- a/docs/docs/skills-reference/converting-netbox-device-types.mdx
+++ b/docs/docs/skills-reference/converting-netbox-device-types.mdx
@@ -32,9 +32,10 @@ The files are numbered in dependency order, so loading them in sequence satisfie
 - `03_device_templates.yml`
 - `04_module_types.yml`
 - `05_module_templates.yml`
-- a Markdown coverage report naming everything the profile could not map
 
-Empty files are not written, so a device-types-only run produces the first three plus the report.
+Empty files are not written, so a device-types-only run produces just the first three.
+
+A Markdown coverage report names everything the profile could not map. It is written to the `--report` path, which is resolved on its own rather than inside the output directory, and defaults to `coverage-report.md` in the current directory.
 
 ## Example prompts
 
@@ -56,6 +57,8 @@ Empty files are not written, so a device-types-only run produces the first three
 - **The skill offers schema changes; it does not make them** — enabling `generate_template` is a migration against your source of truth, so it is proposed for you to apply
 
 ## Running the converter
+
+The skill normally runs the converter for you. To run it by hand, resolve the two `skills/...` paths against wherever your installation put the skill directory. The command below assumes the [manual copy](../installation-setup.mdx), which puts it under your project root; the `npx` installer and the Claude Code plugin place it elsewhere.
 
 ```bash
 python skills/infrahub-converting-netbox-device-types/scripts/netbox_to_infrahub_templates.py \

--- a/docs/docs/skills-reference/converting-netbox-device-types.mdx
+++ b/docs/docs/skills-reference/converting-netbox-device-types.mdx
@@ -1,0 +1,88 @@
+---
+title: NetBox Device Type Converter
+sidebar_position: 15
+---
+
+The NetBox Device Type Converter turns NetBox device-type and module-type YAML — the [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) format, browsable at the [NetBox Data Exchange](https://netboxlabs.com/ndx/) — into Infrahub Object Templates: reusable blueprints that create a device with all its ports already in place. A bundled Python script does the conversion, driven by a mapping profile that describes your target schema, so the skill is about pointing it at the right schema and reading what it reports back — without editing your schema for you or guessing a field name the profile does not define.
+
+## When to use
+
+- Seeding a new Infrahub instance with vendor device models from the NetBox library
+- Converting a handful of device types for a specific project or lab topology
+- Re-running a conversion after the upstream library or your local schema changed
+- Building the mapping profile that binds NetBox fields to a custom Infrahub schema
+
+Not for syncing a **live** NetBox instance into Infrahub — that is [infrahub-sync](https://docs.infrahub.app/sync/), a separate product. This skill converts the static YAML definitions.
+
+## What it produces
+
+One NetBox file becomes several Infrahub artifacts, because Infrahub splits what NetBox keeps together:
+
+| NetBox | Infrahub | Why |
+| -------- | ---------- | ----- |
+| `manufacturer: Cisco` | `OrganizationManufacturer` object | Manufacturers are first-class objects |
+| `model`, `part_number`, `u_height`, `weight` | `DcimDeviceType` object | Templates hold no model data |
+| `interfaces:` and other component lists | `TemplateDcimDevice` plus component templates | The reusable blueprint |
+| `module-types/*.yaml` | `DcimModuleType` object, optionally a module template | A second input family, told apart by the absence of a `slug` |
+
+The files are numbered in dependency order, so loading them in sequence satisfies each file's references:
+
+- `01_manufacturers.yml`
+- `02_device_types.yml`
+- `03_device_templates.yml`
+- `04_module_types.yml`
+- `05_module_templates.yml`
+- a Markdown coverage report naming everything the profile could not map
+
+Empty files are not written, so a device-types-only run produces the first three plus the report.
+
+## Example prompts
+
+- "Convert these Cisco device types into Infrahub object templates"
+- "Seed my instance with device models from the NetBox devicetype-library"
+- "Build a mapping profile for my custom DCIM schema"
+- "Re-run the device-type conversion — we upgraded schema-library"
+- "Convert the module types too, including the line cards"
+
+## Key rules enforced
+
+- **`generate_template: true` comes first** — `Template*` kinds exist only where a node declares it, so the skill checks the target schema rather than assuming either way; this is the most common reason a conversion loads nothing
+- **Names come from the profile, never guessed** — every Infrahub kind, attribute, and relationship name is read from a YAML mapping profile, so a custom schema needs a new profile rather than a forked script
+- **Competing fields declare precedence** — NetBox carries more free-text fields than most schemas have room for, so the profile names one as another's fallback; the loser is reported as shadowed, and an undeclared collision is refused rather than letting mapping order decide it silently
+- **Shared relationships accumulate** — where two NetBox component lists map to the same Infrahub relationship, both are kept; assigning rather than accumulating silently erased the first list
+- **Integers only** — Infrahub has no float or decimal attribute kind, so every numeric transform emits a whole number
+- **Nothing is dropped silently** — anything the profile cannot map is skipped and named in the coverage report, which closes with an explanation of why each gap exists
+- **Template names are slug-based and parent-namespaced** — so names stay unique across the whole library rather than colliding between vendors
+- **The skill offers schema changes, it does not make them** — enabling `generate_template` is a migration against your source of truth, so it is proposed for you to apply
+
+## Running the converter
+
+```bash
+python skills/infrahub-converting-netbox-device-types/scripts/netbox_to_infrahub_templates.py \
+  devicetype-library/device-types/Cisco/ \
+  --mapping skills/infrahub-converting-netbox-device-types/scripts/mappings/schema-library.yml \
+  --output-dir ./generated \
+  --report ./generated/coverage-report.md
+```
+
+Point it at a single file, a folder, or a mixed tree of device types and module types — the two families are told apart automatically, so a mixed tree converts in one pass. Three mapping profiles ship: `schema-library.yml`, `schema-library-modules.yml`, and an annotated `_template.yml` to copy for a custom schema.
+
+## Common mistakes it catches
+
+| Mistake | What the skill does instead |
+| --------- | --------------------------- |
+| Assuming `Template*` kinds already exist | Checks the target schema for `generate_template: true` before converting |
+| Hand-transcribing a 48-port switch | Runs the script, which is exact and repeatable across thousands of device types |
+| Editing the script for a custom schema | Writes a new mapping profile, leaving the script untouched |
+| Reading a clean run as a lossless one | Points you at the coverage report, which names what did not convert |
+| Loading the output files in arbitrary order | Numbers them `01`–`05` in dependency order |
+| Expecting `{module}` port names to resolve | Explains that the bay position is known only once a module is installed |
+| Reaching for this to sync a live NetBox | Sends you to infrahub-sync, which is a different product |
+
+:::warning
+Read the coverage report before loading anything. Against the stock `schema-library.yml` profile most NetBox component lists have no equivalent node, so a report full of unmapped entries is the normal path rather than an error — it is the list of schema changes a lossless conversion would need.
+:::
+
+:::tip
+Module port names carry NetBox's `{module}` token, which no conversion can resolve, because the bay position is known only once a module is installed. Once the schema-library module extensions are loaded, a bundled generator resolves the token per installed module and creates the real device interfaces.
+:::

--- a/docs/docs/skills-reference/converting-netbox-device-types.mdx
+++ b/docs/docs/skills-reference/converting-netbox-device-types.mdx
@@ -3,7 +3,7 @@ title: NetBox Device Type Converter
 sidebar_position: 15
 ---
 
-The NetBox Device Type Converter turns NetBox device-type and module-type YAML — the [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library) format, browsable at the [NetBox Data Exchange](https://netboxlabs.com/ndx/) — into Infrahub Object Templates: reusable blueprints that create a device with all its ports already in place. A bundled Python script does the conversion, driven by a mapping profile that describes your target schema, so the skill is about pointing it at the right schema and reading what it reports back — without editing your schema for you or guessing a field name the profile does not define.
+The NetBox Device Type Converter turns NetBox device-type and module-type YAML into Infrahub Object Templates, so you create a device with its ports already in place from one reusable definition. The input format is [netbox-community/devicetype-library](https://github.com/netbox-community/devicetype-library), which you can browse at the [NetBox Data Exchange](https://netboxlabs.com/ndx/). A bundled Python script does the conversion, driven by a mapping profile that describes your target schema. Point it at the right schema and read what it reports back — without editing your schema for you or guessing a field name the profile does not define.
 
 ## When to use
 
@@ -48,12 +48,12 @@ Empty files are not written, so a device-types-only run produces the first three
 
 - **`generate_template: true` comes first** — `Template*` kinds exist only where a node declares it, so the skill checks the target schema rather than assuming either way; this is the most common reason a conversion loads nothing
 - **Names come from the profile, never guessed** — every Infrahub kind, attribute, and relationship name is read from a YAML mapping profile, so a custom schema needs a new profile rather than a forked script
-- **Competing fields declare precedence** — NetBox carries more free-text fields than most schemas have room for, so the profile names one as another's fallback; the loser is reported as shadowed, and an undeclared collision is refused rather than letting mapping order decide it silently
-- **Shared relationships accumulate** — where two NetBox component lists map to the same Infrahub relationship, both are kept; assigning rather than accumulating silently erased the first list
+- **Competing fields declare precedence** — NetBox defines more free-text fields than most schemas have room for, so the profile names which field falls back to which; the loser is reported as shadowed, and an undeclared collision is refused rather than letting mapping order decide it silently
+- **Shared relationships accumulate** — where two NetBox component lists map to the same Infrahub relationship, both are kept; assigning rather than accumulating would silently erase the first list
 - **Integers only** — Infrahub has no float or decimal attribute kind, so every numeric transform emits a whole number
 - **Nothing is dropped silently** — anything the profile cannot map is skipped and named in the coverage report, which closes with an explanation of why each gap exists
 - **Template names are slug-based and parent-namespaced** — so names stay unique across the whole library rather than colliding between vendors
-- **The skill offers schema changes, it does not make them** — enabling `generate_template` is a migration against your source of truth, so it is proposed for you to apply
+- **The skill offers schema changes; it does not make them** — enabling `generate_template` is a migration against your source of truth, so it is proposed for you to apply
 
 ## Running the converter
 
@@ -65,7 +65,7 @@ python skills/infrahub-converting-netbox-device-types/scripts/netbox_to_infrahub
   --report ./generated/coverage-report.md
 ```
 
-Point it at a single file, a folder, or a mixed tree of device types and module types — the two families are told apart automatically, so a mixed tree converts in one pass. Three mapping profiles ship: `schema-library.yml`, `schema-library-modules.yml`, and an annotated `_template.yml` to copy for a custom schema.
+Point it at a single file, a folder, or a mixed tree of device types and module types — the two families are told apart automatically, so a mixed tree converts in one pass. The skill includes three mapping profiles: `schema-library.yml`, `schema-library-modules.yml`, and an annotated `_template.yml` to copy for a custom schema.
 
 ## Common mistakes it catches
 
@@ -84,5 +84,5 @@ Read the coverage report before loading anything. Against the stock `schema-libr
 :::
 
 :::tip
-Module port names carry NetBox's `{module}` token, which no conversion can resolve, because the bay position is known only once a module is installed. Once the schema-library module extensions are loaded, a bundled generator resolves the token per installed module and creates the real device interfaces.
+Module port names contain NetBox's `{module}` token, which no conversion can resolve, because the bay position is known only once a module is installed. Once the schema-library module extensions are loaded, a bundled generator resolves the token per installed module and creates the real device interfaces.
 :::

--- a/docs/docs/skills-reference/reporting-skill-gaps.mdx
+++ b/docs/docs/skills-reference/reporting-skill-gaps.mdx
@@ -14,6 +14,8 @@ The Skill Gap Reporter turns friction with an Infrahub skill into a reviewed Git
 
 Do not use it for a bug in Infrahub itself, the SDK, or any other `opsmill/infrahub-*` product. That belongs to the Issue Reporter. It is also not for ordinary work that finished without friction.
 
+That offer can also arrive on its own. With the [infrahub-speckit](https://github.com/opsmill/infrahub-speckit) extension installed, Spec Kit's `after_implement` hook checks every finished `/speckit.implement` cycle and prints a one-line offer when it finds evidence of a gap; replying routes into this skill. The hook detects, it never drafts or files. See [Skill-gap detection after implement](../spec-driven-development.mdx#skill-gap-detection-after-implement).
+
 ## What it produces
 
 - A named artifact: the rule file that should have prevented the friction, or a plain statement that no rule covers the topic

--- a/docs/docs/spec-driven-development.mdx
+++ b/docs/docs/spec-driven-development.mdx
@@ -49,6 +49,67 @@ Simple builds execute sequentially: schema first, then objects, then checks. Com
 
 SDD works with any framework that supports a spec, plan, task, and implement workflow. The [infrahub-template](https://github.com/opsmill/infrahub-template) repository includes a pre-configured SDD setup using Spec Kit as a starting point.
 
+## Infrahub routing for Spec Kit
+
+The [infrahub-speckit](https://github.com/opsmill/infrahub-speckit) extension wires the Infrahub skills into Spec Kit's own commands. It needs Spec Kit 0.8.0 or newer:
+
+```bash
+specify extension add infrahub-speckit --from https://github.com/opsmill/infrahub-speckit/archive/refs/heads/main.zip
+```
+
+The extension registers four hooks against the core Spec Kit skills. All four fire whether the skill was invoked by a slash command, by another skill, or by an autonomous agent, and all four no-op in a project with no `.infrahub.yml`:
+
+| Hook | When it fires | What it does |
+| ------ | --------------- | -------------- |
+| `before_specify` | Before `/speckit.specify` writes anything | Classifies the requested artifact type, verifies the Infrahub skills are installed and the instance is reachable, then selects the matching Infrahub spec template |
+| `before_plan` | Before `/speckit.plan` starts research | Re-invokes the skill that matches the artifact |
+| `before_implement` | Before `/speckit.implement` runs its tasks | Re-invokes the matching skill for each artifact type in `tasks.md` |
+| `after_implement` | After `/speckit.implement` finishes | Checks the finished cycle for evidence that a skill's own guidance had a gap, and offers to report it |
+
+All three `before_*` hooks halt with install guidance when the Infrahub skills are not present, and `before_specify` also halts when the instance is unreachable. The `after_implement` hook never halts: implementation is already done, so a missing skill, an error, or an ambiguous read all degrade to a no-op line rather than disrupting finished work.
+
+### Skill-gap detection after implement
+
+Infrahub skills fail quietly. A missing or unclear rule does not crash the run, it produces extra round trips and repeated nudges until the model works the answer out anyway. By the time the cycle ends, that friction is invisible. The `after_implement` hook looks for it while the session still holds the evidence.
+
+Detection is automatic; drafting and filing are not. On most cycles the whole hook is one line:
+
+```text
+[infrahub-speckit] No skill-guidance friction detected this cycle.
+```
+
+When the evidence gate opens, you get an offer and nothing else:
+
+```text
+[infrahub-speckit — friction offer, /speckit.implement]
+
+Skill:        infrahub-managing-schemas
+Evidence:     schema load failed on relationship cardinality, passed after correction
+Rule coverage: no rule file covers this topic
+
+An Infrahub skill's guidance may have a gap here. Reply "report it" to draft a
+skill-friction report for review. Nothing is filed without your approval.
+```
+
+Ignoring it costs nothing. Replying routes the session into the [Skill Gap Reporter](./skills-reference/reporting-skill-gaps.mdx), which searches the tracker, decides whether the skill or Infrahub itself is at fault, and drafts a redacted report. That skill cannot file: it hands the draft to the [Issue Reporter](./skills-reference/reporting-issues.mdx), which shows you the target repository and the full body, then asks how to submit it. You can stop at either gate, and the manual submission method sends nothing from your machine.
+
+Two probes open the gate:
+
+- **A verifier verdict**: a verifier rejected an artifact and later accepted it, red to green on the same target
+- **A correction delta**: you rewrote something the agent authored, in a way a rule could have prevented
+
+Nothing else does:
+
+- **A missing rule file on its own**: the rule-coverage read names the file that should have covered the topic, which is attribution for a finding rather than a trigger for one, and plenty of topics on a healthy cycle have no rule file
+- **Failures the skills do not own**: authentication, connectivity, a container that never started, or a product-side 5xx
+- **Session-shape counters**: retry counts, edit churn, repeated asks, and docs escapes rise for reasons unrelated to a skill's guidance, such as an unclear request
+
+The hook also stays quiet unless the skill guided the authoring inside that same implement run, and unless both the Skill Gap Reporter and the Issue Reporter are installed, since the accept path needs both.
+
+:::note
+Two per-project escape hatches live on the hook's entry in `.specify/extensions.yml`: `optional: true` turns the check into an opt-in offer, and `enabled: false` disables it.
+:::
+
 ## Example walkthrough: VLAN management domain
 
 This example uses [Spec Kit](https://github.com/github/spec-kit) to design a VLAN management domain from scratch — schema, object data, and a validation check. Any SDD framework that follows a spec, plan, task, and implement workflow produces a similar result.
@@ -60,7 +121,7 @@ This example uses [Spec Kit](https://github.com/github/spec-kit) to design a VLA
 specify init . --ai claude
 ```
 
-This creates `.speckit/` config and installs slash commands into `.claude/commands/`.
+This creates the `.specify/` project configuration and installs slash commands into `.claude/commands/`.
 
 ### Step 1: Specify
 
@@ -109,7 +170,7 @@ Run `/speckit.tasks`. The AI breaks the plan into discrete steps in `tasks.md`:
 
 ### Step 5: Implement
 
-Run `/speckit.implement`. The AI executes each task using the appropriate Infrahub skill.
+Run `/speckit.implement`. The AI executes each task using the appropriate Infrahub skill. With the routing extension installed, the cycle closes with the friction check described in [Skill-gap detection after implement](#skill-gap-detection-after-implement).
 
 **Task 1 output** — `schemas/vlan_management.yml` (via Schema Manager):
 

--- a/docs/docs/spec-driven-development.mdx
+++ b/docs/docs/spec-driven-development.mdx
@@ -47,7 +47,7 @@ Simple builds execute sequentially: schema first, then objects, then checks. Com
 
 ## Compatible SDD frameworks
 
-SDD works with any framework that supports a spec, plan, task, and implement workflow. The [infrahub-template](https://github.com/opsmill/infrahub-template) repository includes a pre-configured SDD setup using Spec Kit as a starting point.
+SDD works with any framework that supports a spec, plan, task, and implement workflow. The [infrahub-template](https://github.com/opsmill/infrahub-template) repository scaffolds an Infrahub project and documents the Spec Kit setup it expects, which is the quickest starting point.
 
 ## Infrahub routing for Spec Kit
 
@@ -116,12 +116,25 @@ This example uses [Spec Kit](https://github.com/github/spec-kit) to design a VLA
 
 ### Setup
 
+Start from [infrahub-template](https://github.com/opsmill/infrahub-template), which scaffolds the repository layout the skills expect and ships `invoke` tasks for the instance:
+
 ```bash
-# Initialize Spec Kit in your Infrahub project
-specify init . --ai claude
+uv tool run --from 'copier' copier copy https://github.com/opsmill/infrahub-template.git vlan-demo
+cd vlan-demo
+uv sync --all-packages
+invoke start
 ```
 
-This creates the `.specify/` project configuration and installs slash commands into `.claude/commands/`.
+Then install the skills, Spec Kit, and the Infrahub routing extension:
+
+```bash
+npx skills add opsmill/infrahub-skills
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+specify init --here --integration claude
+specify extension add infrahub-speckit --from https://github.com/opsmill/infrahub-speckit/archive/refs/heads/main.zip
+```
+
+`specify init` creates the `.specify/` project configuration and installs slash commands into `.claude/commands/`. Having the instance up matters for more than the data: `before_specify` gates on `infrahubctl info`, so the cycle stops early rather than planning against an instance it cannot reach.
 
 ### Step 1: Specify
 
@@ -281,6 +294,49 @@ check_definitions:
     file_path: checks/check_vlan_id_uniqueness/check.py
     query: check_vlan_id_uniqueness
 ```
+
+### Step 6: Report the gap it exposed
+
+Task 6 is where the cycle hit friction. The first version of `schemas/vlan_management.yml` left `optional` off the `group` relationship, and relationships default to optional, so `infrahubctl schema check` rejected it:
+
+```text
+cannot use group relationship, relationship must be mandatory
+```
+
+The AI added `optional: false`, re-ran the check, and it passed. That is a verifier going red to green on the same target inside a single implement run, which is exactly what the `after_implement` hook looks for. When the cycle closes, it prints one offer:
+
+> **[infrahub-speckit — friction offer, /speckit.implement]**
+>
+> Skill: `infrahub-managing-schemas`
+> Evidence: `infrahubctl schema check` rejected the VLAN node, then passed once `optional: false` was added to the constrained relationship
+> Rule coverage: `rules/uniqueness-constraints.md`
+>
+> An Infrahub skill's guidance may have a gap here. Reply "report it" to draft a skill-friction report for review. Nothing is filed without your approval.
+
+Ignoring it ends the cycle there. Replying hands the session to the [Skill Gap Reporter](./skills-reference/reporting-skill-gaps.mdx), which searches the tracker, classifies the finding, and drafts:
+
+> **bug: infrahub-managing-schemas: state the mandatory requirement where the constraint is written**
+>
+> **Skill**: infrahub-managing-schemas
+> **Type**: bug
+> **Confidence**: unconfirmed single observation
+> **Tracker search**: `repo:opsmill/infrahub-skills uniqueness constraint mandatory relationship` returned no existing report
+>
+> **What was being attempted**: scoping a uniqueness constraint by the parent relationship of a child node.
+>
+> **Rules consulted**: `uniqueness-constraints.md`, which does state that a relationship in a constraint must be mandatory, cardinality one, and referenced bare.
+>
+> **Where it went wrong**: the constraint was written correctly but the relationship was left at its default, so the check failed on the mandatory requirement. One failed verifier run and one correction.
+>
+> **What finally worked**: `optional: false` on the constrained relationship.
+>
+> **Proposed rule change**: in `uniqueness-constraints.md`, put the three requirements next to the constraint example rather than in a later section, so the relationship and the constraint that binds it are authored together.
+
+It is a **bug** rather than a feature because a rule already claimed the ground and the model still got it wrong. Had no rule covered relationships in constraints, the same friction would have drafted as a `feat:` instead, and the offer would have read `Rule coverage: no rule file covers this topic`. That classification decides the title prefix and the target repository, which is why the coverage read runs before the draft.
+
+The draft carries the version lines the template requires, read from `infrahubctl info`, and nothing that identifies your infrastructure. The Skill Gap Reporter cannot file it: it hands the draft to the [Issue Reporter](./skills-reference/reporting-issues.mdx), which shows you the target repository and the full body, then asks whether to submit through `gh`, a GitHub MCP server, or copy-paste. You can stop at either gate.
+
+Asking for the same thing without the extension installed works too: "report skill friction" reaches the Skill Gap Reporter directly. The hook only removes the need to notice the friction yourself.
 
 ### Result
 


### PR DESCRIPTION
## Summary

Two skills ship in v1.2.8 with no reference page — `infrahub-analyzing-diagnostics` and `infrahub-converting-netbox-device-types` — so anyone who reads about them in the 1.2.8 release notes has nowhere to click, and the docs-site skills table lists 13 of the 15 skills that ship. This adds both pages and closes that gap, which also lets the 1.2.8 notes link every skill they name.

Stacked on #132 (base `docs/release-notes-1-2-8`) rather than branched from `main`, because the release-notes file only exists on that branch — a branch off `main` could add the pages but could not add the links that make them reachable.

## Key Changes

- Readers of the 1.2.8 release notes can now reach every skill it names. Both previously-bare mentions are linked on first mention, matching how the other seven skill links on that page work.
- Someone deciding whether to collect a bundle or analyse one gets a straight answer: the Diagnostics Analyzer page carries a Collector-vs-Analyzer table, since the two skills are adjacent, cross-link in both directions, and are easy to conflate.
- Someone pointing the NetBox converter at their own schema gets the real invocation and the real output-file set, rather than having to read the script.
- The docs-site skills table lists all 15 shipping skills.

## Related Context

Both page titles are taken from the skills' own `SKILL.md` H1s — **Diagnostics Analyzer** and **NetBox Device Type Converter** — rather than invented. Structure is calibrated against `collecting-diagnostics.mdx` and `importing-data.mdx` (the closest analogs) and voice against `teaching-concepts.mdx`, the most recently added page. The outline was agreed before drafting; it is at `dev/specs/docs/skills-reference-missing-pages.md` and is deliberately not committed.

Two workflow steps were skipped, by name:

- **Sidebar update** — `docs/sidebars.ts` is a single `type: 'autogenerated'` entry over the docs tree, so new pages appear without an explicit entry.
- **Redirects** — no redirect mechanism exists in this repo and neither page replaces an existing URL.

## Reviewer attention

- **The converter emits five output files; the skill's own text says three.** `OUTPUT_FILENAMES` in `scripts/netbox_to_infrahub_templates.py` has five entries and the release notes already say five, so the page documents five. But `rules/output-load-order.md` is titled "Emit Three Files in Load Order", `SKILL.md:119` says "that is why three files", and the Rule Categories table says "Three files, load order". **The page and the skill therefore disagree until the skill is corrected** — deliberately left out of this PR to keep it to docs, and worth a follow-up against `skills/infrahub-converting-netbox-device-types/`.
- **`Object Templates` capitalisation.** Every pre-existing skills-reference page that names the feature capitalises it, and 1.2.7 does so seven times; the instances I had written lowercase are now capitalised, including three in `release-1_2_8.mdx`. Two are deliberately left lowercase: a quoted user prompt (users type lowercase) and a pre-existing definitional gloss in `readme.mdx`.
- **`sidebar_position` 14 and 15** append rather than pairing Diagnostics Collector (10) with Diagnostics Analyzer. Appending touches no existing file and matches how the directory has grown; pairing them would have renumbered three pages. Say so if you would rather have the pair adjacent.
- **The converter invocation** was read off `build_parser()` and cross-checked against the SKILL.md example, not composed from memory — four arguments: positional input path(s), `--mapping`, `--output-dir`, `--report`.

## Documentation Updates

- `docs/docs/skills-reference/analyzing-diagnostics.mdx` — new.
- `docs/docs/skills-reference/converting-netbox-device-types.mdx` — new.
- `docs/docs/readme.mdx` — two rows added to the skills table.
- `docs/docs/release-notes/release-1_2_8.mdx` — two first-mention links, plus the three capitalisation fixes above.

## Test Plan

- `cd docs && npm run build` — succeeds with zero broken-link and broken-anchor warnings, and both new pages render at `docs/build/skills-reference/`. `onBrokenAnchors` is warn-only in this repo, so the warning count is checked explicitly rather than inferred from the exit code.
- Every relative link in the new and changed pages resolved against a file on disk.
- `sidebar_position` across `skills-reference/`: 1–15, no duplicates, no gaps.
- `uv run rumdl check .` — clean, 316 files.
- `python scripts/check-cli-invocations.py` — clean.
- Voice sweeps over both new pages: no marketing register, no avoid-list metaphors, no page-or-version-as-subject, no email addresses or IPs. One metaphor (`land on`) was caught and removed during the audit — the same one that had been fixed in the release notes and reintroduced here.

---
Assisted-by: opsmill-docs-writing-infrahub-docs 0.4.0
Assisted-by: opsmill-dev-commit 0.1.0
Assisted-by: opsmill-dev-pr 0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
